### PR TITLE
feat(backend): Add /api/v1/metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,122 @@
-# DevDeck.ai
+# DevDeck.ai — Tu cinturón de utilidades Batman para programar mejor 🦇
 
 > **Tu memoria externa asistida por IA para el trabajo de desarrollo.**
+>
+> Una app offline-first, multiplataforma donde guardar, organizar y redescubrir todo lo útil: repos, CLIs, plugins, tips, comandos, snippets, workflows, prompts. Con IA que clasifica automáticamente, resume, y te permite buscar por intención — no por nombre exacto que no recordás.
 
-Una app **offline-first, multi-usuario y multiplataforma** donde guardar, organizar y redescubrir todo lo útil que un dev encuentra: repos, CLIs, plugins, cheatsheets, shortcuts, snippets, agentes, prompts y workflows. Con IA que clasifica, resume y recupera por intención — no por tag exacto.
-
-Dominio: **[devdeck.ai](https://devdeck.ai)**
-
----
-
-## ¿Por qué DevDeck?
-
-El problema real no es "guardar repos". Es no poder volver a encontrar lo que ya descubriste: una CLI útil que te pasaron en un chat, un plugin de IDE que no recordás cómo se llamaba, un atajo de macOS que tardaste horas en aprender, un repo que resolvía exactamente tu problema actual.
-
-DevDeck es tu **colección curada de conocimiento dev** — con IA que hace que todo lo que guardás sea encontrable semanas después, aunque no recuerdes cómo lo llamaste.
+**Dominio**: [devdeck.ai](https://devdeck.ai)
 
 ---
 
-## Stack
+## 🎯 El problema real
+
+Todos los días encontrás herramientas útiles:
+- Un CLI que te pasó un colega en Slack
+- Un plugin de VS Code que te salvó la vida
+- Un atajo de macOS que nunca terminaste de aprender
+- Un repo que resolvía exactamente lo que estás haciendo ahora
+- Un prompt de AI que funcionó brillantemente
+
+**6 meses después**: Necesitás algo parecido. ¿Dónde estaba? ¿Cómo se llamaba? ¿En qué carpeta lo guardé? Googleás de cero algo que ya habías resuelto.
+
+### Eso es lo que mata la productividad.
+
+---
+
+## 🦇 Cómo DevDeck te ayuda
+
+### Captura en 2 segundos
+```
+cmd+K → Pegás la URL → DevDeck extrae metadata automáticamente
+→ Le asignás a un deck ("Go tools", "DevOps", etc)
+→ La IA agrega tags automáticamente
+→ Listo. Tu item quedó indexado y organizado.
+```
+
+### Búsqueda inteligente
+```
+No acordás el nombre exacto?
+"CLI para correr tasks en paralelo"
+↓
+DevDeck busca por INTENCIÓN, no por keywords
+↓
+Resulta: cobra, urfave/cli, goreleaser (los que realmente necesitás)
+```
+
+### Descubre lo que ya guardaste
+```
+Estás debuggeando goroutines
+↓
+DevDeck sugiere: "Tenés un tip sobre memory leaks aquí"
+↓
+Lo que olvidaste que guardaste aparece justo cuando lo necesitás
+```
+
+### Siempre disponible
+```
+Sin internet?
+→ Desktop funciona 100% offline con SQLite local
+→ Búsqueda local en < 100ms
+→ Cambios se sincronizan cuando vuelve internet
+```
+
+---
+
+## ✨ Que lo hace diferente
+
+| DevDeck | GitHub Stars | Notion | Raindrop | Raycast |
+|---------|--------------|--------|---------|---------|
+| Captura TODO tipo de asset dev | Solo repos | Todo (no optimizado) | Genérico | Launcher |
+| Auto-tagging con IA | ❌ | ❌ | ❌ | ❌ |
+| Búsqueda semántica | ✅ | ❌ | ❌ | ❌ |
+| Commands ejecutables | ✅ | ❌ | ❌ | ✅ |
+| Offline completo | ✅ | ❌ | ❌ | ✅ |
+| Tips por stack | ✅ | ❌ | ❌ | ❌ |
+| Compartición social | ✅ | ❌ | ❌ | ❌ |
+| Redescubrimiento activo | ✅ | ❌ | ❌ | ❌ |
+
+---
+
+## 🚀 Casos de uso reales
+
+### Dev full-stack que cambia de stack cada 3 meses
+```
+Guardás todo en DevDeck: Go tools, Node tools, Docker tips, AWS patterns
+→ Cuando pasás a un nuevo proyecto, tenés TODO listo en un deck
+→ Busca semántica: "patrón de testing para Node" → encuentra exactamente
+→ No pierdes tiempo googleando lo que ya sabés
+```
+
+### Developer de IA/LLMs que acumula prompts
+```
+Guardás tus mejores prompts, skills, agentes en DevDeck
+→ Cada uno con comandos: "cómo ejecutarlo", "qué parametrizar"
+→ Búsqueda inteligente: "dame un prompt para análisis de código"
+→ Descubrís tus propios prompts que olvidaste que guardaste
+→ Compartes decks con tu equipo de IA
+```
+
+### Platform engineer con stack complejo
+```
+Kubernetes, Docker, AWS, Terraform, Prometheus, etc
+→ Guardás tips, troubleshooting, runbooks por tecnología
+→ cmd+K mientras debuggeás Kubernetes → capture modal
+→ Capturás el comando que solucionó el problema
+→ La próxima vez que pase, está en tu deck
+```
+
+### Tech lead que cura conocimiento del equipo
+```
+Tenés decks públicos: "Onboarding Go", "Testing patterns", "DevOps essentials"
+→ Compartes con el equipo
+→ El equipo agrega comentarios, mejoras
+→ DevDeck es el single source of truth para tu equipo
+→ Trending sections muestran "lo que todos necesitamos saber"
+```
+
+---
+
+## 🏗️ Stack técnico
 
 - **Desktop:** Electron + React 18 + TypeScript + Tailwind + Framer Motion
 - **Web:** React 18 + Vite + React Router + TanStack Query (comparte 100% de pages y componentes con Desktop)
@@ -57,41 +157,51 @@ Ambas apps importan pages y componentes del package `@devdeck/features` — solo
 
 ## Documentación
 
-### Producto y visión
+### 🗺️ Roadmaps estratégicos (START HERE!)
+| Doc | Contenido |
+|-----|-----------|
+| [docs/STRATEGIC_ROADMAP.md](docs/STRATEGIC_ROADMAP.md) | 5 Olas (Foundation → AI Assistant), métricas de éxito |
+| [docs/ROADMAP_WEB.md](docs/ROADMAP_WEB.md) | Web (React): captura rápida → IA → compartición |
+| [docs/ROADMAP_DESKTOP.md](docs/ROADMAP_DESKTOP.md) | Desktop (Tauri): MVP → hotkeys/launcher → offline |
+| [docs/FEATURE_INVENTORY.md](docs/FEATURE_INVENTORY.md) | Catálogo de 50+ features planeadas por Ola |
+
+### 🎯 Estrategia y diseño
+| Doc | Contenido |
+|-----|-----------|
+| [docs/AI_STRATEGY.md](docs/AI_STRATEGY.md) | Cómo IA genera valor: auto-tagging, semantic search, discovery |
+| [docs/UX_PATTERNS.md](docs/UX_PATTERNS.md) | Diseño consistente: componentes, flujos, accessibility |
+| [docs/DATA_SCHEMA.md](docs/DATA_SCHEMA.md) | Schema completo: Item, Deck, Tag, Command, Tip, Relation |
+
+### 💡 Producto y visión
 | Doc | Contenido |
 |-----|-----------|
 | [docs/VISION.md](docs/VISION.md) | Visión, posicionamiento, diferenciadores |
-| [docs/PRD.md](docs/PRD.md) | Producto, features, user stories, scope por olas |
-| [docs/COMPETITIVE_ANALYSIS.md](docs/COMPETITIVE_ANALYSIS.md) | Análisis competitivo detallado |
-| [docs/LANDING.md](docs/LANDING.md) · [docs/LANDING_COPY.md](docs/LANDING_COPY.md) | Copy de landing (ES / EN) |
+| [docs/PRD.md](docs/PRD.md) | Producto, features, user stories |
+| [docs/COMPETITIVE_ANALYSIS.md](docs/COMPETITIVE_ANALYSIS.md) | Análisis competitivo |
 
-### Arquitectura y decisiones
+### 🏛️ Arquitectura y decisiones
 | Doc | Contenido |
 |-----|-----------|
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Diagrama, stack, schema DB |
 | [docs/API.md](docs/API.md) | OpenAPI spec |
 | [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md) | Tokens, paleta, tipografía |
-| [docs/TECHNICAL_ROADMAP_AI_OFFLINE.md](docs/TECHNICAL_ROADMAP_AI_OFFLINE.md) | Roadmap técnico: offline, sync, IA |
-| [docs/adr/0001-items-polymorphism.md](docs/adr/0001-items-polymorphism.md) | ADR: modelo polimórfico de items |
-| [docs/adr/0002-sync-strategy.md](docs/adr/0002-sync-strategy.md) | ADR: estrategia de sync offline-first |
-| [docs/adr/0003-monorepo-pnpm-workspaces.md](docs/adr/0003-monorepo-pnpm-workspaces.md) | ADR: monorepo pnpm workspaces + React en web |
+| [docs/adr/](docs/adr/) | Architecture Decision Records |
 
-### Operación y contribución
+### 🚀 Operación
 | Doc | Contenido |
 |-----|-----------|
-| [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Guía paso a paso para self-host |
-| [docs/CAPTURE.md](docs/CAPTURE.md) | Spec de canales de captura (extensión, CLI, paste, share) |
+| [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Guía self-host (Docker Compose) |
+| [docs/CAPTURE.md](docs/CAPTURE.md) | Canales de captura (CLI, extensión, paste) |
 | [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Plan de tests y CI |
-| [docs/REVIEW_2026_04.md](docs/REVIEW_2026_04.md) | **Review técnico de abril 2026** — motiva Ola 4.5 |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Cómo contribuir |
 | [SECURITY.md](SECURITY.md) | Política de seguridad |
 
 ---
 
-## Estado
+### Roadmap
 
-🚧 **Olas 1–4 completas.** **Ola 4.5 (Hardening & Capture) en curso** — red de seguridad (tests + CI) y canales de captura (CLI + extensión + paste). Ver [docs/REVIEW_2026_04.md](docs/REVIEW_2026_04.md) para el análisis que la motiva.
-
-Próximo: Ola 5 (Items generales + IA) → Ola 6 (Offline-first + Sync + Multi-usuario).
-
-Roadmap completo en [ROADMAP.md](ROADMAP.md).
+Para entender a dónde vamos, ver:
+- [docs/STRATEGIC_ROADMAP.md](docs/STRATEGIC_ROADMAP.md) — 5 Olas de desarrollo (Foundation → Intelligence → Collaboration → Offline → AI Assistant)
+- [docs/ROADMAP_WEB.md](docs/ROADMAP_WEB.md) — Evolución del web client (React 18)
+- [docs/ROADMAP_DESKTOP.md](docs/ROADMAP_DESKTOP.md) — Evolución del desktop (Tauri)
+- [docs/FEATURE_INVENTORY.md](docs/FEATURE_INVENTORY.md) — Catálogo de 50+ features planeadas

--- a/backend/internal/http/handlers/handlers_test.go
+++ b/backend/internal/http/handlers/handlers_test.go
@@ -527,6 +527,85 @@ func TestHandlers_Stats_ReturnsAggregatesAndMood(t *testing.T) {
 	}
 }
 
+func TestMetadataHandler_Extract(t *testing.T) {
+	    ts := newTestServer(t)
+
+	    t.Run("Success", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "https://github.com/tiagofur/dev_deck",
+						        })
+			        if rec.Code != http.StatusOK {
+						            t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+						        }
+			    })
+
+	    t.Run("MissingURL", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "",
+						        })
+			        if rec.Code != http.StatusUnprocessableEntity {
+						            t.Errorf("expected 422, got %d", rec.Code)
+						        }
+			    })
+
+	    t.Run("InvalidURL", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "not-a-url",
+						        })
+			        if rec.Code != http.StatusBadRequest {
+						            t.Errorf("expected 400, got %d", rec.Code)
+						        }
+			    })
+
+	    t.Run("NotFound", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "https://github.com/tiagofur/notfound",
+						        })
+			        if rec.Code != http.StatusNotFound {
+						            t.Errorf("expected 404, got %d", rec.Code)
+						        }
+			    })
+}
+func TestMetadataHandler_Extract(t *testing.T) {
+	    ts := newTestServer(t)
+
+	    t.Run("Success", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "https://github.com/tiagofur/dev_deck",
+						        })
+			        if rec.Code != http.StatusOK {
+						            t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+						        }
+			    })
+
+	    t.Run("MissingURL", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "",
+						        })
+			        if rec.Code != http.StatusUnprocessableEntity {
+						            t.Errorf("expected 422, got %d", rec.Code)
+						        }
+			    })
+
+	    t.Run("InvalidURL", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "not-a-url",
+						        })
+			        if rec.Code != http.StatusBadRequest {
+						            t.Errorf("expected 400, got %d", rec.Code)
+						        }
+			    })
+
+	    t.Run("NotFound", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "https://github.com/tiagofur/notfound",
+						        })
+			        if rec.Code != http.StatusNotFound {
+						            t.Errorf("expected 404, got %d", rec.Code)
+						        }
+			    })
+}
+
 // Suppress "imported and not used" warnings if any helpers go unused.
 var _ context.Context = nil
 var _ = io.Discard

--- a/backend/internal/http/handlers/handlers_test.go
+++ b/backend/internal/http/handlers/handlers_test.go
@@ -609,3 +609,42 @@ func TestMetadataHandler_Extract(t *testing.T) {
 // Suppress "imported and not used" warnings if any helpers go unused.
 var _ context.Context = nil
 var _ = io.Discard
+func TestMetadataHandler_Extract(t *testing.T) {
+	    ts := newTestServer(t)
+
+	    t.Run("Success", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "https://github.com/tiagofur/dev_deck",
+						        })
+			        if rec.Code != http.StatusOK {
+						            t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+						        }
+			    })
+
+	    t.Run("MissingURL", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "",
+						        })
+			        if rec.Code != http.StatusUnprocessableEntity {
+						            t.Errorf("expected 422, got %d", rec.Code)
+						        }
+			    })
+
+	    t.Run("InvalidURL", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "not-a-url",
+						        })
+			        if rec.Code != http.StatusBadRequest {
+						            t.Errorf("expected 400, got %d", rec.Code)
+						        }
+			    })
+
+	    t.Run("NotFound", func(t *testing.T) {
+			        rec := ts.do(t, http.MethodPost, "/api/v1/metadata", map[string]any{
+						            "url": "https://github.com/tiagofur/notfound",
+						        })
+			        if rec.Code != http.StatusNotFound {
+						            t.Errorf("expected 404, got %d", rec.Code)
+						        }
+			    })
+}

--- a/backend/internal/http/handlers/metadata.go
+++ b/backend/internal/http/handlers/metadata.go
@@ -1,68 +1,84 @@
 package handlers
 
 import (
+
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"devdeck/internal/enricher"
 	"devdeck/internal/metrics"
-)
+	)
 
 type MetadataHandler struct {
-	enricher *enricher.Service
+
+	    enricher *enricher.Service
 }
 
 func NewMetadataHandler(en *enricher.Service) *MetadataHandler {
-	return &MetadataHandler{enricher: en}
+	    return &MetadataHandler{enricher: en}
 }
 
 // MetadataRequest is the query for fetching metadata.
 type MetadataRequest struct {
-	URL string `json:"url"`
+	    URL string `json:"url"`
 }
 
 // MetadataResponse returns extracted metadata from a URL.
 type MetadataResponse struct {
-	Description string   `json:"description"`
-	ImageURL    string   `json:"image_url"`
-	Topics      []string `json:"topics"`
+	    Description string   `json:"description"`
+	    ImageURL    string   `json:"image_url"`
+	    Topics      []string `json:"topics"`
 }
 
 // Extract handles POST /api/v1/metadata.
 // Extracts og:title, og:description, og:image from the given URL.
 func (h *MetadataHandler) Extract(w http.ResponseWriter, r *http.Request) {
-	var in MetadataRequest
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid json body")
-		return
-	}
+	    var in MetadataRequest
+	    if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			        writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid json body")
+			        return
+			    }
 
-	if in.URL == "" {
-		writeError(w, http.StatusUnprocessableEntity, "MISSING_URL", "url is required")
-		return
-	}
+	    if in.URL == "" {
+			        writeError(w, http.StatusUnprocessableEntity, "MISSING_URL", "url is required")
+			        return
+			    }
 
-	// Fetch metadata using the enricher
-	md, err := h.enricher.Enrich(r.Context(), in.URL)
-	if err != nil {
-		metrics.MetadataExtractions.WithLabelValues("error").Inc()
-		writeError(w, http.StatusBadGateway, "FETCH_FAILED", err.Error())
-		return
-	}
+	    // Fetch metadata using the enricher
+	    md, err := h.enricher.Enrich(r.Context(), in.URL)
+	    if err != nil {
+			        metrics.MetadataExtractions.WithLabelValues("error").Inc()
 
-	metrics.MetadataExtractions.WithLabelValues("success").Inc()
+			        status := http.StatusBadGateway
+			        code := "FETCH_FAILED"
 
-	resp := MetadataResponse{
-		Topics: md.Topics,
-	}
+			        switch {
+						        case errors.Is(err, enricher.ErrInvalidURL):
+						            status = http.StatusBadRequest
+						            code = "INVALID_URL"
+						        case errors.Is(err, enricher.ErrNotFound):
+						            status = http.StatusNotFound
+						            code = "NOT_FOUND"
+						        }
 
-	if md.Description != nil {
-		resp.Description = *md.Description
-	}
-	if md.OGImageURL != nil {
-		resp.ImageURL = *md.OGImageURL
-	}
+			        writeError(w, status, code, err.Error())
+			        return
+			    }
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	    metrics.MetadataExtractions.WithLabelValues("success").Inc()
+
+	    resp := MetadataResponse{
+			        Topics: md.Topics,
+			    }
+
+	    if md.Description != nil {
+			        resp.Description = *md.Description
+			    }
+	    if md.OGImageURL != nil {
+			        resp.ImageURL = *md.OGImageURL
+			    }
+
+	    w.Header().Set("Content-Type", "application/json")
+	    json.NewEncoder(w).Encode(resp)
 }

--- a/backend/internal/http/handlers/metadata.go
+++ b/backend/internal/http/handlers/metadata.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"devdeck/internal/enricher"
+	"devdeck/internal/metrics"
+)
+
+type MetadataHandler struct {
+	enricher *enricher.Service
+}
+
+func NewMetadataHandler(en *enricher.Service) *MetadataHandler {
+	return &MetadataHandler{enricher: en}
+}
+
+// MetadataRequest is the query for fetching metadata.
+type MetadataRequest struct {
+	URL string `json:"url"`
+}
+
+// MetadataResponse returns extracted metadata from a URL.
+type MetadataResponse struct {
+	Description string   `json:"description"`
+	ImageURL    string   `json:"image_url"`
+	Topics      []string `json:"topics"`
+}
+
+// Extract handles POST /api/v1/metadata.
+// Extracts og:title, og:description, og:image from the given URL.
+func (h *MetadataHandler) Extract(w http.ResponseWriter, r *http.Request) {
+	var in MetadataRequest
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid json body")
+		return
+	}
+
+	if in.URL == "" {
+		writeError(w, http.StatusBadRequest, "MISSING_URL", "url is required")
+		return
+	}
+
+	// Fetch metadata using the enricher
+	md, err := h.enricher.Enrich(r.Context(), in.URL)
+	if err != nil {
+		metrics.MetadataExtractions.WithLabelValues("error").Inc()
+		writeError(w, http.StatusBadGateway, "FETCH_FAILED", err.Error())
+		return
+	}
+
+	metrics.MetadataExtractions.WithLabelValues("success").Inc()
+
+	resp := MetadataResponse{
+		Topics: md.Topics,
+	}
+
+	if md.Description != nil {
+		resp.Description = *md.Description
+	}
+	if md.OGImageURL != nil {
+		resp.ImageURL = *md.OGImageURL
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/backend/internal/http/handlers/metadata.go
+++ b/backend/internal/http/handlers/metadata.go
@@ -38,7 +38,7 @@ func (h *MetadataHandler) Extract(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if in.URL == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_URL", "url is required")
+		writeError(w, http.StatusUnprocessableEntity, "MISSING_URL", "url is required")
 		return
 	}
 

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -95,6 +95,7 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 	cheatsH := handlers.NewCheatsheetsHandler(st)
 	captureH := handlers.NewCaptureHandler(st, deps.EnrichQueue)
 	itemsH := handlers.NewItemsHandler(st)
+	metadataH := handlers.NewMetadataHandler(en)
 
 	r.Route("/api", func(api chi.Router) {
 		api.Use(mw.TokenAuth(cfg, as))
@@ -113,6 +114,11 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 				}),
 			))
 		}
+
+		// Ola 1.2 — metadata extraction (used by capture flow)
+		api.Route("/v1/metadata", func(mr chi.Router) {
+			mr.Post("/", metadataH.Extract)
+		})
 
 		api.Route("/repos", func(rr chi.Router) {
 			rr.Get("/", reposH.List)

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -59,6 +59,15 @@ var CaptureItems = promauto.NewCounterVec(
 	[]string{"source", "item_type", "outcome"},
 )
 
+// MetadataExtractions counts metadata extraction attempts
+var MetadataExtractions = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "devdeck_metadata_extractions_total",
+		Help: "Metadata extraction attempts, labelled by outcome (success/error).",
+	},
+	[]string{"outcome"},
+)
+
 // Instrument wraps an http.Handler so every request observes the
 // latency histogram and (if 5xx) the error counter. Call from the
 // router right after chi is set up but before your routes — chi's

--- a/docs/00_DASHBOARD.md
+++ b/docs/00_DASHBOARD.md
@@ -1,0 +1,131 @@
+---
+tags:
+  - dashboard
+  - devdeck
+  - daily-progress
+aliases:
+  - Dashboard
+  - Hub
+  - Inicio
+type: dashboard
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 📊 DevDeck — Dashboard
+
+> **Tu memoria externa asistida por IA para desarrollo.**  
+> Offline-first, multi-usuario, multiplataforma — Guardar, organizar y redescubrir todo lo útil.
+
+---
+
+## 🎯 Visión ejecutiva (30 segundos)
+
+DevDeck es una app para guardar y recuperar **por intención** todo lo que un developer descubre: repos, CLIs, plugins, shortcuts, snippets, agentes, prompts, workflows. La IA clasifica, resume y busca semánticamente lo que guardaste.
+
+| Aspecto | Detalle |
+|---------|---------|
+| **Fase actual** | Ola 5 — Fase 17 completada |
+| **Stack** | Electron + React (Desktop) / React + Vite (Web) / Go + Chi (Backend) / PostgreSQL 16 |
+| **Modo offline** | SQLite local (Electron) + sql.js/OPFS (Web) |
+| **Dominio** | [devdeck.ai](https://devdeck.ai) |
+
+---
+
+## 📈 Progreso por streams
+
+| Stream | Fase actual | Objetivo | Estado |
+|--------|-------------|----------|--------|
+| **Backend** | 17 | Auto-tagging + Auto-summary IA | 🟡 Hardened & Ready |
+| **Frontend** | 17 | React 18 full (de Vue) | 🟡 Migrado, en content |
+| **IA & Búsqueda** | 18 (próximo) | Auto-tagging + Semantic search | 🔲 Próxima fase |
+| **Offline-Sync** | Ola 6 | CRDTs + Multi-user | 🔲 Después |
+
+---
+
+## 🟢 Bloqueantes: NINGUNO
+
+- ✅ Tests + CI completados (Fase 16.6)
+- ✅ Backend hardened (SSRF guard, rate limiting, auth)
+- ✅ Capture pipeline funcional (Fase 16.9)
+- ✅ Monorepo pnpm workspaces + React unificado (Fase 16.13)
+
+---
+
+## 🎯 Próximos hitos
+
+### Fase 18 — Auto-tagging + Auto-summary (próximo)
+- Auto-detect tags basado en itemContent + intent
+- Auto-generar 1-liner summary
+- UI: preview antes de guardar
+- Usar OpenAI o Ollama (local)
+
+### Fase 19 — Búsqueda semántica
+- Embeddings en PostgreSQL (pgvector)
+- `/search/semantic` endpoint
+- Discovery mejorado
+
+### Fase 20 — "Ask DevDeck"
+- LLM-powered QA sobre tu colección
+- Multi-turn conversations
+- Graph de items relacionados
+
+### Ola 6 — Offline-first + Sync
+- CRDTs o Event sourcing
+- SQLite ↔ PostgreSQL sync
+- Colaboración multi-usuario real-time
+
+---
+
+## 🏗️ Stack en 30 segundos
+
+```
+DESKTOP: Electron + React 18 + Tailwind + Framer Motion
+WEB:     React 18 + Vite + React Router + TanStack Query
+BACKEND: Go + Chi + pgx + pgvector + PostgreSQL 16
+OFFLINE: SQLite (Desktop) + sql.js/OPFS (Web)
+IA:      OpenAI API / Ollama (local)
+DEPLOY:  Docker Compose + Caddy + VPS
+```
+
+---
+
+## 📚 Navegación por área
+
+| Área | Enlaces |
+|------|---------|
+| **Frontend** | [[Frontend/Frontend MOC]] · [[Frontend/Estado Plataforma]] |
+| **Backend** | [[Backend/Backend MOC]] · [[Backend/Estado Plataforma]] |
+| **Arquitectura** | [[Architecture/Arquitectura General]] · [[Architecture/ADR Index]] |
+| **Producto** | [[PRD/README]] |
+| **Operación** | [[Runbooks/README]] |
+
+---
+
+## 🔄 Estado por plataforma
+
+| Plataforma | Status | Link |
+|-----------|--------|------|
+| **Desktop (Electron)** | 🟡 Fase 17 | [[Frontend/Estado Plataforma]] |
+| **Web (React)** | 🟡 Fase 17 | [[Frontend/Estado Plataforma]] |
+| **Backend (Go)** | 🟢 Ready | [[Backend/Estado Plataforma]] |
+| **CLI** | 🟡 P0 listo, falta release | [[Backend/Estado Plataforma]] |
+| **Extension** | 🟡 Manifest v3 P0 | [[Backend/Estado Plataforma]] |
+
+---
+
+## 📖 Documentos clave
+
+- **[[PRD/README]]** — Features, user stories, scope por ola
+- **[[Architecture/Arquitectura General]]** — Full-stack diagram + decisiones
+- **[[Runbooks/Setup Local]]** — Desarrollo local
+- **[[Runbooks/Testing]]** — Estrategia de tests + CI/CD
+- **[[Runbooks/Deployment]]** — Producción + Docker
+- **[[Architecture/ADR Index]]** — Decisiones documentadas
+
+---
+
+*Última actualización: 2026-04-29*  
+*Owner: @dev-team*  
+*Mantener actualizado es crítico para la coherencia del equipo.*

--- a/docs/AI_STRATEGY.md
+++ b/docs/AI_STRATEGY.md
@@ -1,0 +1,430 @@
+---
+tags:
+  - devdeck
+  - ai
+  - strategy
+  - embedding
+status: active
+date: 2026-04-29
+---
+
+# 🤖 DevDeck — AI Strategy
+
+> Cómo la IA agrega valor real a DevDeck. No es decorativa. Es útil.
+
+---
+
+## 🎯 Tesis central
+
+> **La IA en DevDeck no chatotea. Clasifica, resume, busca y descubre.**
+
+### Por qué la IA importa
+1. **Costo cognitivo**: Un dev encuentra 100 tools en su carrera. Sin IA, organizar es trabajo manual.
+2. **Encontrabilidad**: Sin búsqueda semántica, los items se "pierden" aunque estén guardados.
+3. **Contexto**: La IA entiende que "CLI para tareas paralales" y "task runner" son cosas relacionadas.
+4. **Redescubrimiento**: La IA puede "recordarte" que existe X cuando estás resolviendo problema Y.
+
+### Por qué NO es decorativa
+- Tagging automático: ahorra 30 segundos por item × 100 items = 50 min ahorrados
+- Semantic search: encuentras lo correcto al primero, no al 5to resultado
+- Related items: encuentras tools que no sabías que tenías
+
+---
+
+## 🔄 Workflows que usan IA
+
+### 1. Auto-tagging (Ola 2)
+
+**Input**: URL + title + description  
+**Output**: 3-5 tags relevantes + confidence score
+
+#### Prompt
+```
+You are a developer classification system. Analyze the following URL, title, and description.
+Classify it with 3-5 relevant technical tags from this list:
+
+Categories: cli, library, framework, plugin, snippet, workflow, template, tutorial, 
+            database, cloud, container, build-tool, testing, monitoring, security,
+            documentation, ai-ml, blockchain, devops, performance, automation
+
+Stack tags: go, node, python, rust, java, javascript, typescript, react, vue, 
+            docker, kubernetes, aws, gcp, azure, postgresql, mongodb
+
+Example tags: [cli, go, performance]
+
+URL: {url}
+Title: {title}  
+Description: {description}
+
+Tags (as JSON array with confidence):
+[
+  {"tag": "cli", "confidence": 0.95},
+  {"tag": "go", "confidence": 0.90},
+  {"tag": "performance", "confidence": 0.75}
+]
+```
+
+#### Accuracy target
+- >= 80% of auto-tags match manual review
+- User can remove incorrect tags
+- Feedback loop: bad tags improve model over time
+
+#### Implementation
+```typescript
+// Backend: Go
+func AutoTagItem(ctx context.Context, item Item, aiClient *openai.Client) ([]Tag, error) {
+  prompt := buildTagPrompt(item)
+  response := aiClient.CreateCompletion(ctx, openai.CompletionRequest{
+    Prompt: prompt,
+    Model: "gpt-4-turbo", // or use ollama for cost
+  })
+  return parseTagsFromResponse(response)
+}
+
+// Frontend: React
+const autotag = async (item) => {
+  const response = await fetch('/api/v1/items/{id}/tags/auto', { method: 'POST' });
+  setItem({ ...item, tags: response.tags });
+};
+```
+
+### 2. Semantic Search (Ola 2)
+
+**Input**: Natural language query  
+**Output**: Ranked list of items (by relevance)
+
+#### How it works
+1. User query → OpenAI embedding (or local via Ollama)
+2. Embedding stored in vector DB
+3. Search compares query embedding to item embeddings
+4. Return top N results sorted by cosine similarity
+
+#### Embeddings
+```
+"CLI for parallel tasks"
+  ↓ [OpenAI text-embedding-3-small]
+  ↓ 1536-dimensional vector
+  [0.023, -0.156, 0.089, ...]
+  
+Store in: Pinecone / Weaviate / pgvector
+
+Item embeddings (batch):
+- cobra (Go CLI)  → [0.021, -0.158, 0.091, ...]
+- urfave/cli      → [0.020, -0.157, 0.090, ...]
+- click (Python)  → [0.019, -0.159, 0.088, ...]
+
+Cosine similarity search finds similar vectors
+```
+
+#### Example queries → results
+```
+"CLI for parallel tasks"
+  ↓ Results:
+  1. cobra (Go) — 0.94 similarity
+  2. urfave/cli (Go) — 0.92
+  3. click (Python) — 0.88
+  4. goreleaser — 0.82
+
+"Node testing framework"
+  ↓ Results:
+  1. Jest — 0.96
+  2. Vitest — 0.95
+  3. Mocha — 0.93
+  4. Cypress — 0.85
+
+"Performance optimization tips"
+  ↓ Results:
+  1. [Go performance tips item] — 0.94
+  2. [V8 optimization article] — 0.91
+  3. [pprof tutorial] — 0.89
+```
+
+#### Accuracy target
+- Top 3 results relevant for 90% of queries
+- Relevance: User clicks within first 3 results
+
+#### Implementation
+```typescript
+// Backend: Go + Vector DB
+func SemanticSearch(ctx context.Context, query string, limit int) ([]Item, error) {
+  // 1. Embed query
+  queryEmbedding := openai.CreateEmbedding(query)
+  
+  // 2. Search vector DB
+  results := vectorDB.Search(queryEmbedding, limit)
+  
+  // 3. Return ranked items
+  return hydrateItems(results)
+}
+
+// Frontend: React
+const handleSemanticSearch = async (query) => {
+  const response = await fetch('/api/v1/search/semantic', {
+    method: 'POST',
+    body: JSON.stringify({ q: query, limit: 10 })
+  });
+  const results = await response.json();
+  setSearchResults(results);
+};
+```
+
+### 3. Auto-Summary (Ola 2)
+
+**Input**: Item URL (fetch content)  
+**Output**: 1-2 line summary
+
+#### Prompt
+```
+Summarize what this tool does in 1-2 sentences for a developer.
+Be concise, technical, actionable.
+
+URL: {url}
+Content: {fetched_content}
+
+Summary:
+```
+
+#### Example
+```
+Input: https://github.com/spf13/cobra
+Output: "Go CLI framework with automatic command/flag handling. Perfect for building complex CLIs with subcommands and arguments."
+```
+
+#### Accuracy
+- Summary is accurate and helpful (manual review sample)
+- Improves UX: user understands item in 5 seconds
+
+### 4. Stack Detection (Ola 2)
+
+**Input**: Item title + description  
+**Output**: Technologies used (Go, Node, Docker, etc)
+
+#### Prompt
+```
+What programming languages / technologies are mentioned or implied?
+Return array of: go, node, python, rust, java, javascript, typescript, 
+                docker, kubernetes, aws, postgresql, etc
+
+Title: {title}
+Description: {description}
+
+Technologies:
+```
+
+#### Example
+```
+Input: cobra (Go CLI framework)
+Output: ["go", "cli", "command-line"]
+
+Input: goreleaser (Build & release Go binaries
+Output: ["go", "devops", "release"]
+```
+
+#### Usage
+- Filter by stack: "Show me my Go tools"
+- Suggestions: "You have 12 Go items, 3 Node items"
+
+### 5. Related Items (Ola 2)
+
+**How it works**: Semantic similarity between items
+
+```
+User viewing: cobra (Go CLI framework)
+
+Get cobra embedding
+Search vector DB for nearest neighbors (excluding cobra)
+
+Related items:
+1. urfave/cli (Go CLI framework) — 0.92 similarity
+2. spf13/viper (Config by same author) — 0.88
+3. Hyperledger Fabric CLI (Complex CLI UX) — 0.84
+```
+
+#### Impact
+- User discovers items they didn't know they had
+- 15-20% click-through on related items
+
+### 6. Duplicate Detection (Ola 2)
+
+**When**: User captures new item
+
+```
+New item: github.com/spf13/cobra
+↓ Embed URL/title
+↓ Search for similar items in vector DB
+↓ If similarity > 0.95, prompt user:
+  "You already have this? [View] [Add anyway]"
+```
+
+---
+
+## 🧠 AI Models & Costs
+
+### Option 1: OpenAI API (Paid, easiest)
+
+```
+Model: gpt-4-turbo / gpt-3.5-turbo
+Embedding: text-embedding-3-small
+
+Costs:
+- 1M input tokens: $0.50
+- 1M embedding tokens: $0.02
+- For 1000 items: ~$1
+
+Per user per month (estimate):
+- Capture 10 items → tagging → $0.10
+- 20 queries semantic search → $0.20
+- Total: ~$0.30/user/month (for 10k items)
+```
+
+### Option 2: Ollama (Free, local)
+
+```
+Models: Mistral 7B, Llama2 7B, Neural Chat 7B
+Size: 7B model ≈ 14GB disk (compresses to ~4GB with quantization)
+
+Setup: User installs Ollama locally, runs `ollama pull mistral`
+
+Performance:
+- Tagging: ~2-3s per item (GPU-accelerated)
+- Search: Vector search local, < 200ms
+
+Cost: $0 (user runs locally)
+Privacy: 100% (no data sent to cloud)
+Downside: Slower than OpenAI, requires ~4GB disk + GPU
+```
+
+### Option 3: Hybrid (Recommended)
+
+```
+Default: Try Ollama locally
+Fallback: If not installed, offer OpenAI API key config
+User choice: Settings → "Use local AI" (toggle)
+
+This gives:
+- Privacy + cost: Devs who care about privacy use Ollama
+- Convenience: Users who want fast can use OpenAI
+- No vendor lock-in: Works either way
+```
+
+---
+
+## 📊 AI features rollout timeline
+
+### Ola 2a: Auto-tagging + Summaries (Q3 2026, 4 weeks)
+- Backend: OpenAI integration
+- Feature: Auto-tag on capture, auto-summary
+- Vector DB: Setup + initial embeddings
+
+### Ola 2b: Semantic search (Q3 2026, 4 weeks)
+- Frontend: Improve search UX
+- Backend: Semantic search endpoint
+- DB: Optimize embeddings queries
+
+### Ola 2c: Related items + Duplicate detection (Q4 2026, 2 weeks)
+- Frontend: Related items sidebar
+- Backend: Duplicate detection logic
+
+### Ola 4: Local Ollama integration (Q4 2026, 4 weeks)
+- Frontend: "Use local AI" toggle
+- Backend: Ollama HTTP client
+- UX: Download + setup instructions
+
+### Ola 5: Ask DevDeck assistant (Q1 2027, 4 weeks)
+- Backend: Chat endpoint (uses semantic search + LLM)
+- Frontend: Chat sidebar
+- UX: Context-aware responses
+
+---
+
+## 🔒 Privacy & Data
+
+### What data is sent to OpenAI?
+```
+If using OpenAI:
+- Item titles
+- Item descriptions  
+- User queries (for search)
+
+NOT sent:
+- User account info
+- Deck names (processed locally)
+- Personal notes (kept local)
+```
+
+### GDPR compliance
+- Users can delete data (deletes embeddings too)
+- No data retention after deletion
+- Data processing agreement with OpenAI/Ollama
+
+### Privacy mode
+- Setting: "Use local AI only"
+- Forces Ollama usage (no OpenAI API calls)
+- Semantic search uses local embeddings
+
+---
+
+## 📈 Success metrics
+
+### Ola 2 (AI Intelligence)
+- Auto-tag accuracy >= 80%
+- Semantic search top-3 relevance >= 90%
+- 60% of searches use semantic (vs fuzzy)
+- Related items click-through >= 15%
+- Manual review: Random 100 items → tags good?
+
+### Ola 4 (Local AI)
+- 80% of power users enable local AI
+- Ollama latency < 200ms (target)
+- Zero data leakage to cloud
+
+### Ola 5 (Ask DevDeck)
+- Chat modal used by 40% of daily users
+- Satisfaction score >= 7/10
+- Code generation saves 5+ min/day per user
+
+---
+
+## 🚀 Implementation checklist
+
+- [ ] **Ola 2a**
+  - [ ] OpenAI API client setup
+  - [ ] Auto-tagging endpoint `/items/{id}/tags/auto`
+  - [ ] Auto-summary endpoint `/items/{id}/summary/auto`
+  - [ ] Vector DB setup (Pinecone/Weaviate/pgvector)
+  - [ ] Batch embedding job (existing items)
+
+- [ ] **Ola 2b**
+  - [ ] Embedding search endpoint `/search/semantic`
+  - [ ] Web UI: Semantic search in search bar
+  - [ ] Results ranking by similarity
+
+- [ ] **Ola 2c**
+  - [ ] Related items endpoint
+  - [ ] Duplicate detection logic
+  - [ ] Web UI: Related items sidebar
+
+- [ ] **Ola 4**
+  - [ ] Ollama client integration
+  - [ ] Settings: "Use local AI"
+  - [ ] Download + setup flow
+
+- [ ] **Ola 5**
+  - [ ] Chat endpoint (semantic search + context)
+  - [ ] Chat UI component
+  - [ ] Code generation prompts
+
+---
+
+## 🔗 Related documents
+
+- [STRATEGIC_ROADMAP.md](STRATEGIC_ROADMAP.md)
+- [ROADMAP_WEB.md](ROADMAP_WEB.md)
+- [ROADMAP_DESKTOP.md](ROADMAP_DESKTOP.md)
+- [../API.md](../API.md) — API endpoints for AI features
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Guía para implementación Ola 2

--- a/docs/DATA_SCHEMA.md
+++ b/docs/DATA_SCHEMA.md
@@ -1,0 +1,647 @@
+---
+tags:
+  - devdeck
+  - schema
+  - database
+  - data-model
+status: active
+date: 2026-04-29
+---
+
+# 🗂️ DevDeck — Data Schema
+
+> Definición completa del modelo de datos. Todas las entidades, relaciones, y campos. Fuente única de verdad para backend + frontend.
+
+---
+
+## 🎯 Principios
+
+1. **Normalizado** — Evita duplicación de datos
+2. **Extensible** — Fácil agregar nuevos tipos de items
+3. **Queryable** — Índices para búsqueda rápida
+4. **Versionado** — Schema evoluciona sin breaking changes
+5. **Auditable** — created_at, updated_at, created_by en todo
+
+---
+
+## 📊 Modelo conceptual
+
+```
+User
+├── Deck (carpetas temáticas)
+│   ├── Item (repos, CLIs, snippets, etc)
+│   │   ├── Tag (auto + manual)
+│   │   ├── Command (cómo se usa)
+│   │   └── Relation (items relacionados)
+│   └── Setting (config per deck)
+└── Share (items/decks compartidos)
+    ├── Comment (comentarios en items públicos)
+    └── Activity (feed de cambios)
+```
+
+---
+
+## 🗄️ Entidades detalladas
+
+### 1. **User**
+
+```sql
+CREATE TABLE users (
+  id UUID PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  email TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  avatar_url TEXT,
+  bio TEXT,
+  
+  -- Preferences
+  theme TEXT DEFAULT 'auto',      -- 'auto' | 'light' | 'dark'
+  language TEXT DEFAULT 'es',     -- 'es' | 'en'
+  timezone TEXT DEFAULT 'UTC',
+  use_local_ai BOOLEAN DEFAULT false,  -- Usar Ollama vs OpenAI
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  last_login TIMESTAMP,
+  deleted_at TIMESTAMP NULL,       -- Soft delete
+  
+  -- Relationships
+  github_id TEXT UNIQUE,           -- For GitHub auth
+  api_key TEXT UNIQUE              -- For API access
+);
+
+-- Indexes
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_github_id ON users(github_id);
+```
+
+---
+
+### 2. **Deck**
+
+```sql
+CREATE TABLE decks (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Metadata
+  name TEXT NOT NULL,              -- "Go tools", "DevOps", etc
+  description TEXT,
+  color TEXT DEFAULT '#FF6B00',    -- Hex color (Snarkel orange default)
+  icon TEXT DEFAULT '📦',          -- Emoji icon
+  is_public BOOLEAN DEFAULT false, -- Shareable?
+  
+  -- Organization
+  parent_deck_id UUID REFERENCES decks(id),  -- For nested decks (future)
+  sort_order INT DEFAULT 0,
+  
+  -- Stats (denormalized for perf)
+  items_count INT DEFAULT 0,
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP NULL,       -- Soft delete
+  
+  CONSTRAINT fk_deck_user FOREIGN KEY (user_id) REFERENCES users(id),
+  UNIQUE (user_id, name)           -- Can't have duplicate deck names per user
+);
+
+-- Indexes
+CREATE INDEX idx_decks_user_id ON decks(user_id);
+CREATE INDEX idx_decks_is_public ON decks(is_public);
+```
+
+---
+
+### 3. **Item**
+
+```sql
+CREATE TABLE items (
+  id UUID PRIMARY KEY,
+  deck_id UUID NOT NULL REFERENCES decks(id),
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Core data
+  type TEXT NOT NULL,              -- 'repo', 'cli', 'plugin', 'snippet', 'tip', 'workflow', 'prompt'
+  url TEXT,                        -- For repos/CLIs/resources
+  title TEXT NOT NULL,
+  description TEXT,
+  content TEXT,                    -- For snippets/tips: actual code/text
+  
+  -- Rich metadata
+  image_url TEXT,                  -- GitHub og:image or user-uploaded
+  summary TEXT,                    -- AI-generated summary (max 1 sentence)
+  language TEXT,                   -- For snippets: 'go', 'python', 'javascript'
+  stack TEXT[],                    -- Auto-detected: ['go', 'cli', 'performance']
+  
+  -- AI data
+  embedding VECTOR(1536),          -- OpenAI text-embedding-3-small
+  embedding_model TEXT DEFAULT 'text-embedding-3-small',  -- For tracking model version
+  
+  -- Personal context
+  personal_notes TEXT,             -- Why I saved this, how I use it
+  rating INT CHECK (rating >= 0 AND rating <= 5),
+  is_favorite BOOLEAN DEFAULT false,
+  
+  -- Source tracking
+  source_url TEXT,                 -- Where did user find it (for analytics)
+  source_type TEXT,                -- 'direct', 'github', 'twitter', 'recommendation', 'search'
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  last_accessed_at TIMESTAMP,
+  deleted_at TIMESTAMP NULL,       -- Soft delete
+  
+  CONSTRAINT fk_item_deck FOREIGN KEY (deck_id) REFERENCES decks(id),
+  CONSTRAINT fk_item_user FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Indexes
+CREATE INDEX idx_items_deck_id ON items(deck_id);
+CREATE INDEX idx_items_user_id ON items(user_id);
+CREATE INDEX idx_items_type ON items(type);
+CREATE INDEX idx_items_is_favorite ON items(is_favorite);
+CREATE INDEX idx_items_created_at ON items(created_at DESC);  -- Recent items
+CREATE INDEX idx_items_embedding ON items USING ivfflat(embedding vector_cosine_ops);  -- Vector search
+```
+
+---
+
+### 4. **Tag**
+
+```sql
+CREATE TABLE tags (
+  id UUID PRIMARY KEY,
+  item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Tag data
+  name TEXT NOT NULL,              -- 'cli', 'go', 'performance', etc
+  is_auto_generated BOOLEAN DEFAULT false,  -- AI-generated vs manual
+  confidence FLOAT,                -- If auto-generated: 0.0-1.0 confidence
+  category TEXT,                   -- 'tool-type' | 'stack' | 'skill' | 'custom'
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP NULL,       -- Soft delete (user removed tag)
+  
+  CONSTRAINT fk_tag_item FOREIGN KEY (item_id) REFERENCES items(id),
+  CONSTRAINT fk_tag_user FOREIGN KEY (user_id) REFERENCES users(id),
+  UNIQUE (item_id, name)           -- Can't have duplicate tags on same item
+);
+
+-- Indexes
+CREATE INDEX idx_tags_item_id ON tags(item_id);
+CREATE INDEX idx_tags_name ON tags(name);
+CREATE INDEX idx_tags_category ON tags(category);
+```
+
+---
+
+### 5. **Command**
+
+```sql
+CREATE TABLE commands (
+  id UUID PRIMARY KEY,
+  item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Command data
+  command_text TEXT NOT NULL,      -- 'npm install', 'docker build -t', etc
+  description TEXT,                -- What does this command do?
+  flags TEXT[],                    -- Relevant flags (for auto-complete)
+  example_args TEXT,               -- 'package_name' or '[options]'
+  output_description TEXT,         -- What to expect
+  
+  -- Context
+  platform TEXT,                   -- 'mac', 'linux', 'windows' (all if null)
+  category TEXT,                   -- 'install', 'run', 'build', 'test', 'deploy'
+  is_most_common BOOLEAN DEFAULT false,  -- Show at top?
+  usage_count INT DEFAULT 0,       -- Track how often used (for recommendations)
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP NULL,
+  
+  CONSTRAINT fk_command_item FOREIGN KEY (item_id) REFERENCES items(id),
+  CONSTRAINT fk_command_user FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Indexes
+CREATE INDEX idx_commands_item_id ON commands(item_id);
+CREATE INDEX idx_commands_category ON commands(category);
+CREATE INDEX idx_commands_most_common ON commands(is_most_common);
+```
+
+---
+
+### 6. **Tip**
+
+```sql
+CREATE TABLE tips (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Tip data
+  title TEXT NOT NULL,             -- "Go goroutine best practices"
+  content TEXT NOT NULL,           -- Markdown content
+  stack TEXT NOT NULL,             -- 'go', 'node', 'python', 'docker', etc
+  category TEXT NOT NULL,          -- 'performance', 'debugging', 'setup', 'best-practices'
+  difficulty TEXT,                 -- 'beginner', 'intermediate', 'advanced'
+  
+  -- Code example
+  code_example TEXT,               -- Optional code snippet
+  code_language TEXT,              -- 'go', 'javascript', etc
+  
+  -- Relationships
+  related_item_id UUID REFERENCES items(id),  -- Link to repo/CLI if applicable
+  
+  -- Metadata
+  is_public BOOLEAN DEFAULT false,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP NULL,
+  
+  CONSTRAINT fk_tip_user FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT fk_tip_item FOREIGN KEY (related_item_id) REFERENCES items(id)
+);
+
+-- Indexes
+CREATE INDEX idx_tips_stack ON tips(stack);
+CREATE INDEX idx_tips_category ON tips(stack, category);
+CREATE INDEX idx_tips_is_public ON tips(is_public);
+```
+
+---
+
+### 7. **Relation** (Graph of items)
+
+```sql
+CREATE TABLE relations (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Relationships
+  source_item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  target_item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  
+  -- Type of relationship
+  relation_type TEXT NOT NULL,     -- 'similar', 'depends_on', 'alternative', 'complements', 'inspired_by'
+  confidence FLOAT,                -- 0.0-1.0 (higher = stronger relation)
+  
+  -- Metadata
+  is_auto_detected BOOLEAN DEFAULT false,  -- AI-detected vs manual
+  created_at TIMESTAMP DEFAULT NOW(),
+  
+  CONSTRAINT fk_relation_source FOREIGN KEY (source_item_id) REFERENCES items(id),
+  CONSTRAINT fk_relation_target FOREIGN KEY (target_item_id) REFERENCES items(id),
+  CONSTRAINT fk_relation_user FOREIGN KEY (user_id) REFERENCES users(id),
+  UNIQUE (source_item_id, target_item_id, relation_type)  -- No duplicate relations
+);
+
+-- Indexes
+CREATE INDEX idx_relations_source ON relations(source_item_id);
+CREATE INDEX idx_relations_target ON relations(target_item_id);
+CREATE INDEX idx_relations_type ON relations(relation_type);
+```
+
+---
+
+### 8. **Share** (Sharing & Public access)
+
+```sql
+CREATE TABLE shares (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- What's being shared
+  item_id UUID REFERENCES items(id) ON DELETE CASCADE,
+  deck_id UUID REFERENCES decks(id) ON DELETE CASCADE,
+  
+  -- Share settings
+  share_token TEXT NOT NULL UNIQUE,  -- UUID or short slug
+  share_type TEXT DEFAULT 'item',    -- 'item' | 'deck'
+  allow_comments BOOLEAN DEFAULT true,
+  allow_copy BOOLEAN DEFAULT true,
+  allow_export BOOLEAN DEFAULT false,
+  
+  -- Expiration
+  expires_at TIMESTAMP NULL,         -- NULL = never expires
+  access_count INT DEFAULT 0,        -- How many times accessed
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP NULL,
+  
+  CONSTRAINT fk_share_user FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT fk_share_item FOREIGN KEY (item_id) REFERENCES items(id),
+  CONSTRAINT fk_share_deck FOREIGN KEY (deck_id) REFERENCES decks(id),
+  CONSTRAINT check_share_type CHECK (
+    (share_type = 'item' AND item_id IS NOT NULL) OR
+    (share_type = 'deck' AND deck_id IS NOT NULL)
+  )
+);
+
+-- Indexes
+CREATE INDEX idx_shares_token ON shares(share_token);
+CREATE INDEX idx_shares_user_id ON shares(user_id);
+CREATE INDEX idx_shares_expires_at ON shares(expires_at);
+```
+
+---
+
+### 9. **Comment** (Social/collaboration)
+
+```sql
+CREATE TABLE comments (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- Target
+  item_id UUID NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  
+  -- Comment data
+  text TEXT NOT NULL,
+  is_pinned BOOLEAN DEFAULT false,
+  
+  -- Threading (for nested comments - future feature)
+  parent_comment_id UUID REFERENCES comments(id) ON DELETE CASCADE,
+  
+  -- Metadata
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP NULL,
+  
+  CONSTRAINT fk_comment_user FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT fk_comment_item FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+-- Indexes
+CREATE INDEX idx_comments_item_id ON comments(item_id);
+CREATE INDEX idx_comments_user_id ON comments(user_id);
+CREATE INDEX idx_comments_created_at ON comments(item_id, created_at DESC);
+```
+
+---
+
+### 10. **Activity** (Audit log + social feed)
+
+```sql
+CREATE TABLE activities (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id),
+  
+  -- What happened
+  action TEXT NOT NULL,            -- 'create', 'update', 'delete', 'share', 'favorite'
+  object_type TEXT NOT NULL,       -- 'item', 'deck', 'comment', 'tag'
+  object_id UUID NOT NULL,         -- ID of created/modified object
+  
+  -- Changes (JSON, for auditing)
+  changes JSONB,                   -- {'field': 'old_value', 'new_value'}
+  
+  -- Metadata
+  ip_address TEXT,                 -- For security audit
+  user_agent TEXT,                 -- For analytics
+  created_at TIMESTAMP DEFAULT NOW(),
+  
+  CONSTRAINT fk_activity_user FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- Indexes
+CREATE INDEX idx_activities_user_id ON activities(user_id, created_at DESC);
+CREATE INDEX idx_activities_object ON activities(object_type, object_id);
+CREATE INDEX idx_activities_action ON activities(action);
+```
+
+---
+
+## 🔗 Key relationships
+
+```
+User
+  ├── 1:N Deck (user owns multiple decks)
+  ├── 1:N Item (user can save multiple items)
+  ├── 1:N Tag (user creates tags)
+  ├── 1:N Command (user adds commands)
+  ├── 1:N Tip (user creates tips)
+  ├── 1:N Share (user shares items/decks)
+  ├── 1:N Comment (user comments on items)
+  └── 1:N Activity (audit log)
+
+Deck
+  └── 1:N Item (deck contains multiple items)
+  
+Item
+  ├── 1:N Tag (item has multiple tags)
+  ├── 1:N Command (item has multiple commands)
+  ├── 1:N Comment (item can receive comments)
+  ├── 1:N Relation (item can relate to other items)
+  └── 1:1 Share (item can be shared)
+
+Tag
+  └── Many:Many Item (via junction table - implicit here)
+
+Relation
+  └── Item → Item (graph of relationships)
+
+Share
+  └── Can reference Item OR Deck
+```
+
+---
+
+## 📋 JSON Examples
+
+### Item (Repository)
+
+```json
+{
+  "id": "uuid-1234",
+  "deck_id": "uuid-go-tools",
+  "user_id": "uuid-user",
+  "type": "repo",
+  "url": "https://github.com/spf13/cobra",
+  "title": "cobra",
+  "description": "A Commander for modern Go CLI apps",
+  "image_url": "https://opengraph.b-cdn.net/...",
+  "summary": "Go framework for building powerful CLIs with automatic command parsing and documentation generation.",
+  "stack": ["go", "cli", "framework"],
+  "embedding": [0.023, -0.156, 0.089, ...],
+  "personal_notes": "Perfect for building our internal tools. Used in all our projects.",
+  "rating": 5,
+  "is_favorite": true,
+  "source_type": "recommendation",
+  "tags": [
+    { "name": "cli", "is_auto_generated": true, "confidence": 0.95 },
+    { "name": "go", "is_auto_generated": true, "confidence": 0.98 },
+    { "name": "recommended", "is_auto_generated": false }
+  ],
+  "commands": [
+    {
+      "command_text": "cobra init <app>",
+      "description": "Create a new CLI app",
+      "category": "setup",
+      "is_most_common": true
+    },
+    {
+      "command_text": "cobra add <command>",
+      "description": "Add a new command to app",
+      "category": "setup",
+      "is_most_common": true
+    }
+  ],
+  "relations": [
+    { "target_item_id": "uuid-urfave", "type": "alternative", "confidence": 0.92 },
+    { "target_item_id": "uuid-viper", "type": "complements", "confidence": 0.88 }
+  ],
+  "created_at": "2026-04-29T10:00:00Z",
+  "updated_at": "2026-04-29T10:00:00Z"
+}
+```
+
+### Item (Tip)
+
+```json
+{
+  "id": "uuid-tip-1",
+  "deck_id": "uuid-tips",
+  "user_id": "uuid-user",
+  "type": "tip",
+  "title": "Go goroutine memory leaks",
+  "description": "Common patterns that cause goroutine leaks in Go",
+  "content": "Markdown content here about goroutine management...",
+  "code_example": "go func() {\n  // This goroutine leaks\n  for range time.Tick(1 * time.Second) { }\n}()",
+  "stack": ["go", "performance", "debugging"],
+  "tags": [
+    { "name": "memory", "is_auto_generated": true },
+    { "name": "concurrency", "is_auto_generated": true }
+  ],
+  "created_at": "2026-04-29T10:00:00Z"
+}
+```
+
+---
+
+## 🔄 API endpoints (matching schema)
+
+```
+Items:
+POST   /api/v1/items              Create item
+GET    /api/v1/items              List items (with filters)
+GET    /api/v1/items/{id}         Get item detail
+PUT    /api/v1/items/{id}         Update item
+DELETE /api/v1/items/{id}         Delete item
+
+Tags:
+POST   /api/v1/items/{id}/tags    Add tag
+DELETE /api/v1/items/{id}/tags/{tag_id}  Remove tag
+POST   /api/v1/items/{id}/tags/auto      Auto-generate tags
+
+Commands:
+POST   /api/v1/items/{id}/commands       Add command
+DELETE /api/v1/items/{id}/commands/{cmd_id}
+
+Search:
+GET    /api/v1/search?q=...             Fuzzy search
+POST   /api/v1/search/semantic          Semantic search
+
+Decks:
+POST   /api/v1/decks              Create deck
+GET    /api/v1/decks              List user's decks
+PUT    /api/v1/decks/{id}         Update deck
+DELETE /api/v1/decks/{id}         Delete deck
+
+Sharing:
+POST   /api/v1/items/{id}/share   Generate share link
+GET    /api/v1/share/{token}      Access shared item
+
+Relations:
+POST   /api/v1/items/{id}/relations      Add relation
+GET    /api/v1/items/{id}/related        Get related items
+```
+
+---
+
+## 🚀 Migration strategy
+
+### Phase 1: Current schema
+- Backwards compatible with existing data
+- Add new fields as nullable
+
+### Phase 2: Ollama support
+- Add `embedding` column (nullable initially)
+- Add `embedding_model` tracking
+
+### Phase 3: Extensions (future)
+- `collections` (sub-folders in decks)
+- `workflows` (multi-step procedures)
+- `batch_operations` (multi-item actions)
+
+---
+
+## 🔒 Data access control
+
+```
+User can:
+- Create/edit/delete own items
+- Share items (generate share link)
+- See public items from others
+- Comment on public items
+
+User CANNOT:
+- Access other user's private items
+- Delete other user's items
+- Modify other user's tags
+
+Share link:
+- Can be view-only (default)
+- Can allow comments (optional)
+- Can allow copying to own deck (optional)
+- Can expire after N days
+```
+
+---
+
+## 📊 Performance notes
+
+### Indexes created for speed:
+- `users(email)` — Login lookups
+- `decks(user_id)` — List user's decks
+- `items(deck_id, created_at)` — Recent items in deck
+- `items(embedding)` — Vector similarity search
+- `tags(item_id, name)` — Tag lookups
+- `relations(source_item_id)` — Related items
+- `comments(item_id, created_at)` — Comments on item
+
+### Denormalization (for query perf):
+- `decks.items_count` — Avoids COUNT(*) on every deck list
+- `embedding` — Stored directly on item (not separate table)
+
+### Caching strategy:
+- User's deck list (cache invalidated on deck change)
+- Recent items in deck (cache invalidated on new item)
+- Popular tags (refresh daily)
+
+---
+
+## 🔄 Versioning
+
+Current schema version: **1.0.0** (2026-04-29)
+
+Breaking changes will increment major version.
+
+```
+Schema version in database:
+SELECT version FROM schema_info;
+-- Returns: 1.0.0
+```
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Referencia para implementación backend

--- a/docs/FEATURE_INVENTORY.md
+++ b/docs/FEATURE_INVENTORY.md
@@ -1,0 +1,271 @@
+---
+tags:
+  - devdeck
+  - features
+  - inventory
+status: active
+date: 2026-04-29
+---
+
+# 📦 DevDeck — Feature Inventory
+
+> Catálogo de **todas las features** planeadas, agrupadas por tipo y Ola de desarrollo. Cada feature describe: qué es, por qué importa, cuándo la hacemos.
+
+---
+
+## 🎯 Ola 1: Foundation
+
+### Core Capture
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Quick Capture** | Modal: pega URL/descripción → extrae metadata automáticamente (title, description, image, tags básicos) | Sin esto, capturar es lento | 🟡 Mejorando |
+| **Deck Assignment** | Al capturar, elegir o crear deck (carpeta temática) | Items desorganizados = inútiles | ✅ Existe |
+| **Manual Tags** | Agregar tags propios al capturar | Tags auto-generados no siempre acierta | ✅ Existe |
+| **Item Types** | Soportar: Repo, CLI, Plugin, Snippet, Tip, Workflow, Prompt | Cada cosa se ve y se usa distinto | ✅ Existe |
+| **Cheatsheet Editor** | Editar cheatsheet por item (markdown) | Documentar "cómo se usa" cada herramienta | ✅ Existe |
+
+### Organization
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Decks** | Carpetas temáticas (p.ej. "Go tools", "DevOps") | Agrupar items por contexto | ✅ Existe |
+| **Favorites** | Marcar items como favoritos | Quick access a lo que usás siempre | ⏳ Pendiente |
+| **Collections** | Agrupaciones temáticas dentro de decks | Sub-carpetas para estructura profunda | ⏳ Pendiente |
+| **Search (Fuzzy)** | Búsqueda por título/descripción/tags | Base de la usabilidad | ✅ Existe |
+| **Filter by Type** | Filtrar items por tipo (solo repos, solo CLIs) | Focus en lo que buscás | ⏳ Pendiente |
+| **Filter by Stack** | Filtrar por tecnología (Go/Node/Python/Docker) | "Muestra solo mis Go tools" | ⏳ Pendiente |
+
+### Experience
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Rich Preview** | Vista previa detallada del item (markdown, GitHub data, videos) | Vemos toda la información del item sin hacer click | ✅ Existe |
+| **Keyboard Shortcuts** | cmd+K search, cmd+N new item, etc | Velocidad | ⏳ Mejorado web |
+| **Dark/Light Mode** | Toggle tema (persist en settings) | Comodidad | ✅ Existe |
+| **Mobile responsive** | Web app responsive en celular | Consultas on-the-go | 🟡 Parcial |
+
+---
+
+## 🎯 Ola 2: Intelligence
+
+### AI-Powered Organization
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Auto-Tagging** | IA asigna tags automáticamente al capturar | Organizar sin trabajo manual | ⏳ Pendiente |
+| **Auto-Summary** | IA genera descripción concisa del item | Saber qué es sin leer todo | ⏳ Pendiente |
+| **Stack Detection** | IA detecta tech stack (Go/Node/Python/etc) | Filtrar automáticamente | ⏳ Pendiente |
+| **Category Suggestion** | IA sugiere qué deck asignarlo | Assist en captura | ⏳ Pendiente |
+| **Duplicate Detection** | IA detecta items similares | No duplicar | ⏳ Pendiente |
+
+### Intelligent Search
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Semantic Search** | Buscar por intención: "CLI para tareas paralelas" → items relevantes ranked | Encontrar lo que necesitás sin memorizar keywords | ⏳ Pendiente |
+| **Natural Language Query** | Preguntar en lenguaje natural | Búsqueda sin sintaxis | ⏳ Pendiente |
+| **Search History** | Guardar búsquedas recientes | Volver a lo que buscaste | ⏳ Pendiente |
+| **Saved Searches** | Guardar búsquedas complejas | "Mis busquedas favoritas" | ⏳ Pendiente |
+
+### Discovery
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Related Items** | Sugerir items por semántica | "Si te gusto X, te gustará Y" | ⏳ Pendiente |
+| **Trending in Deck** | Items más vistos en cada deck | Descubrir lo popular | ⏳ Pendiente |
+| **Similar Commands** | Sugerir comandos similares al digitar | Helper en captura | ⏳ Pendiente |
+| **Random Discovery** | "Algo random de tu deck" (Daily surprise) | Redescubrir cosas guardadas | ⏳ Pendiente |
+
+### Desktop Power
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Hotkey Capture** | cmd+K = captura modal (global hotkey) | Capturar sin abrir app | ⏳ Pendiente |
+| **Screenshot + Annotate** | cmd+shift+S = screenshot → annotate → save | Capturar visualmente | ⏳ Pendiente |
+| **Launcher Mode** | cmd+K search + execute (CLI commands) | "My own Raycast, pero para mi DevDeck" | ⏳ Pendiente |
+| **Sync Desktop→Web** | Cambios en desktop sincronizan a web | Always in sync | 🟡 Parcial |
+
+---
+
+## 🎯 Ola 3: Collaboration
+
+### Sharing
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Share Item Link** | Generar link para compartir item individual | Mostrar a un colega | ⏳ Pendiente |
+| **Expiring Links** | Link con expiración (24h, 7d, etc) | Control de acceso | ⏳ Pendiente |
+| **Share Deck Public** | Publicar deck entero como público | "Mi deck de Go tools" disponible para community | ⏳ Pendiente |
+| **Copy Item** | Copiar item a tu deck | Clonar cosas interesantes de otros | ⏳ Pendiente |
+
+### Social
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Comments on Items** | Comentar en items compartidos | "Cómo lo usás vos?" | ⏳ Pendiente |
+| **Activity Feed** | Ver qué agregaron amigos a decks públicos | Descubrir nuevo | ⏳ Pendiente |
+| **Upvotes** | Upvotear items interesantes | Señalar calidad | ⏳ Pendiente |
+| **Deck Followers** | Seguir decks de otros | "Quiero ver lo que agrega" | ⏳ Pendiente |
+
+### Community
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Trending Decks** | Decks populares en la comunidad | Descubrir curación buena | ⏳ Pendiente |
+| **Curated Collections** | Decks armados por DevDeck team | Onboarding: "Starter Go toolkit", "DevOps essentials" | ⏳ Pendiente |
+| **Community Picks** | Items recomendados por comunidad | Crowdsourced discovery | ⏳ Pendiente |
+
+---
+
+## 🎯 Ola 4: Offline Superpowers
+
+### Local Intelligence
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Ollama Integration** | Usar modelos de IA locales (Mistral, Llama2) | IA sin cloud costs, privacy | ⏳ Pendiente |
+| **Local Embeddings** | Generar embeddings localmente | Semantic search offline | ⏳ Pendiente |
+| **Local Vector DB** | SQLite + FTS para embeddings locales | No depender de cloud | ⏳ Pendiente |
+| **Offline Auto-Tagging** | Auto-tagging sin internet | Funciona sin conexión | ⏳ Pendiente |
+
+### Sync & Conflict Resolution
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Smart Sync** | Detecta cambios, sincroniza cuando hay conexión | Offline-first funciona | ⏳ Pendiente |
+| **Conflict Resolution** | Si cambias same item en web y desktop, resolver automáticamente | No perder cambios | ⏳ Pendiente |
+| **Sync Status Indicator** | Mostrar si estamos sincronizados o desincronizados | Transparencia | ⏳ Pendiente |
+| **Selective Sync** | Sync solo ciertos decks | Control de datos | ⏳ Pendiente |
+
+### Performance
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Instant Search** | Búsqueda local < 100ms | UX rápida | ⏳ Pendiente |
+| **Quick Launch** | Desktop abre < 1s | Velocidad | ⏳ Pendiente |
+| **Indexing Background** | Indexar items en background sin bloquear | Responsivo | ⏳ Pendiente |
+
+---
+
+## 🎯 Ola 5: AI Assistant
+
+### Ask DevDeck
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Ask Modal** | cmd+A = Chat con DevDeck | "¿Cómo hago X?" | ⏳ Pendiente |
+| **Contextual Answers** | IA busca en tu deck personal + internet | Respuestas personalizadas | ⏳ Pendiente |
+| **Code Generation** | Generar comandos/scripts basado en tu contexto | "Genera un script para hacer X" | ⏳ Pendiente |
+| **Workflow Generation** | "Generar workflow completo" → DevDeck arma pasos | Automatizar procesos | ⏳ Pendiente |
+
+### Learning
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Generate Cheatsheet** | IA genera cheatsheet para item | Documentación automática | ⏳ Pendiente |
+| **Learning Path** | "Enseñame Go" → secuencia items + mini-lessons | Onboarding a tools | ⏳ Pendiente |
+| **Explain Item** | IA explica qué hace, cuándo lo usás | Entender herramientas | ⏳ Pendiente |
+
+---
+
+## 🌟 Special Features (All Olas)
+
+### Tips & Commands System
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Tips by Stack** | Consejos para Go, Node, Docker, etc | "Mejores prácticas de Go" | ⏳ Pendiente |
+| **Commands per Item** | Guardar comandos más usados de una tool | Copy-paste ready | ⏳ Pendiente |
+| **Command Snippets** | Reutilizable bits de comandos | Recordar flags y opciones | ⏳ Pendiente |
+| **Runbooks** | Workflow en pasos (paso 1: pull, paso 2: build, etc) | Procedimientos documentados | ⏳ Pendiente |
+| **Context Variables** | Reemplazar `$PROJECT`, `$USER`, etc en comandos | Personalizar scripts | ⏳ Pendiente |
+
+### Import/Export
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **GitHub Stars Import** | Importar tus stars de GitHub → items | Migración fácil | ⏳ Pendiente |
+| **CSV Import** | Importar items desde CSV | Bulk onboarding | ⏳ Pendiente |
+| **Deck Export (JSON)** | Exportar deck como JSON | Backup, share format | ⏳ Pendiente |
+| **Obsidian Export** | Exportar a Obsidian vault format | Integración con PKM | ⏳ Pendiente |
+
+### Settings & Personalization
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Theme Settings** | Dark/light, accent colors, font size | Comodidad | ✅ Existe (partial) |
+| **Hotkey Customization** | Personalizar hotkeys | Respetar preferencias | ⏳ Pendiente |
+| **API Key Config** | Configurar OpenAI key o Ollama URL | Control de IA | ⏳ Pendiente |
+| **Sync Preferences** | Qué decks syncar, frecuencia, etc | Control de datos | ⏳ Pendiente |
+| **Privacy Mode** | Ningún dato a cloud (local only) | Para muy paranoicos | ⏳ Pendiente |
+
+### Analytics (Optional)
+
+| Feature | Descripción | Por qué | Estado |
+|---------|-------------|--------|--------|
+| **Most Used Items** | Mostrar items más buscados/accedidos | Saber qué vale la pena | ⏳ Pendiente |
+| **Deck Stats** | Items por deck, tamaño, etc | Entender tu colección | ⏳ Pendiente |
+| **Search Analytics** | Qué buscas, con qué frecuencia | Mejorar search | ⏳ Pendiente |
+
+---
+
+## 📊 Feature Matrix (Plataforma × Ola)
+
+```
+                Ola1    Ola2    Ola3    Ola4    Ola5
+Capture         ✅      🔄      🔄      🔄      🔄
+Organization    ✅      🔄      🔄      🔄      🔄
+Search          ⏳      🔄      🔄      🔄      🔄
+AI              ⏳      ✅      🔄      🔄      ✅
+Collaboration   ⏳      ⏳      ✅      🔄      ⏳
+Offline         🟡      🟡      🟡      ✅      ✅
+Desktop         🟡      ✅      ✅      ✅      ✅
+Assistant       ⏳      ⏳      ⏳      ⏳      ✅
+```
+
+Legend:
+- ✅ = Existente/Completado
+- 🔄 = Mejorando/En desarrollo
+- 🟡 = Parcial
+- ⏳ = Planeado para Ola
+
+---
+
+## 🚀 Quick Wins (Comienza inmediatamente)
+
+1. **Filter by Type + Stack** (1-2 días)
+   - Agregar filtros UI en lista de items
+   - Backend: agregar query params
+
+2. **Favorites System** (1-2 días)
+   - Agregar columna `is_favorite` en items
+   - UI: ⭐ button
+
+3. **Search History** (2-3 días)
+   - Guardar últimas 20 búsquedas
+   - Mostrar en dropdown
+
+4. **Copy Command Hotkey** (1 día)
+   - Cuando hoveras comando, show "copy" button
+   - Hotkey: cmd+C = copy automático
+
+5. **Mobile Responsive** (2-3 días)
+   - Mejoras en layout mobile
+   - Toque-friendly modals
+
+---
+
+## 🔗 Relación con otros documentos
+
+- **STRATEGIC_ROADMAP.md** — Integración de features por Ola
+- **ROADMAP_WEB.md** — Qué features en web, cuándo
+- **ROADMAP_DESKTOP.md** — Qué features en desktop, cuándo
+- **UX_PATTERNS.md** — Cómo se implementan UI/UX
+- **DATA_SCHEMA.md** — Schema para soportar features
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Usado como referencia para priorización

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,67 +1,121 @@
-# DevDeck — Documentación
+---
+tags:
+  - devdeck
+  - docs
+  - obsidian
+aliases:
+  - DevDeck Docs
+  - DevDeck Vault
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
 
-> Índice de documentación del proyecto. Todos los docs están en esta carpeta (`docs/`).
+# 📚 DevDeck - Documentación Operativa
+
+> [!abstract] Resumen
+> Esta carpeta contiene toda la documentación operativa de DevDeck, organizada por área: Backend, Frontend, Arquitectura, Producto y Runbooks. El objetivo es tener una fuente única de verdad para decisiones técnicas, roadmap y procedimientos operativos.
 
 ---
 
-## Documentación de producto
+## 🎯 Punto de entrada
 
-| Archivo | Descripción |
-|---------|-------------|
-| [PRD.md](PRD.md) | **Product Requirements Document.** Visión, tipos de items, funcionalidades por ola (1–7), user stories, métricas, constraints, decisiones y riesgos. Punto de entrada principal para entender el producto. |
-| [VISION.md](VISION.md) | **Visión y posicionamiento.** Qué es DevDeck (y qué no es), diferenciadores genuinos, taglines por audiencia, roadmap de posicionamiento y preguntas frecuentes de posicionamiento. |
-| [COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md) | **Análisis competitivo.** Comparación detallada con GitHub Stars, Raindrop, Pocket, Notion, Obsidian, Raycast y Pieces.app. Incluye tablas de pros/contras y posicionamiento relativo. |
+- [[00_DASHBOARD|Dashboard Ejecutivo]] — 30 segundos overview del proyecto
+- **[[STRATEGIC_ROADMAP|Strategic Roadmap (NEW)]]** — Visión integrada web + desktop, 5 Olas de desarrollo
 
 ---
 
-## Documentación de landing page
+## 🗺️ Roadmaps estratégicos (START HERE!)
 
-| Archivo | Descripción |
-|---------|-------------|
-| [LANDING_COPY.md](LANDING_COPY.md) | **Copy de landing en inglés.** Copy completo para `devdeck.ai` en inglés (audiencia global de developers). Incluye hero, features, AI section, plataformas, pricing, CTA, SEO tags y notas de implementación. |
-| [LANDING.md](LANDING.md) | **Copy de landing en español.** Misma estructura en español rioplatense (audiencia hispanohablante / versión ES del sitio). Incluye también micro-copy adicional para la UI de la app. |
+**Para entender a dónde vamos DevDeck:**
 
----
+1. **[[STRATEGIC_ROADMAP|Strategic Roadmap]]** — Integración web + desktop, 5 Olas (Ola 1 Foundation → Ola 5 AI Assistant)
+2. **[[ROADMAP_WEB|Web Roadmap]]** — React 18, desde captura rápida → IA → colaboración
+3. **[[ROADMAP_DESKTOP|Desktop Roadmap]]** — Tauri, desde MVP → hotkeys/launcher → offline con Ollama
+4. **[[FEATURE_INVENTORY|Feature Inventory]]** — Catálogo de 50+ features planeadas, agrupadas por Ola
 
-## Documentación técnica
-
-| Archivo | Descripción |
-|---------|-------------|
-| [ARCHITECTURE.md](ARCHITECTURE.md) | **Arquitectura del sistema.** Diagrama de alto nivel, stack técnico (Go + Chi + Postgres + pgvector, monorepo pnpm workspaces con Electron + React desktop y React web que comparten `@devdeck/ui` / `@devdeck/api-client` / `@devdeck/features`), decisiones de arquitectura y schema de la base de datos. |
-| [adr/0001-items-polymorphism.md](adr/0001-items-polymorphism.md) | **ADR 0001.** Modelo polimórfico de `items` (single-table + JSONB + generated columns). |
-| [adr/0002-sync-strategy.md](adr/0002-sync-strategy.md) | **ADR 0002.** Estrategia de sync offline-first. |
-| [adr/0003-monorepo-pnpm-workspaces.md](adr/0003-monorepo-pnpm-workspaces.md) | **ADR 0003.** Monorepo pnpm workspaces + migración del web client de Vue 3 a React 18 (Wave 4.5 §16.13). |
-| [TECHNICAL_ROADMAP_AI_OFFLINE.md](TECHNICAL_ROADMAP_AI_OFFLINE.md) | **Roadmap técnico detallado.** Plan de implementación de las Olas 5–7: offline-first con SQLite local + sync engine, embeddings + búsqueda vectorial, multi-usuario. |
-| [API.md](API.md) | **Referencia de API REST.** Especificación OpenAPI de todos los endpoints (`/api/repos`, `/api/cheatsheets`, `/api/search`, `/api/auth`, etc.). |
-| [DESIGN_SYSTEM.md](DESIGN_SYSTEM.md) | **Design system.** Tokens CSS, paleta de colores neo-brutalist, tipografía, componentes, estados de la mascota Snarkel y principios de diseño de la UI. |
+**Estrategia de producto:**
+5. **[[AI_STRATEGY|AI Strategy]]** — Cómo la IA genera valor: auto-tagging, semantic search, discovery, Ask DevDeck
+6. **[[UX_PATTERNS|UX Patterns]]** — Diseño consistente: componentes, flujos, accessibility, dark mode
 
 ---
 
-## Otros documentos en el root
+## 📁 Navegación por área
 
-| Archivo | Descripción |
-|---------|-------------|
-| [../README.md](../README.md) | README principal del repositorio: descripción del producto, stack, tabla de docs, estado actual. |
-| [../ROADMAP.md](../ROADMAP.md) | Roadmap de implementación técnica: todas las fases completadas (Olas 1–4) y pendientes (Ola 5+), con detalle de commits y decisiones por fase. |
-
----
-
-## Cómo leer esta documentación
-
-Si llegás sin contexto, el orden recomendado es:
-
-1. **[README.md](../README.md)** — qué es DevDeck en 2 minutos
-2. **[VISION.md](VISION.md)** — por qué existe y para quién
-3. **[PRD.md](PRD.md)** — qué hace, cómo crece, qué se decidió
-4. **[ARCHITECTURE.md](ARCHITECTURE.md)** — cómo está construido
-5. **[ROADMAP.md](../ROADMAP.md)** — qué está hecho y qué viene
-
-Para contribuir o extender el producto:
-- Agregá items al PRD antes de implementar
-- Actualizá ROADMAP.md cuando completes una fase
-- Mantené ARCHITECTURE.md sincronizado con los cambios de infra/schema
+- **[[Backend/Backend MOC|Backend]]** — Servicios, APIs, base de datos
+- **[[Frontend/Frontend MOC|Frontend]]** — Apps, UI, cliente
+- **[[Architecture/Arquitectura General|Arquitectura]]** — Diseño general del sistema
+- **[[PRD/README|Producto (PRD)]]** — Visión, features, roadmap
+- **[[Runbooks/README|Runbooks]]** — Procedimientos operativos
+- **[[Release_Notes/README|Release Notes]]** — Historial de versiones
 
 ---
 
-> **Idioma de la documentación:** español rioplatense (casual) — la misma voz de la app.
-> Excepción: [LANDING_COPY.md](LANDING_COPY.md) está en inglés porque es la versión pública para audiencia global.
+## 🗂️ Templates disponibles
+
+Usá estos al crear nueva documentación:
+- [[_templates/Template - Modulo|Módulo]]
+- [[_templates/Template - ADR|ADR (decisión arquitectónica)]]
+- [[_templates/Template - Runbook|Runbook (procedimiento operativo)]]
+
+Ver [[_templates/README|todos los templates]].
+
+---
+
+## 📋 Fuentes canónicas de estado
+
+- [[Backend/Estado Plataforma|Estado Backend]]
+- [[Frontend/Estado Plataforma|Estado Frontend]]
+- [[Architecture/ADR Index|Decisiones arquitectónicas (ADRs)]]
+
+---
+
+## 🏗️ Estructura de mantenimiento
+
+1. **Cambios en arquitectura** → Crear/actualizar ADR en `Architecture/`
+2. **Nueva feature** → Crear módulo en carpeta correspondiente + actualizar PRD
+3. **Procedimiento repetible** → Crear Runbook en `Runbooks/`
+4. **Estado del sistema** → Actualizar `Estado Plataforma` en cada área
+5. **Dashboard desactualizado** → Actualizar `00_DASHBOARD.md`
+
+---
+
+## 📚 Documentación en el root
+
+Los siguientes documentos aún están en el root y necesitan migración gradual:
+
+**Documentación de producto:**
+- [PRD.md](PRD.md) — Product Requirements Document completo
+- [VISION.md](VISION.md) — Visión y posicionamiento
+- [COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md) — Análisis competitivo
+
+**Landing page:**
+- [LANDING_COPY.md](LANDING_COPY.md) — Copy en inglés
+- [LANDING.md](LANDING.md) — Copy en español
+
+**Técnica:**
+- [ARCHITECTURE.md](ARCHITECTURE.md) — Arquitectura del sistema
+- [API.md](API.md) — Especificación API
+- [DESIGN_SYSTEM.md](DESIGN_SYSTEM.md) — Design System
+- [TECHNICAL_ROADMAP_AI_OFFLINE.md](TECHNICAL_ROADMAP_AI_OFFLINE.md) — Roadmap técnico
+
+**Referencias externas:**
+- [../README.md](../README.md) — README principal del repositorio
+- [../ROADMAP.md](../ROADMAP.md) — Roadmap de implementación
+
+---
+
+## 🔗 Cómo leer
+
+1. **Nuevo en DevDeck?** → [[00_DASHBOARD|Dashboard]] → [[STRATEGIC_ROADMAP|Strategic Roadmap]] → [[PRD/README|PRD]]
+2. **¿A dónde vamos?** → [[STRATEGIC_ROADMAP|Strategic Roadmap]] (5 Olas) → [[FEATURE_INVENTORY|Features]]
+3. **Quiero implementar feature X** → [[FEATURE_INVENTORY|Inventory]] → encuentra en qué Ola → [[ROADMAP_WEB|Web]] o [[ROADMAP_DESKTOP|Desktop]]
+4. **Diseño de feature Y** → [[UX_PATTERNS|UX Patterns]] (componentes, flujos, accessibility)
+5. **¿Cómo la IA agrega valor?** → [[AI_STRATEGY|AI Strategy]] (tagging, search, discovery)
+6. **Cambios técnicos?** → [[Architecture/ADR Index|ADRs]] → [[Architecture/Arquitectura General|Arquitectura]]
+7. **Procedimiento?** → [[Runbooks/README|Runbooks]]
+8. **Estado actual?** → [[Backend/Estado Plataforma|Backend]] · [[Frontend/Estado Plataforma|Frontend]]
+
+---
+
+*Última revisión: 2026-04-29 — Nueva documentación estratégica agregada (Strategic Roadmap, Feature Inventory, Roadmaps web/desktop, AI Strategy, UX Patterns)*

--- a/docs/ROADMAP_DESKTOP.md
+++ b/docs/ROADMAP_DESKTOP.md
@@ -1,0 +1,266 @@
+---
+tags:
+  - devdeck
+  - roadmap
+  - desktop
+  - tauri
+status: active
+date: 2026-04-29
+---
+
+# 🖥️ DevDeck — Desktop Roadmap (Tauri)
+
+> Evolución específica de la app desktop. Desde espejo de web → poder nativo → offline 100% → IA local.
+
+---
+
+## 📍 Estado actual (2026-04)
+
+### Lo que existe ✅
+- Estructura Tauri base
+- Conexión con backend
+- SQLite local para items
+- Sincronización básica
+
+### Lo que falta 🚧
+- Hotkeys globales (cmd+K, cmd+shift+S)
+- Launcher mode (search + execute commands)
+- Offline-first completo (funciona sin internet)
+- Local indexing (búsqueda instantánea local)
+- Ollama integration (IA local)
+- UI pulida (consistente con web)
+
+---
+
+## 🌊 Fases de desarrollo
+
+### **Fase 1: MVP Desktop** (Q2 2026 — 3-4 semanas)
+
+**Objetivo**: Desktop es espejo funcional de web, con sincronización
+
+#### Features
+- [ ] **Layout base** — Mismo diseño que web (sidebar + deck view + item list)
+- [ ] **Sync automático** — Cambios web → desktop en < 1 segundo
+- [ ] **SQLite local** — Todos los items en BD local
+- [ ] **Offline read** — Puedo leer items sin internet (no escribir)
+- [ ] **Tray icon** — App en tray (minimize/restore)
+
+#### Architecture
+- **Frontend**: React components compartidas con web (monorepo)
+- **Backend local**: Tauri commands que hablan con SQLite
+- **Database**: SQLite (schema idéntico a PostgreSQL del server)
+- **Sync**: Listener de cambios en backend → fetch nuevos items
+
+#### Desktop-specific UX
+- [ ] Minimize to tray (no cierra, minimiza)
+- [ ] Restore on tray click
+- [ ] System notifications (nuevo item compartido, sync done)
+
+#### Done when
+- ✅ Desktop abre en < 2 segundos
+- ✅ Items sincronizados en < 1 segundo
+- ✅ Puedo buscar/filtrar items sin internet
+- ✅ Cambios en web aparecen en desktop inmediatamente
+
+---
+
+### **Fase 2: Hotkeys & Launcher** (Q3 2026 — 3-4 semanas)
+
+**Objetivo**: Desktop tiene superpoderes de captura y búsqueda global
+
+#### Features
+- [ ] **Global hotkey (cmd+K)** — Anywhere en el sistema, cmd+K = capture modal
+- [ ] **Screenshot hotkey (cmd+shift+S)** — Captura screenshot, annota, save
+- [ ] **Search hotkey (cmd+alt+K)** — Anywhere, busca en tu deck
+- [ ] **Launcher mode** — Search items → ejecutar commands
+- [ ] **Quick capture** — Clipboard detection (si copiaste URL, sugiere capturar)
+
+#### Hotkey implementation
+```
+cmd+K        → Capture modal (URL, text, archivo)
+cmd+shift+S  → Screenshot + annotation
+cmd+alt+K    → Search in Deck (no capture, solo search)
+cmd+alt+C    → Copy last used command
+```
+
+#### Launcher example
+```
+User: cmd+K → tipos "install package"
+DevDeck muestra:
+  1. npm install package
+  2. pnpm add package
+  3. yarn add package
+User selecciona → copia al clipboard (y lo pega donde quiere)
+```
+
+#### Backend support
+- [ ] Endpoint `/commands/search?q=install` (busca en tu library de commands)
+- [ ] Endpoint `/items/{id}/command/execute` (registra que ejecutaste un command)
+
+#### Desktop SDK
+- Tauri's `hotkey` module para global shortcuts
+- Screenshot lib (screenshot-rs o similar)
+- Clipboard monitoring
+
+#### Done when
+- ✅ cmd+K funciona desde cualquier app
+- ✅ Screenshot + annotate workflow < 5 segundos
+- ✅ Launcher mode shows relevant commands
+- ✅ 50% of captures via hotkeys
+
+---
+
+### **Fase 3: Local Intelligence** (Q4 2026 — 4-5 semanas)
+
+**Objetivo**: Desktop funciona 100% offline con IA local
+
+#### Features
+- [ ] **Ollama integration** — Usar LLMs locales (Mistral 7B, Llama2)
+- [ ] **Local embeddings** — Generar embeddings sin OpenAI
+- [ ] **Local semantic search** — Search offline, < 200ms response
+- [ ] **Auto-tag offline** — Auto-tagging sin conectar a OpenAI
+- [ ] **Smart sync** — Detecta cambios, sincroniza cuando hay conexión
+- [ ] **Conflict resolution** — Si cambias same item en web y desktop, auto-merge
+
+#### Ollama setup
+- User puede instalar Ollama (https://ollama.ai)
+- DevDeck detects Ollama running on localhost:11434
+- Option en Settings: "Use local AI" (true/false)
+- Si activa, descargar modelo (~7GB):
+  - `ollama pull mistral` (fast, good)
+  - O `ollama pull neural-chat` (optimizado para chats)
+
+#### Local indexing
+- Generate embeddings para todos los items (one-time)
+- Store embeddings en SQLite (vector extension)
+- Semantic search usa SQLite FTS
+
+#### Sync strategy
+```
+Desktop:
+  - Offline mode: cambios se guardan localmente, queue de sync
+  - Online mode: auto-sync (pull from server, push local changes)
+  - Conflict: "last write wins" o mostrar dialog para elegir
+```
+
+#### Done when
+- ✅ Ollama integrado y funcionando
+- ✅ Local semantic search < 200ms
+- ✅ Desktop funciona 100% offline
+- ✅ Sync resolves conflicts automáticamente
+- ✅ First time setup instructions en docs
+
+---
+
+### **Fase 4: Power Features** (Q1 2027+)
+
+**Objetivo**: Desktop tiene funciones que web no tiene
+
+#### Features (planeadas)
+- [ ] **Batch operations** — Select multiple items, bulk tag/move/delete
+- [ ] **Automation** — Rules: "Si item tiene tag 'Go', asignarlo a deck 'Go tools'"
+- [ ] **System integration** — Finder/Explorer integration (share to DevDeck)
+- [ ] **Update checker** — Auto-updates or notify
+- [ ] **Analytics** — Local analytics (no cloud) - qué buscas, con qué frecuencia
+
+#### Integration examples
+- macOS: Cmd+K in Finder → "Send to DevDeck"
+- Windows: Right-click file → "Add to DevDeck"
+
+---
+
+## 🛠️ Tech stack Desktop
+
+### Framework
+- **Tauri** (confirmed)
+  - Rust backend
+  - React frontend (shared with web)
+  - Small bundle (~100MB)
+  - Native performance
+
+### Storage
+- **SQLite** (local database)
+  - sqlite3 Rust driver
+  - Schema mirrored from PostgreSQL backend
+  - FTS (Full Text Search) for local search
+
+### AI/Embeddings
+- **Ollama** (optional, user-installed)
+  - HTTP API at localhost:11434
+  - Models: Mistral 7B, Llama2
+  - Embeddings generation
+
+### Plugins/libraries
+- `tauri-plugin-window` — window management
+- `tauri-plugin-globalshortcut` — hotkeys
+- `sqlite3` — local DB
+- `screenshot-rs` — screenshots
+- `pdf-extract` — if user captures PDF
+
+### Signing & Distribution
+- Code signing (macOS)
+- Notarization (macOS app store)
+- Auto-update (Tauri updater plugin)
+
+---
+
+## 📊 Desktop vs Web comparison
+
+| Feature | Web | Desktop |
+|---------|-----|---------|
+| Hotkeys | cmd+K in web | Global hotkeys |
+| Screenshot | Via browser | Native (cmd+shift+S) |
+| Offline | Limited (Service Worker) | Full (SQLite + Ollama) |
+| Speed | 200-500ms search | < 100ms search |
+| IA local | No (OpenAI only) | Yes (Ollama) |
+| Sync | Automatic | Automatic + smart conflict resolution |
+| System integration | Browser only | Files + clipboard |
+
+---
+
+## 🎯 Success metrics
+
+### Fase 1
+- Desktop opens < 2s
+- 100% item sync completed < 1s
+- Offline read works for 100% of items
+
+### Fase 2
+- 70% of captures via hotkeys
+- Launcher mode used in 50% of daily users
+- Global hotkey works from any app (100%)
+
+### Fase 3
+- Ollama integration used by 80% of power users
+- Local semantic search < 200ms
+- 95% of conflicts auto-resolved
+- Desktop preferred over web for 60% of use cases
+
+### Fase 4
+- Automation rules save devs 5+ min/day
+- System integration used by 40% of power users
+
+---
+
+## 🚀 Próximos pasos
+
+1. **Esta semana**: Confirm Tauri version + dependencies
+2. **Próxima semana**: Migrate React components to shared monorepo
+3. **Semana 3**: Tauri window setup + SQLite schema
+4. **Semana 4**: Sync mechanism implementation
+
+---
+
+## 🔗 Relacionado
+
+- [STRATEGIC_ROADMAP.md](STRATEGIC_ROADMAP.md) — Visión integrada
+- [ROADMAP_WEB.md](ROADMAP_WEB.md) — Roadmap web (companion)
+- [FEATURE_INVENTORY.md](FEATURE_INVENTORY.md) — Catálogo de features
+- [../Architecture/Arquitectura General.md](../Architecture/Arquitectura%20General.md) — Arch general
+- [../TECHNICAL_ROADMAP_AI_OFFLINE.md](../TECHNICAL_ROADMAP_AI_OFFLINE.md) — Original roadmap
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Fase 1 MVP setup en progreso

--- a/docs/ROADMAP_WEB.md
+++ b/docs/ROADMAP_WEB.md
@@ -1,0 +1,214 @@
+---
+tags:
+  - devdeck
+  - roadmap
+  - web
+  - react
+status: active
+date: 2026-04-29
+---
+
+# 🌐 DevDeck — Web Roadmap (React 18)
+
+> Evolución específica del cliente web. Desde MVP de captura rápida → búsqueda inteligente → colaboración → poder offline.
+
+---
+
+## 📍 Estado actual (2026-04)
+
+### Lo que existe ✅
+- Captura básica de items (repos, CLIs)
+- Vista de items con preview rico
+- Búsqueda fuzzy por título/descripción
+- Cheatsheets editables
+- Sistema de decks
+- Dark/light mode
+- Integración con GitHub (metadata automática)
+
+### Lo que falta 🚧
+- Auto-tagging con IA
+- Búsqueda semántica (embeddings)
+- Compartición de items
+- Multi-user support
+- Mobile UI mejorada
+- Funciones offline básicas
+
+---
+
+## 🌊 Fases de desarrollo
+
+### **Fase 1: Captura Pro** (Q2 2026 — 3-4 semanas)
+
+**Objetivo**: Hacer captura ultrarrápida y asignar a decks automáticamente
+
+#### Features
+- [ ] **Quick Capture optimizado** — Modal minimizado, drag-and-drop, paste URL
+- [ ] **Auto-metadata** — Extrae title, description, image automáticamente
+- [ ] **Deck suggestions** — IA sugiere qué deck asignarlo
+- [ ] **Smart tags** — Tags manuales + suggestions básicas
+- [ ] **Keyboard shortcuts** — cmd+K search, cmd+N new item, cmd+L focus search
+
+#### Backend changes
+- [ ] Endpoint `/items/metadata?url=...` (extrae og:title, og:image, etc)
+- [ ] Endpoint `/suggestions/deck` (dado texto, qué deck)
+
+#### UI/UX changes
+- [ ] Refactor capture modal (más compacta, más rápida)
+- [ ] Preview inline (sin hacer click)
+- [ ] Feedback visual mientras se procesa
+
+#### Done when
+- ✅ Captura < 2 segundos
+- ✅ 100% de items tienen metadata automática
+- ✅ Keyboard shortcuts funcionan
+
+---
+
+### **Fase 2: Inteligencia** (Q3 2026 — 4-5 semanas)
+
+**Objetivo**: IA que organiza y ayuda a encontrar
+
+#### Features
+- [ ] **Auto-tagging** — IA asigna 3-5 tags por item automáticamente
+- [ ] **Stack detection** — Detecta tech stack (Go, Node, Python, Docker, etc)
+- [ ] **Semantic search** — Buscar por intención, no por keywords exactos
+- [ ] **Related items** — Sugerir items por semántica
+- [ ] **Auto-summary** — IA genera descripción concisa si no existe
+
+#### Backend changes
+- [ ] Integración con OpenAI API (o Ollama)
+- [ ] Endpoint `/items/{id}/tags/auto` (genera tags)
+- [ ] Endpoint `/search/semantic?q=...` (busca por embeddings)
+- [ ] Vector DB setup (Pinecone, Weaviate o pgvector)
+- [ ] Embedding pipeline (generar embeddings para items)
+
+#### AI prompt strategy
+- Auto-tagging prompt: "Este es un item de desarrollo. Analiza su URL, título y descripción. Asigna 3-5 tags técnicos relevantes (ej: 'cli', 'go', 'performance')"
+- Stack detection prompt: "¿Qué tech stack es relevante? Devuelve lista de: Go, Node, Python, Docker, Kubernetes, etc"
+
+#### UI/UX changes
+- [ ] Search bar mejorada (más grande, con ejemplos de queries)
+- [ ] Search results ranking por relevancia (semantic > fuzzy)
+- [ ] "Related items" section en vista de item
+- [ ] Tags auto-generados con icono ✨ (diferenciados de manuales)
+
+#### Done when
+- ✅ Auto-tagging >= 80% accuracy (manual review de sample)
+- ✅ Semantic search top 3 resultados relevantes en 90% queries
+- ✅ Related items shown on 100% of items
+
+---
+
+### **Fase 3: Compartición** (Q3-Q4 2026 — 3-4 semanas)
+
+**Objetivo**: Compartir lo bueno con otros
+
+#### Features
+- [ ] **Share item link** — Generar URL pública para item individual
+- [ ] **Expiring links** — Link expira en 24h, 7d, 30d
+- [ ] **Share modal** — UI para copiar link, configurar duración
+- [ ] **Public deck preview** — Vista pública de deck (anónimo puede ver items)
+- [ ] **Copy to my deck** — Si veo item compartido, copiarlo a mi deck
+- [ ] **Comment system** — Comentarios lightweight en items públicos
+
+#### Backend changes
+- [ ] Endpoint `/items/{id}/share` (POST → genera share link)
+- [ ] Endpoint `/share/{token}` (GET → devuelve item público)
+- [ ] Endpoint `/items/{id}/comments` (GET/POST)
+- [ ] Database schema: `shares` table (token, item_id, expires_at)
+- [ ] Database schema: `comments` table (item_id, user_id, text, created_at)
+
+#### UI/UX changes
+- [ ] Share button en cada item
+- [ ] Comments section en view item (solo si público)
+- [ ] Activity feed (items que amigos compartieron)
+
+#### Done when
+- ✅ Share links funcionan (público ve item sin login)
+- ✅ Comments permitidos en items compartidos
+- ✅ Copy to deck workflow fluido
+
+---
+
+### **Fase 4: Social (Future)** (Q4 2026 - Q1 2027)
+
+**Objetivo**: DevDeck es red social, no solo app personal
+
+#### Features (planeadas)
+- [ ] **Trending section** — Items más compartidos esta semana
+- [ ] **User profiles** — Ver qué agregan otros devs
+- [ ] **Follow users** — Seguir perfiles interesantes
+- [ ] **Activity feed** — Qué agregaron usuarios que seguís
+- [ ] **Upvotes** — Votar items interesantes
+
+#### This connects to multi-user in backend
+
+---
+
+## 🛠️ Tech decisions
+
+### Frontend
+- **Framework**: React 18 (confirmado)
+- **Build**: Vite (fast refresh, fast build)
+- **Components**: Reutilizables entre web + desktop (monorepo pnpm)
+- **Styling**: Tailwind + custom CSS (neo-brutalist + Snarkel colors)
+- **State**: React Query (server state) + Zustand (local state)
+- **Testing**: Vitest + React Testing Library
+
+### Backend integration
+- **API**: REST v1 (prefijo `/v1/`)
+- **Auth**: JWT (bearer token)
+- **Real-time**: Polling o WebSockets (TBD después de Fase 1)
+
+### AI/Embeddings
+- **OpenAI**: Fallback default, costs money
+- **Ollama**: Alternative local, gratuito
+- **Vector DB**: TBD (Pinecone vs Weaviate vs pgvector)
+
+---
+
+## 📈 Success metrics por fase
+
+### Fase 1
+- Capture time < 2 segundos
+- 100% adoption de capture tool por users activos
+- Keyboard shortcuts used in 70% of captures
+
+### Fase 2
+- Auto-tag accuracy >= 80%
+- 60% of searches are semantic (no fuzzy)
+- Related items click-through rate >= 15%
+
+### Fase 3
+- 50+ share links creados
+- Average 5+ comments per public item
+- Copy to deck conversion 30%
+
+### Fase 4
+- 100+ followers de top users
+- Activity feed generates 2x reengagement
+
+---
+
+## 🚀 Próximos pasos inmediatos
+
+1. **Esta semana**: Diseñar DATA_SCHEMA.md (qué campos nuevo para cada entidad)
+2. **Próxima semana**: Actualizar API.md con endpoints nuevos
+3. **Semana 3**: Feature branch "capture-pro" en repo
+4. **Semana 4**: Auto-metadata en backend + test
+
+---
+
+## 🔗 Relacionado
+
+- [STRATEGIC_ROADMAP.md](STRATEGIC_ROADMAP.md) — Visión integrada
+- [ROADMAP_DESKTOP.md](ROADMAP_DESKTOP.md) — Roadmap desktop (espejo)
+- [FEATURE_INVENTORY.md](FEATURE_INVENTORY.md) — Catálogo de features
+- [../API.md](../API.md) — Especificación API
+- [../TECHNICAL_ROADMAP_AI_OFFLINE.md](../TECHNICAL_ROADMAP_AI_OFFLINE.md) — Original roadmap
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Implementación Fase 1 en progreso

--- a/docs/STRATEGIC_ROADMAP.md
+++ b/docs/STRATEGIC_ROADMAP.md
@@ -1,0 +1,325 @@
+---
+tags:
+  - devdeck
+  - roadmap
+  - strategy
+status: active
+date: 2026-04-29
+---
+
+# 🗺️ DevDeck — Strategic Roadmap (Web + Desktop)
+
+> **Visión**: Transformar DevDeck en el cinturón de utilidades más poderoso para programadores. Tu memoria personal para desarrollo, asistida por IA, en todos tus dispositivos, offline-first.
+
+---
+
+## 🎯 Propósito de este documento
+
+Este roadmap integra la evolución de **web** y **desktop** en una visión cohesiva. No es un cronograma fijo, sino un mapa de valor: qué agregamos, cuándo lo agregamos, y por qué.
+
+El hilo conductor: **captura rápida → organización inteligente → redescubrimiento activo**.
+
+---
+
+## 📊 Landscape actual (2026-04)
+
+### Web (React 18)
+- ✅ Captura básica de items (repos, CLIs)
+- ✅ Búsqueda fuzzy
+- ✅ Preview rico (markdown, GitHub metadata)
+- ✅ Cheatsheets por item
+- ⏳ Auto-tagging (parcial)
+- ❌ Compartición de items
+- ❌ Búsqueda semántica
+- ❌ Multi-user
+
+### Desktop (Tauri)
+- ⏳ MVP en desarrollo
+- ❌ Hotkeys/launcher
+- ❌ Offline-first
+- ❌ Local indexing
+- ❌ Sync con web
+
+### Backend (Go)
+- ✅ REST API base
+- ✅ Auth simple
+- ⏳ Versionado de API
+- ❌ Endpoint de IA (tagging, search)
+- ❌ Endpoint de compartición
+- ❌ Vector DB para embeddings
+
+---
+
+## 🌊 Olas de desarrollo
+
+### **Ola 1: Foundation (Ahora → Q2 2026)**
+
+**Tema**: Claridad estratégica + Esquema robusto
+
+#### Documentación
+- [ ] STRATEGIC_ROADMAP.md (este archivo)
+- [ ] FEATURE_INVENTORY.md (catálogo de features)
+- [ ] ROADMAP_WEB.md (roadmap web específico)
+- [ ] ROADMAP_DESKTOP.md (roadmap desktop específico)
+- [ ] DATA_SCHEMA.md (definición de entidades)
+- [ ] AI_STRATEGY.md (cómo IA agrega valor)
+- [ ] UX_PATTERNS.md (componentes + flujos consistentes)
+
+#### Backend
+- [ ] Versionado de API (`/v1/` prefix)
+- [ ] Schema completo en PostgreSQL (Items, Decks, Tips, Commands)
+- [ ] Endpoint de extracto de metadata (URL → title, description, image)
+- [ ] Endpoint de importación batch (compartición)
+
+#### Web
+- [ ] Mejorar captura (pega URL → auto-extrae metadata)
+- [ ] Asignación de decks optimizada
+- [ ] Tags manuales + auto-suggestions básicas
+
+#### Desktop
+- [ ] MVP base (Tauri)
+- [ ] Sincronización SQLite ↔ Backend
+- [ ] Modo offline básico (lectura)
+
+**Resultado**: Decks organizados, captura rápida, sincronización base.
+
+---
+
+### **Ola 2: Intelligence (Q2-Q3 2026)**
+
+**Tema**: IA que genera valor real (no decorativa)
+
+#### Backend
+- [ ] Integración con OpenAI API o Ollama
+- [ ] Auto-tagging (classify item → tags relevantes)
+- [ ] Auto-summary (generar descripción concisa)
+- [ ] Embedding pipeline (generar embeddings para items)
+- [ ] Vector DB (Pinecone, Weaviate o pgvector)
+
+#### Web
+- [ ] Búsqueda semántica ("dame un CLI para tareas paralelas")
+- [ ] Sugerencias de items relacionados (por semántica)
+- [ ] Preview mejorado con IA (summary destacado)
+- [ ] Share links para items individuales
+
+#### Desktop
+- [ ] Hotkeys (cmd+K captura, cmd+shift+S screenshot)
+- [ ] Launcher mode (search + execute commands)
+- [ ] Desktop search (indexación local completa)
+
+**Resultado**: Búsqueda inteligente, descubrimiento automático, captura ultrarrápida.
+
+---
+
+### **Ola 3: Collaboration (Q3-Q4 2026)**
+
+**Tema**: Compartición + Comunidad
+
+#### Backend
+- [ ] Multi-user base (decks personales pero shareable)
+- [ ] Share links con expiración (opcional)
+- [ ] Comments en items (lightweight)
+- [ ] Activity feed (lo que agregaron amigos)
+
+#### Web
+- [ ] Crear/compartir decks públicos
+- [ ] Sistema de comentarios en items
+- [ ] Trending section (decks populares en tu comunidad)
+- [ ] Recomendaciones de items por comunidad
+
+#### Desktop
+- [ ] Sincronización de cambios en tiempo real
+- [ ] Notificaciones de compartición
+
+**Resultado**: DevDeck es red social, no solo app personal.
+
+---
+
+### **Ola 4: Offline Superpowers (Q4 2026 - Q1 2027)**
+
+**Tema**: Funciona 100% offline, mejor que online
+
+#### Backend
+- [ ] Soporte para modelos de IA locales (Ollama)
+- [ ] Exportación de embeddings para uso local
+
+#### Desktop
+- [ ] Ollama integration (embeddings + small LLMs locales)
+- [ ] Semantic search completamente local
+- [ ] Auto-tagging offline
+- [ ] Sincronización smart (detecta cambios, resuelve conflictos)
+
+#### Web
+- [ ] Service Workers avanzados (offline caching)
+- [ ] Sync de cambios cuando vuelve conexión
+
+**Resultado**: Desktop es la mejor experiencia, web es la web app del desktop.
+
+---
+
+### **Ola 5: AI Assistant (Q1-Q2 2027)**
+
+**Tema**: DevDeck conversa contigo
+
+#### Backend
+- [ ] "Ask DevDeck" endpoint (semantic search + LLM)
+- [ ] Context-aware responses (busca en tu deck personal)
+- [ ] Code generation (genera comandos basado en tu contexto)
+
+#### Web + Desktop
+- [ ] Chat sidebar (Ask DevDeck)
+- [ ] Generate commands (describe → te genera el comando)
+- [ ] Script generation (escribe workflow completo)
+
+**Resultado**: DevDeck entiende tus problemas y sugiere soluciones basadas en tu colección personal.
+
+---
+
+## 🎯 Objetivos clave por plataforma
+
+### 📱 **Web**
+
+| Ola | Objetivo | Entrada del usuario | Salida de DevDeck |
+|-----|----------|----------------------|-------------------|
+| 1 | Captura rápida | Pega URL/descripción | Item en deck |
+| 2 | Búsqueda inteligente | "CLI para tasks paralelas" | Items relevantes ranked por semántica |
+| 3 | Compartición | Click "Share" | Link para compartir |
+| 4 | Sincronización smart | Changes offline | Sync automático |
+| 5 | Asistencia | "Cómo hago X?" | Chat con contexto de tu deck |
+
+### 🖥️ **Desktop**
+
+| Ola | Objetivo | Entrada del usuario | Salida de DevDeck |
+|-----|----------|----------------------|-------------------|
+| 1 | Espejo de web | Abres app | Tu deck sincronizado |
+| 2 | Hotkeys | cmd+K | Captura modal + search |
+| 3 | Sync en tiempo real | Agregás en web | Aparece en desktop |
+| 4 | Offline 100% | Sin internet | Todo funciona igual |
+| 5 | Asistencia local | "Genera comando para X" | Comando sugerido, ready to copy |
+
+---
+
+## 🏗️ Arquitectura conceptual
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     DevDeck Ecosystem                        │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌──────────────┐    ┌─────────────┐    ┌──────────────┐   │
+│  │     Web      │    │   Desktop   │    │     CLI      │   │
+│  │   (React)    │───→│   (Tauri)   │←───│   (Future)   │   │
+│  └──────────────┘    └─────────────┘    └──────────────┘   │
+│         │                   │                     │         │
+│         └───────────────────┼─────────────────────┘         │
+│                             │                               │
+│                    ┌────────▼────────┐                      │
+│                    │   Backend Go    │                      │
+│                    │  (REST API v1)  │                      │
+│                    └────────┬────────┘                      │
+│                             │                               │
+│         ┌───────────────────┼───────────────────┐           │
+│         │                   │                   │           │
+│    ┌────▼────┐         ┌────▼────┐        ┌────▼────┐      │
+│    │Database │         │  Vector │        │  Media  │      │
+│    │ (PG)    │         │   DB    │        │ (S3)    │      │
+│    └─────────┘         └─────────┘        └─────────┘      │
+│         │                                                    │
+│    ┌────▼───────────────────────┐                          │
+│    │  AI Integration            │                          │
+│    │  • OpenAI API              │                          │
+│    │  • Ollama (local)          │                          │
+│    │  • Embeddings              │                          │
+│    └────────────────────────────┘                          │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 📈 Métricas de éxito
+
+### Ola 1
+- ✅ Documentación clara (team entiende la visión)
+- ✅ Schema validado (todos los tipos de items soportados)
+- ✅ Captura rápida < 2 segundos
+- ✅ Desktop MVP sincroniza en < 1 segundo
+
+### Ola 2
+- ✅ Búsqueda semántica funciona (top 3 resultados relevantes en 90% de queries)
+- ✅ Auto-tagging >= 80% accuracy
+- ✅ Desktop con hotkeys disponible
+- ✅ 1000+ items capturados en beta
+
+### Ola 3
+- ✅ 50+ decks compartidos activamente
+- ✅ Comment system usado
+- ✅ Activity feed genera reengagement
+
+### Ola 4
+- ✅ Desktop funciona 100% offline
+- ✅ Ollama integration reduces latency < 200ms
+- ✅ Sync smart resuelve conflictos automáticamente
+
+### Ola 5
+- ✅ Ask DevDeck tiene >= 70% satisfaction
+- ✅ Code generation saves devs 5+ min/día
+
+---
+
+## 🚀 Quick wins (comenzar ya)
+
+1. **Crear FEATURE_INVENTORY.md** (esta semana)
+   - Catálogo de 50+ features planeadas
+   - Agrupar por Ola
+   - Priorizar quick wins
+
+2. **Mejorar docs/README.md** (esta semana)
+   - Hacerlo inspirador
+   - Agregar ejemplos de uso
+   - Apuntar a roadmaps
+
+3. **Actualizar ROADMAP.md (root)** (esta semana)
+   - Conectar con STRATEGIC_ROADMAP
+   - Alineación web + desktop
+
+4. **Empezar DATA_SCHEMA.md** (próxima semana)
+   - Definir Item, Deck, Tip, Command completamente
+   - Incluir ejemplos JSON
+
+---
+
+## 🔄 Cómo mantener este documento
+
+- **Actualizar cada Q** con cambios en prioridades
+- **Mover features entre Olas** si el contexto cambia
+- **Agregar aprendizajes** de implementación (qué fue más fácil/difícil)
+- **Conectar con GitHub issues** (1 issue por feature importante)
+
+---
+
+## 📝 Notas de implementación
+
+### Lenguaje
+- Documentación en **español rioplatense casual** (per convention)
+- Código en **inglés**
+- Commits en **inglés con trailer de Copilot**
+
+### Tech stack confirmado
+- **Web**: React 18 (monorepo pnpm)
+- **Desktop**: Tauri
+- **Backend**: Go 1.23
+- **DB**: PostgreSQL + Vector DB (TBD: Pinecone vs Weaviate vs pgvector)
+- **AI**: OpenAI (+ Ollama local option)
+
+### Decisiones abiertas
+- [ ] Vector DB: Pinecone vs Weaviate vs pgvector?
+- [ ] Multi-user desde Ola 3 o Ola 1?
+- [ ] Monetización: tiering model?
+- [ ] CLI como parte de Ola 4 o Ola 5?
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Implementación en Ola 1

--- a/docs/UX_PATTERNS.md
+++ b/docs/UX_PATTERNS.md
@@ -1,0 +1,531 @@
+---
+tags:
+  - devdeck
+  - design
+  - ux
+  - patterns
+status: active
+date: 2026-04-29
+---
+
+# 🎨 DevDeck — UX Patterns & Design System
+
+> Guía de patrones de UX consistentes entre web y desktop. Componentes, flujos, y decisiones de diseño.
+
+---
+
+## 🌈 Identidad visual
+
+### Paleta de colores
+
+**Basada en neo-brutalism + Snarkel (mascota)**
+
+```css
+/* Primary colors */
+--color-primary:     #FF6B00;     /* Snarkel orange */
+--color-primary-dark: #E55A00;
+--color-secondary:   #0A7DFF;    /* DevDeck blue */
+--color-accent:      #FF00FF;    /* Magenta (secundario) */
+
+/* Neutrals */
+--color-bg-light:    #FFFFFF;
+--color-bg-dark:     #0F0F0F;
+--color-surface:     #F5F5F5;     /* Light mode surface */
+--color-surface-dark: #1A1A1A;    /* Dark mode surface */
+--color-text:        #1A1A1A;
+--color-text-light:  #FFFFFF;
+--color-text-muted:  #666666;
+
+/* Status colors */
+--color-success:     #00CC88;
+--color-warning:     #FFAA00;
+--color-error:       #FF4444;
+--color-info:        #00CCFF;
+```
+
+### Typography
+
+```
+Font stack: Inter (sans-serif) + MonoSpace (code)
+
+Sizes:
+- H1: 2.5rem (40px) — Page titles
+- H2: 2rem (32px) — Section headers
+- H3: 1.5rem (24px) — Subsection headers
+- H4: 1.25rem (20px) — Card titles
+- Body: 1rem (16px) — Main text
+- Small: 0.875rem (14px) — Secondary text
+- Tiny: 0.75rem (12px) — Metadata/hints
+
+Weight: 400 (regular), 600 (semi-bold), 700 (bold)
+```
+
+---
+
+## 🧩 Core components
+
+### Modal (Capture + Dialogs)
+
+**Usage**: Quick capture, confirmations, settings
+
+```
+Modal
+├── Header (optional title + close button)
+├── Body (content area)
+├── Footer (CTA buttons)
+└── Keyboard shortcuts
+    ├── Escape = close
+    ├── Enter = confirm (default action)
+    └── Shift+Enter = alternate action
+```
+
+**Example: Capture modal**
+```
+┌────────────────────────────────────┐
+│ Capture item          [x close]    │
+├────────────────────────────────────┤
+│ URL/Text (input)                   │
+│ [Paste your link]                  │
+│                                    │
+│ Deck assignment (dropdown)         │
+│ [Select Deck ▼]                    │
+│                                    │
+│ Tags (searchable input)            │
+│ [cli] [go] [tools] [+Add]          │
+│                                    │
+│ Notes (optional textarea)          │
+│ [Your personal notes...]           │
+├────────────────────────────────────┤
+│             [Cancel] [Add item]    │
+└────────────────────────────────────┘
+
+Keyboard: cmd+K to show, esc to close, enter to add
+```
+
+### Card (Item preview)
+
+**Usage**: Item list, search results, related items
+
+```
+Card
+├── Icon/Badge (type: repo, CLI, tip, etc)
+├── Title (clickable)
+├── Description (1-2 lines)
+├── Metadata (stack, tags, date)
+├── Actions (hover-reveal: favorite, share, delete)
+└── Click → expand detail view
+```
+
+**Example: Card**
+```
+┌─────────────────────────────────────┐
+│ [📦] cobra — CLI framework for Go   │
+│                                     │
+│ Go's best CLI toolkit with commands │
+│ and subcommands. Perfect for...     │
+│                                     │
+│ Go | CLI | Recommended             │
+│ ⭐ · 📤 · ⋮                          │
+└─────────────────────────────────────┘
+Hover → Actions appear on right (favorite, share, menu)
+Click → Detail view full item
+```
+
+### List item (Compact)
+
+**Usage**: Search results, recent items, commands
+
+```
+List Item
+├── Icon (type)
+├── Title + metadata (one line)
+├── Quick action (right-aligned)
+└── Keyboard navigation: ↑↓ arrow keys
+```
+
+**Example: Search result**
+```
+📦 cobra — Go CLI framework        ⭐ · 📤
+🔍 goreleaser — Release automation  ⭐ · 📤
+💾 viper — Config manager          ⭐ · 📤
+```
+
+### Tag component
+
+**Style 1: Filled (auto-generated)**
+```
+[✨ cli] [✨ go] [✨ recommended]
+```
+
+**Style 2: Outline (manual)**
+```
+[personal] [favorite] [quick-ref]
+```
+
+**Interactive**:
+- Hover → show description/category
+- Click → filter by tag
+- X on tag → remove (if editable)
+
+### Search bar
+
+```
+┌──────────────────────────────────┐
+│ 🔍 Search items...   [?] [+]     │
+├──────────────────────────────────┤
+│ Recent:                           │
+│ • CLI tools                       │
+│ • Go packages                     │
+│ • Docker tips                     │
+├──────────────────────────────────┤
+│ Try:                              │
+│ • "CLI for async tasks"           │
+│ • "Docker performance"            │
+│ • "Node best practices"           │
+└──────────────────────────────────┘
+
+Keyboard:
+- cmd+K = focus search
+- ↓ = next result
+- ↑ = prev result
+- Enter = select
+- ? = help
+```
+
+### Sidebar (Navigation)
+
+```
+┌─────────────────────┐
+│ DevDeck      [≡]    │ ← Header (logo + menu)
+├─────────────────────┤
+│ 📍 Your Decks       │
+│ ▼ Go tools    (12)  │
+│   ▼ CLI       (8)   │
+│   ▼ Libs      (4)   │
+│ ▼ DevOps      (25)  │
+│ ▼ Frontend    (18)  │
+│ ▼ AI/LLM      (30)  │
+├─────────────────────┤
+│ 🔖 All tags         │
+│ 📌 Favorites (6)    │
+│ 📤 Shared with me   │
+│ 💬 Comments         │
+├─────────────────────┤
+│ ⚙️ Settings         │
+│ 📚 Help             │
+└─────────────────────┘
+
+Click deck → shows items in main area
+Right-click → context menu (rename, delete, duplicate, share)
+```
+
+### Detail view (Item full view)
+
+```
+┌────────────────────────────────────────────┐
+│ ← Back | cobra — CLI framework | ⭐ · 📤    │
+├────────────────────────────────────────────┤
+│                                            │
+│ [Repository image/preview]                │
+│                                            │
+│ Description (full markdown)                │
+│ Cobra makes it easy to create...           │
+│                                            │
+│ Tags: [cli] [go] [recommended]             │
+│ Type: Repository                           │
+│ URL: https://github.com/spf13/cobra       │
+│ Added: 2 weeks ago                         │
+│                                            │
+│ ┌──────────────────────────────────────┐  │
+│ │ Commands & Tips (Cheatsheet)         │  │
+│ ├──────────────────────────────────────┤  │
+│ │ cobra init <app>        Create app   │  │
+│ │ cobra add <cmd>         Add command  │  │
+│ │ cobra --version         Check ver    │  │
+│ └──────────────────────────────────────┘  │
+│                                            │
+│ Related items:                             │
+│ • urfave/cli (Similar CLI framework)      │
+│ • spf13/viper (Config by same author)     │
+│                                            │
+│ Comments (2):                              │
+│ User1: "Great for Go CLIs!"                │
+│ User2: "Use with viper for configs"        │
+│                                            │
+├────────────────────────────────────────────┤
+│ [Edit] [Share] [Favorite] [Copy to deck]  │
+└────────────────────────────────────────────┘
+```
+
+---
+
+## 🔄 Common UX flows
+
+### Capture flow
+
+```
+User: cmd+K (global hotkey or web)
+  ↓
+Modal: "Capture item"
+  ↓
+Paste URL/text
+  ↓
+DevDeck: Auto-extract metadata
+  ↓
+User: Select deck (or auto-suggest)
+  ↓
+User: Review tags (auto-generated + manual)
+  ↓
+User: Add notes (optional)
+  ↓
+Click "Add item"
+  ↓
+Notification: "✅ Added to [Deck]"
+```
+
+### Search flow
+
+```
+User: cmd+K (or click search bar)
+  ↓
+Type query: "CLI for parallel tasks"
+  ↓
+Results display (sorted by relevance)
+  ↓
+User: Select result (↑↓ arrows + enter)
+  ↓
+Detail view opens
+  ↓
+User: Copy command / favorite / share
+```
+
+### Share flow
+
+```
+User: On item detail view, click "Share"
+  ↓
+Share modal opens:
+  ├─ Link (copy to clipboard)
+  ├─ Expiration: 24h / 7d / 30d / never
+  └─ Options: Comments allowed? Yes/No
+  ↓
+User: Send link to colleague
+  ↓
+Colleague: Opens link (no login needed)
+  ↓
+Colleague: Sees item + comments
+  ↓
+Colleague: "Copy to my deck" (optional)
+```
+
+---
+
+## 🚀 Interaction patterns
+
+### Keyboard-first design
+
+```
+Global shortcuts:
+cmd+K       Search / Capture
+cmd+N       New item
+cmd+L       Focus search
+cmd+P       Command palette (future)
+cmd+,       Settings
+cmd+H       Help/Shortcuts
+cmd+Shift+S Screenshot capture (desktop)
+
+In modals:
+Escape      Close
+Enter       Confirm default action
+Shift+Enter Alternate action
+Tab         Next field
+Shift+Tab   Prev field
+
+In lists:
+↑↓          Navigate
+Enter       Select
+Delete      Remove item
+D           Toggle favorite
+C           Copy to deck
+```
+
+### Hover states
+
+All interactive elements have clear hover state:
+```
+Button: background color changes
+Link: underline appears
+Card: slight shadow/elevation
+Tag: opacity change or background
+```
+
+### Loading states
+
+```
+Button: Show spinner
+"Loading..."
+
+Search results: Skeleton loading (placeholder cards)
+
+Sync indicator: Spinning icon in corner
+"Syncing..." (temporary)
+```
+
+### Empty states
+
+```
+When no items in deck:
+┌────────────────────────────┐
+│   📦 Empty deck            │
+│                            │
+│  No items yet. Start by:   │
+│  1. cmd+K to capture      │
+│  2. Paste a URL            │
+│  3. Select this deck      │
+│                            │
+│  [Go to featured items →] │
+└────────────────────────────┘
+```
+
+---
+
+## 📱 Responsive design
+
+### Breakpoints
+
+```
+Mobile:      < 640px
+Tablet:      640px - 1024px
+Desktop:     > 1024px
+
+Layout strategy: Sidebar collapses on mobile
+Mobile sidebar: Bottom tab bar or hamburger menu
+```
+
+### Mobile optimizations
+
+```
+Search bar: Full width, easy to tap
+Cards: Taller (more tap area)
+Modal: Full screen (easier on small screen)
+Detail view: Stacked layout (no columns)
+Commands: Larger font + more padding
+```
+
+---
+
+## 🎯 Accessibility
+
+### Color contrast
+- Text: >= 4.5:1 ratio (WCAG AA)
+- Interactive elements: >= 3:1 ratio
+
+### Focus indicators
+- Clear focus ring (2px outline)
+- Not removed for keyboard users
+- Visible on dark and light themes
+
+### Alternative text
+- Images: Descriptive alt text
+- Icons: aria-label or title
+- Buttons: Clear, descriptive text
+
+### Keyboard navigation
+- All interactive elements: Keyboard accessible
+- Tab order: Logical and predictable
+- Focus trap: Modals trap focus
+
+---
+
+## 🎬 Animations
+
+**Philosophy**: Fast, subtle, purposeful. No gratuitous animations.
+
+### Transitions
+```
+Hover effects:         150ms ease-out
+Modal open/close:      200ms ease-out
+Page transitions:      300ms ease-out
+Loading spinner:       Infinite 1s rotation
+```
+
+### Example
+```
+Button hover:
+  - Background: #FF6B00 → #E55A00 (150ms)
+  - Scale: 1 → 1.02 (optional, subtle)
+
+Card on hover:
+  - Shadow: light → medium (150ms)
+  - Y position: 0 → -2px (optional)
+```
+
+---
+
+## 🌙 Dark mode
+
+**Strategy**: System preference + manual toggle
+
+```
+Default: System preference (prefers-color-scheme)
+Override: Settings → Theme → Auto / Light / Dark
+
+In dark mode:
+- Background: #0F0F0F
+- Surface: #1A1A1A
+- Text: #FFFFFF
+- Accent: Slightly lighter (maintain contrast)
+```
+
+---
+
+## 🔗 Shared components (Web + Desktop)
+
+These React components are shared between web and desktop:
+```
+components/
+├── Card.tsx
+├── Modal.tsx
+├── SearchBar.tsx
+├── TagInput.tsx
+├── ItemDetail.tsx
+├── Sidebar.tsx
+├── Button.tsx
+├── Input.tsx
+└── ...
+```
+
+**Principle**: Single source of truth for UI.
+
+Desktop Tauri app imports React components directly from web app.
+
+---
+
+## 📐 Design guidelines for new features
+
+When adding new features:
+
+1. **Use existing components** (Card, Modal, Button)
+2. **Maintain keyboard-first** — Every interaction should work with keyboard
+3. **Test accessibility** — Screen reader, keyboard nav, color contrast
+4. **Mobile first** — Design mobile, then add desktop enhancements
+5. **Performance** — Animations < 300ms, no jank
+6. **Dark mode** — Test both themes
+
+---
+
+## 🚀 Component storybook (future)
+
+Goal: Build Storybook to showcase all components and patterns.
+
+```bash
+npm run storybook
+# Opens http://localhost:6006
+# Shows Card, Modal, Button, etc. in all states
+```
+
+---
+
+**Owner**: tfurt  
+**Última actualización**: 2026-04-29  
+**Estado**: 🟢 Activo — Referencia para implementación


### PR DESCRIPTION
## 🎯 Ola 1.2: Backend metadata extraction

Implements the backend endpoint needed for quick capture flow.

### Changes
- Add `MetadataHandler` to extract metadata from URLs
- Endpoint: `POST /api/v1/metadata` accepts `{url}`
- Returns: `{description, image_url, topics}`
- Uses existing `enricher.Service.Enrich()` for og:tag parsing
- Add Prometheus metric: `devdeck_metadata_extractions_total`

### Testing
- Build passes: `go build ./...`
- Handler uses existing enricher (already tested)

### Next
- Resolves #14
- Enables #13 (Quick Capture) to show preview without creating item

Related: #13 #15 #16