### PR TITLE
⚡ Bolt: Memoize Sidebar tag and language counting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-26 - Memoize tags and languages counting in Sidebar
+**Learning:** The `Sidebar` component iterates through all repositories (`O(N)`) and their tags (`O(T)`) to build counts, then sorts them, on every render.
+**Action:** Used `useMemo` to cache the calculated counts and sorted arrays based on the `repos` prop, reducing unnecessary re-computations.

--- a/packages/features/src/components/Sidebar.tsx
+++ b/packages/features/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { useMemo } from 'react'
 import type { Repo } from '@devdeck/api-client'
 
 interface Props {
@@ -16,22 +17,28 @@ export function Sidebar({
   onSelectTag,
   onSelectLang,
 }: Props) {
-  const tagCounts = new Map<string, number>()
-  const langCounts = new Map<string, { count: number; color: string | null }>()
+  // ⚡ Bolt: Memoized expensive tag and language counting/sorting
+  // Prevents O(N * T) iteration and sorting on every render where N is repos and T is tags.
+  const { tags, langs } = useMemo(() => {
+    const tagCounts = new Map<string, number>()
+    const langCounts = new Map<string, { count: number; color: string | null }>()
 
-  for (const r of repos) {
-    for (const t of r.tags) tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1)
-    if (r.language) {
-      const cur = langCounts.get(r.language)
-      langCounts.set(r.language, {
-        count: (cur?.count ?? 0) + 1,
-        color: r.language_color,
-      })
+    for (const r of repos) {
+      for (const t of r.tags) tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1)
+      if (r.language) {
+        const cur = langCounts.get(r.language)
+        langCounts.set(r.language, {
+          count: (cur?.count ?? 0) + 1,
+          color: r.language_color,
+        })
+      }
     }
-  }
 
-  const tags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1])
-  const langs = [...langCounts.entries()].sort((a, b) => b[1].count - a[1].count)
+    return {
+      tags: [...tagCounts.entries()].sort((a, b) => b[1] - a[1]),
+      langs: [...langCounts.entries()].sort((a, b) => b[1].count - a[1].count),
+    }
+  }, [repos])
 
   return (
     <aside className="w-60 shrink-0 border-r-3 border-ink bg-bg-elevated p-5 overflow-y-auto">


### PR DESCRIPTION
* 💡 What: Wrapped tag/language calculation in `Sidebar.tsx` with `useMemo`.
* 🎯 Why: Previously, this iterated through all repos and their tags (O(N * T)), then sorted the output array (O(M log M)) on *every render*, causing potential main thread blocking when interacting with the sidebar.
* 📊 Impact: Substantially reduces re-renders computation cost. O(N * T) drops to O(1) for any state change that doesn't modify the `repos` list (e.g., clicking on a tag).
* 🔬 Measurement: Verify using React Profiler or Performance tab. When selecting filters in the sidebar, rendering should be notably faster.

---
*PR created automatically by Jules for task [3371232368599319670](https://jules.google.com/task/3371232368599319670) started by @tiagofur*