### PR TITLE
🔒 security: enable electron sandbox in desktop app

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -97,7 +97,7 @@ function createWindow(): void {
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false, // required for preload to use ipcRenderer
+      sandbox: true,
       preload: preloadPath,
     },
   })


### PR DESCRIPTION
🎯 **What:** Enabled the Electron sandbox for the main renderer process in the desktop application.
⚠️ **Risk:** Running the renderer process without a sandbox increases the attack surface, potentially allowing a compromised renderer to access more system resources than necessary.
🛡️ **Solution:** Set `sandbox: true` in the `webPreferences` of the `BrowserWindow`. Removed the misleading comment that suggested disabling the sandbox was required for IPC.

---
*PR created automatically by Jules for task [884296094710912471](https://jules.google.com/task/884296094710912471) started by @tiagofur*