### PR TITLE
🧹 Convert commented usage to JSDoc in packages/ui/src/confirm.ts

### DIFF
--- a/packages/ui/src/confirm.ts
+++ b/packages/ui/src/confirm.ts
@@ -1,16 +1,20 @@
-// Promise-based confirm dialog. Same singleton pattern as toast.ts.
-//
-// Usage:
-//   const ok = await confirm({
-//     title: 'Borrar repo',
-//     message: 'Esto no se puede deshacer.',
-//     confirmLabel: 'Borrar',
-//     variant: 'danger',
-//   })
-//   if (!ok) return
-//
-// Replaces window.confirm() so we can show a brutalist-styled dialog
-// instead of the native OS one.
+/**
+ * Promise-based confirm dialog. Same singleton pattern as toast.ts.
+ *
+ * @example
+ * ```typescript
+ * const ok = await confirm({
+ *   title: 'Borrar repo',
+ *   message: 'Esto no se puede deshacer.',
+ *   confirmLabel: 'Borrar',
+ *   variant: 'danger',
+ * })
+ * if (!ok) return
+ * ```
+ *
+ * Replaces window.confirm() so we can show a brutalist-styled dialog
+ * instead of the native OS one.
+ */
 
 export type ConfirmVariant = 'primary' | 'danger'
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored commented-out documentation and usage example in `packages/ui/src/confirm.ts` into a proper JSDoc block.

💡 **Why:** How this improves maintainability
The original comments were identified as "commented-out code" which often triggers linter/health warnings. By converting them to JSDoc, we maintain the documentation and usage examples for developers while satisfying health checks.

✅ **Verification:** How you confirmed the change is safe
Manually verified the JSDoc syntax and confirmed it does not affect code execution. Attempted to run tests, but was blocked by environment issues (missing dependencies/network).

✨ **Result:** The improvement achieved
Cleaned up the file according to code health standards without losing valuable context and usage documentation.

---
*PR created automatically by Jules for task [3659174095668530492](https://jules.google.com/task/3659174095668530492) started by @tiagofur*