### PR TITLE
fix: align production readiness with origin main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,33 +88,38 @@ jobs:
       - name: Smoke test (--help)
         run: /tmp/devdeck --help
 
-  desktop:
-    name: Desktop (Vitest + typecheck + build)
+  monorepo:
+    name: Monorepo (pnpm typecheck + tests)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: desktop
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        run: npm run typecheck
+        run: pnpm typecheck
 
-      - name: Vitest unit tests
-        run: npm test
+      - name: Unit tests
+        run: pnpm test
 
-      - name: Build (electron-vite)
-        run: npm run build
+      - name: Verify web build
+        run: pnpm build:web
+
+      - name: Verify desktop build
+        run: pnpm build:desktop
 
   extension:
     name: Extension (Manifest v3 + node:test)
@@ -147,7 +152,7 @@ jobs:
   e2e:
     name: E2E (Playwright + live backend)
     runs-on: ubuntu-latest
-    needs: [backend, desktop]
+    needs: [backend, monorepo]
     services:
       postgres:
         image: postgres:16-alpine
@@ -182,8 +187,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
 
       - name: Apply DB migrations
         working-directory: backend
@@ -210,24 +220,23 @@ jobs:
           echo "API never became healthy" >&2
           exit 1
 
-      - name: Install desktop deps
-        working-directory: desktop
-        run: npm ci
+      - name: Install monorepo deps
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        working-directory: desktop
-        run: npx playwright install --with-deps chromium
+        working-directory: apps/desktop
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        working-directory: desktop
-        run: npm run test:e2e
+        working-directory: apps/desktop
+        run: pnpm test:e2e
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: desktop/playwright-report
+          path: apps/desktop/playwright-report
           retention-days: 7
 
       - name: Stop backend

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,10 @@ pnpm-debug.log*
 
 # Root/node workspaces
 node_modules/
+bin/
 
 # Go backend
+backend/devdeck
 backend/bin/
 backend/tmp/
 backend/*.exe
@@ -31,6 +33,8 @@ apps/*/dist/
 apps/*/out/
 apps/*/.vite/
 apps/*/coverage/
+apps/*/package-lock.json
+apps/*/pnpm-lock.yaml
 apps/desktop/build/icon.*
 packages/*/node_modules/
 packages/*/dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,7 @@ pnpm install
 
 ### Backend
 ```bash
-cd backend
-cp .env.example .env
-# editar DATABASE_URL, GITHUB_* si vas a testear auth
-docker compose -f ../deploy/docker-compose.dev.yml up -d db
-go run ./cmd/api
+docker compose -f deploy/docker-compose.local.yml up -d db migrate api
 ```
 
 ### Desktop (Electron + React)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -263,7 +263,7 @@
 - `internal/store/auth.go`: UpsertUser, GetUserByGitHubID, CreateRefreshSession, GetRefreshSession, DeleteAllRefreshSessions
 - `internal/http/handlers/auth.go`: GitHub OAuth login/callback/refresh/logout/me endpoints
 - `internal/http/middleware/auth.go`: Dual mode — static token (Wave 1) + JWT with context injection
-- `internal/config/config.go`: JWT_SECRET, GITHUB_CLIENT_ID/SECRET, OAUTH_REDIRECT_URL, ALLOWED_GITHUB_LOGINS
+- `internal/config/config.go`: JWT_SECRET, GITHUB_CLIENT_ID/SECRET, GITHUB_OAUTH_CALLBACK_URL, APP_OAUTH_REDIRECT_URL, ALLOWED_GITHUB_LOGINS
 - `internal/http/router.go`: Auth routes under /api/auth/*, public OAuth endpoints, JWT-protected /me
 - `cmd/api/main.go`: AuthService wiring, JWT mode initialization
 
@@ -292,7 +292,7 @@
 - Cheatsheet detail: entries con copy button + filtro por tag/search
 - Discovery mode: skip/keep flow
 - Mascota Snarkel — componente Vue con 5 moods, bubble con transición, click-to-interact
-- Deploy a `app.devdeck.tu-dominio.com` via Caddy (pendiente config)
+- Deploy web + api vía Caddy y Docker Compose (ver `deploy/README.md` y `docs/SELF_HOSTING.md`)
 
 ### Fase 16 — Pulido cross-platform ⏳
 - Verificación paridad Electron ↔ Web
@@ -306,7 +306,7 @@
 - OS-level global shortcuts: `Ctrl/Cmd+K` → search, `Ctrl/Cmd+N` → add (fire en background)
 - `auth.ts` detecta Electron y delega a `window.electronAPI`, fallback a localStorage
 - `electron.d.ts` con tipos para `window.electronAPI`
-- JWT mode no activado por defecto (`VITE_AUTH_MODE=token` → static)
+- Desktop mantiene fallback `VITE_AUTH_MODE=token` para dev/E2E; web usa `jwt` como modo productivo
 
 **Web Vue P1 — COMPLETADO:**
 - `GlobalSearchModal.vue` — Ctrl+K, búsqueda cross-entity, resultados agrupados

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps/web/package.json ./apps/web/package.json
+COPY packages/api-client/package.json ./packages/api-client/package.json
+COPY packages/features/package.json ./packages/features/package.json
+COPY packages/ui/package.json ./packages/ui/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY apps/web ./apps/web
+COPY packages/api-client ./packages/api-client
+COPY packages/features ./packages/features
+COPY packages/ui ./packages/ui
+
+ARG VITE_API_URL=https://api.devdeck.ai
+ARG VITE_AUTH_MODE=jwt
+
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_AUTH_MODE=$VITE_AUTH_MODE
+
+RUN pnpm -F @devdeck/web build
+
+FROM nginx:1.27-alpine
+
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -34,11 +34,12 @@ type Config struct {
 	RateLimitDisabled  bool `env:"RATE_LIMIT_DISABLED" envDefault:"false"`
 
 	// ─── Wave 4: Auth ───
-	JWTSecret           string `env:"JWT_SECRET"`
-	GitHubClientID      string `env:"GITHUB_CLIENT_ID"`
-	GitHubClientSecret  string `env:"GITHUB_CLIENT_SECRET"`
-	OAuthRedirectURL    string `env:"OAUTH_REDIRECT_URL" envDefault:"http://localhost:5173/auth/callback"`
-	AllowedGitHubLogins string `env:"ALLOWED_GITHUB_LOGINS"` // comma-separated, empty = allow all
+	JWTSecret              string `env:"JWT_SECRET"`
+	GitHubClientID         string `env:"GITHUB_CLIENT_ID"`
+	GitHubClientSecret     string `env:"GITHUB_CLIENT_SECRET"`
+	GitHubOAuthCallbackURL string `env:"GITHUB_OAUTH_CALLBACK_URL" envDefault:"http://localhost:8080/api/auth/github/callback"`
+	AppOAuthRedirectURL    string `env:"APP_OAUTH_REDIRECT_URL" envDefault:"http://localhost:5173/auth/callback"`
+	AllowedGitHubLogins    string `env:"ALLOWED_GITHUB_LOGINS"` // comma-separated, empty = allow all
 }
 
 func (c Config) CORSOriginList() []string {

--- a/backend/internal/http/handlers/auth.go
+++ b/backend/internal/http/handlers/auth.go
@@ -23,7 +23,8 @@ type AuthHandler struct {
 type AuthConfig struct {
 	GitHubClientID     string
 	GitHubClientSecret string
-	RedirectURL        string
+	GitHubCallbackURL  string
+	AppRedirectURL     string
 	AllowedLogins      map[string]bool // empty = allow all
 }
 
@@ -48,7 +49,7 @@ func (h *AuthHandler) GitHubLogin(w http.ResponseWriter, r *http.Request) {
 
 	url := fmt.Sprintf(
 		"https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&state=%s&scope=read:user",
-		h.config.GitHubClientID, h.config.RedirectURL, state,
+		h.config.GitHubClientID, h.config.GitHubCallbackURL, state,
 	)
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
@@ -109,7 +110,7 @@ func (h *AuthHandler) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 	// Redirect to the frontend with tokens in URL fragment.
 	// The frontend reads the fragment and stores the tokens.
 	redirectTo := fmt.Sprintf("%s#access_token=%s&refresh_token=%s&expires_in=%d",
-		h.config.RedirectURL, pair.AccessToken, pair.RefreshToken, pair.ExpiresIn)
+		h.config.AppRedirectURL, pair.AccessToken, pair.RefreshToken, pair.ExpiresIn)
 	http.Redirect(w, r, redirectTo, http.StatusTemporaryRedirect)
 }
 

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -71,7 +71,8 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 		authH = handlers.NewAuthHandler(st, as, handlers.AuthConfig{
 			GitHubClientID:     cfg.GitHubClientID,
 			GitHubClientSecret: cfg.GitHubClientSecret,
-			RedirectURL:        cfg.OAuthRedirectURL,
+			GitHubCallbackURL:  cfg.GitHubOAuthCallbackURL,
+			AppRedirectURL:     cfg.AppOAuthRedirectURL,
 			AllowedLogins:      cfg.AllowedLoginsMap(),
 		})
 		r.Route("/api/auth", func(ar chi.Router) {

--- a/backend/internal/testutil/postgres.go
+++ b/backend/internal/testutil/postgres.go
@@ -1,3 +1,5 @@
+//go:build !(darwin && arm64)
+
 // Package testutil provides shared test infrastructure.
 //
 // The Postgres helper boots a real Postgres container via testcontainers-go,

--- a/backend/internal/testutil/postgres_darwin_arm64.go
+++ b/backend/internal/testutil/postgres_darwin_arm64.go
@@ -1,0 +1,30 @@
+//go:build darwin && arm64
+
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SetupPostgres is a darwin/arm64-specific stub.
+//
+// testcontainers-go currently pulls a native dependency chain that crashes
+// during package initialization on some macOS Apple Silicon environments
+// (`github.com/shoenig/go-m1cpu` via gopsutil). We avoid importing that stack
+// entirely on this platform so local `go test` stays usable.
+//
+// CI runs on Linux and still exercises the real testcontainers-backed helper
+// from postgres.go.
+func SetupPostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	msg := "DB-backed tests disabled on darwin/arm64: testcontainers-go pulls a native dependency that crashes during init (go-m1cpu via gopsutil). Run these tests in Linux CI or another non-Apple-Silicon environment."
+	if os.Getenv("DEVDECK_REQUIRE_DB") == "1" {
+		t.Fatalf(msg)
+	}
+	t.Skip(msg)
+	return nil
+}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,16 +1,22 @@
 # DevDeck local dev environment
 # Copy to deploy/.env and adjust as needed
 
-PG_PASS=devdeck_local_pass
-AUTH_MODE=token
-API_TOKEN=change_me_use_openssl_rand_hex_32
+DOMAIN=devdeck.local
+APP_DOMAIN=app.devdeck.local
+API_DOMAIN=api.devdeck.local
+POSTGRES_USER=devdeck
+POSTGRES_PASSWORD=devdeck_local_pass
+POSTGRES_DB=devdeck
+AUTH_MODE=jwt
+API_TOKEN=
 JWT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback
+GITHUB_OAUTH_CALLBACK_URL=http://localhost:8080/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback
 ALLOWED_GITHUB_LOGINS=
 GITHUB_TOKEN=
 LOG_LEVEL=info
 REFRESH_INTERVAL_HOURS=168
 SEED_CHEATSHEETS=true
-CORS_ORIGINS=app://.,http://localhost:5173,http://localhost:4173
+CORS_ORIGINS=http://localhost:5173,http://localhost:4173,app://.

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -4,10 +4,9 @@
 # Caddy provisions a Let's Encrypt cert automatically the first time
 # the domain resolves to this server.
 
-{$DOMAIN} {
+{$API_DOMAIN} {
     encode gzip zstd
 
-    # Health check is public; everything else hits the API which enforces auth.
     handle /healthz {
         reverse_proxy api:8080
     }
@@ -16,7 +15,6 @@
         reverse_proxy api:8080
     }
 
-    # Anything else gets a 404 from Caddy (we don't serve a web client yet).
     handle {
         respond "DevDeck API" 200
     }
@@ -26,4 +24,19 @@
         format console
         level INFO
     }
+}
+
+{$APP_DOMAIN} {
+    encode gzip zstd
+    reverse_proxy web:80
+
+    log {
+        output stdout
+        format console
+        level INFO
+    }
+}
+
+{$DOMAIN} {
+    redir https://{$APP_DOMAIN}{uri} permanent
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,13 +1,14 @@
 # DevDeck — Deploy
 
-Deploy del backend Go + Postgres + Caddy a un VPS Linux.
+Deploy de DevDeck web + API + Postgres + Caddy a un VPS Linux.
 
 ## 0. Requisitos en el VPS
 
 - Ubuntu 22.04+ / Debian 12+ (cualquier distro con Docker funciona)
 - Docker + Docker Compose plugin instalados
 - Puertos `80` y `443` abiertos
-- Un dominio (o subdominio) apuntando al IP del VPS via registro `A`
+- Dominios apuntando al IP del VPS via registro `A`
+  - Ejemplo: `app.devdeck.tudominio.com  →  1.2.3.4`
   - Ejemplo: `api.devdeck.tudominio.com  →  1.2.3.4`
 
 ### Instalar Docker (si no lo tenés)
@@ -28,7 +29,7 @@ cd devdeck/deploy
 ## 2. Generar secretos
 
 ```bash
-# API token (largo, random)
+# JWT secret
 openssl rand -hex 32
 
 # Postgres password
@@ -42,20 +43,31 @@ Guardalos a mano — los vas a necesitar en el siguiente paso.
 Creá `deploy/.env` con este contenido:
 
 ```env
-# Dominio que apunta al VPS
-DOMAIN=api.devdeck.tudominio.com
+# Dominios que apuntan al VPS
+DOMAIN=devdeck.tudominio.com
+APP_DOMAIN=app.devdeck.tudominio.com
+API_DOMAIN=api.devdeck.tudominio.com
 
 # Postgres
-PG_PASS=<el-base64-de-arriba>
+POSTGRES_USER=devdeck
+POSTGRES_PASSWORD=<el-base64-de-arriba>
+POSTGRES_DB=devdeck
 
 # Backend
-API_TOKEN=<el-hex-de-arriba>
+AUTH_MODE=jwt
+JWT_SECRET=<el-hex-de-arriba>
+GITHUB_CLIENT_ID=<oauth-app-client-id>
+GITHUB_CLIENT_SECRET=<oauth-app-client-secret>
+GITHUB_OAUTH_CALLBACK_URL=https://api.devdeck.tudominio.com/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=https://app.devdeck.tudominio.com/auth/callback
+ALLOWED_GITHUB_LOGINS=tu-login
 GITHUB_TOKEN=                # opcional, ghp_... para 5000 req/h en lugar de 60
 
 # Optional tuning
 LOG_LEVEL=info
-CORS_ORIGINS=app://.,http://localhost:5173
+CORS_ORIGINS=https://app.devdeck.tudominio.com,app://.
 REFRESH_INTERVAL_HOURS=168
+SEED_CHEATSHEETS=true
 ```
 
 > ⚠️ **Nunca** commitees `.env`. Está en `.gitignore`.
@@ -68,9 +80,9 @@ docker compose up -d --build
 
 Esto va a:
 1. Buildear `devdeck-api:latest` desde `../backend/Dockerfile`
-2. Bajar `postgres:16-alpine` y `caddy:2-alpine`
-3. Levantar los 3 servicios
-4. **Caddy provisiona el certificado TLS automáticamente** la primera vez que tu dominio resuelva al VPS (Let's Encrypt)
+2. Buildear `devdeck-web:latest` desde `../apps/web/Dockerfile`
+3. Levantar `db`, `migrate`, `api`, `web`, `caddy`
+4. **Caddy provisiona los certificados TLS automáticamente** la primera vez que los dominios resuelvan al VPS (Let's Encrypt)
 
 Verificá que arrancaron:
 
@@ -79,33 +91,25 @@ docker compose ps
 docker compose logs -f api
 ```
 
-## 5. Aplicar la migración inicial (solo la primera vez)
-
-```bash
-docker compose exec -T db psql -U devdeck devdeck \
-  < ../backend/migrations/0001_init.sql
-```
-
-## 6. Probar que está vivo
+## 5. Probar que está vivo
 
 ```bash
 # Health (público)
 curl https://api.devdeck.tudominio.com/healthz
 
-# Auth check
-curl -H "Authorization: Bearer $API_TOKEN" \
-  https://api.devdeck.tudominio.com/api/repos
+# Frontend
+curl -I https://app.devdeck.tudominio.com
 ```
 
-Si todo está bien, vas a ver `{"status":"ok"}` y `{"total":0,"items":[]}`.
+Si todo está bien, vas a ver `{"status":"ok"}` y un `200 OK` del frontend.
 
-## 7. Apuntar el cliente Electron al VPS
+## 6. Apuntar el cliente Electron al VPS
 
 En tu máquina local, en `desktop/.env`:
 
 ```env
 VITE_API_URL=https://api.devdeck.tudominio.com
-VITE_API_TOKEN=<el-mismo-API_TOKEN-del-VPS>
+VITE_AUTH_MODE=jwt
 ```
 
 Después rebuildeás el desktop con `npm run build:win` (Fase 6) y listo: tu DevDeck instalado en Windows habla con tu VPS.
@@ -143,11 +147,11 @@ gunzip -c backups/devdeck-2026-04-07.sql.gz \
 docker compose exec db psql -U devdeck devdeck
 ```
 
-### Rotar el API token
+### Rotar el JWT secret
 1. Generá uno nuevo con `openssl rand -hex 32`
 2. Editá `.env`
 3. `docker compose up -d api` (recrea solo el container del api)
-4. Actualizá también `desktop/.env` y rebuildeá el cliente
+4. Todos los tokens existentes quedan inválidos; los users deben reloguearse
 
 ---
 
@@ -162,8 +166,10 @@ docker compose exec db psql -U devdeck devdeck
 - Casi siempre es `DB_URL` mal escrito o el container `db` todavía no terminó de inicializar (la primera vez puede tardar 10-20s)
 - `docker compose logs db` y `docker compose logs api` te dicen qué pasa
 
-### "API_TOKEN is required when AUTH_MODE=token"
-- Olvidaste setear `API_TOKEN` en `.env`. Editá y `docker compose up -d api`.
+### Login OAuth falla o vuelve mal al frontend
+- Verificá que `GITHUB_OAUTH_CALLBACK_URL` sea `https://api.../api/auth/github/callback`.
+- Verificá que `APP_OAUTH_REDIRECT_URL` sea `https://app.../auth/callback`.
+- Si usás un dominio raíz, `DOMAIN` redirige al `APP_DOMAIN`.
 
 ### Quedé fuera por rate limit de GitHub
 - Conseguite un PAT (Settings → Developer settings → Personal access tokens → Generate new) con scope `public_repo`

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: devdeck
-      POSTGRES_PASSWORD: ${PG_PASS}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devdeck}
       POSTGRES_DB: devdeck
     ports:
       - "5432:5432"
@@ -24,7 +24,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      PGPASSWORD: ${PG_PASS}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-devdeck}
     volumes:
       - ../backend/migrations:/migrations:ro
     # Extract only the +goose Up section (stop at +goose Down) before running.
@@ -52,13 +52,14 @@ services:
         condition: service_completed_successfully
     environment:
       PORT: "8080"
-      DB_URL: postgres://devdeck:${PG_PASS}@db:5432/devdeck?sslmode=disable
+      DB_URL: postgres://devdeck:${POSTGRES_PASSWORD:-devdeck}@db:5432/devdeck?sslmode=disable
       AUTH_MODE: ${AUTH_MODE:-token}
       API_TOKEN: ${API_TOKEN}
       JWT_SECRET: ${JWT_SECRET:-}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
-      OAUTH_REDIRECT_URL: ${OAUTH_REDIRECT_URL:-http://localhost:5173/auth/callback}
+      GITHUB_OAUTH_CALLBACK_URL: ${GITHUB_OAUTH_CALLBACK_URL:-http://localhost:8080/api/auth/github/callback}
+      APP_OAUTH_REDIRECT_URL: ${APP_OAUTH_REDIRECT_URL:-http://localhost:5173/auth/callback}
       ALLOWED_GITHUB_LOGINS: ${ALLOWED_GITHUB_LOGINS:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       LOG_LEVEL: ${LOG_LEVEL:-debug}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,15 +1,15 @@
 # DevDeck production stack — runs on the VPS.
 #
-# Three services:
-#   db     — Postgres 16, persistent volume
-#   api    — Go API, built from ../backend/Dockerfile
-#   caddy  — Reverse proxy with automatic Let's Encrypt TLS
+# Five services:
+#   db       — Postgres 16, persistent volume
+#   migrate  — one-shot SQL migrations runner
+#   api      — Go API, built from ../backend/Dockerfile
+#   web      — React SPA, built from ../apps/web/Dockerfile
+#   caddy    — Reverse proxy with automatic Let's Encrypt TLS
 #
 # Setup:
 #   1. cp .env.example .env  &&  edit values
 #   2. docker compose up -d
-#   3. (first time only) apply migration:
-#      docker compose exec -T db psql -U devdeck devdeck < ../backend/migrations/0001_init.sql
 
 services:
   db:
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: devdeck
-      POSTGRES_PASSWORD: ${PG_PASS}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: devdeck
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -31,6 +31,30 @@ services:
     networks:
       - internal
 
+  migrate:
+    image: postgres:16-alpine
+    container_name: devdeck-migrate
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ../backend/migrations:/migrations:ro
+    command: >-
+      sh -c '
+        set -e
+        run() { awk "/-- [+]goose Down/{exit} {print}" "/migrations/$1" | psql -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB"; }
+        for f in $(ls /migrations/*.sql | xargs -n1 basename | sort); do
+          echo "Applying $$f"
+          run "$$f"
+        done
+        echo "All migrations applied."
+      '
+    restart: "no"
+    networks:
+      - internal
+
   api:
     build:
       context: ../backend
@@ -39,21 +63,46 @@ services:
     container_name: devdeck-api
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     environment:
       PORT: "8080"
-      DB_URL: postgres://devdeck:${PG_PASS}@db:5432/devdeck?sslmode=disable
-      AUTH_MODE: token
-      API_TOKEN: ${API_TOKEN}
+      DB_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable
+      AUTH_MODE: ${AUTH_MODE:-jwt}
+      API_TOKEN: ${API_TOKEN:-}
+      JWT_SECRET: ${JWT_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      GITHUB_OAUTH_CALLBACK_URL: https://${API_DOMAIN}/api/auth/github/callback
+      APP_OAUTH_REDIRECT_URL: https://${APP_DOMAIN}/auth/callback
+      ALLOWED_GITHUB_LOGINS: ${ALLOWED_GITHUB_LOGINS:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      CORS_ORIGINS: ${CORS_ORIGINS:-app://.}
+      CORS_ORIGINS: ${CORS_ORIGINS:-https://${APP_DOMAIN},app://.}
       REFRESH_INTERVAL_HOURS: ${REFRESH_INTERVAL_HOURS:-168}
+      SEED_CHEATSHEETS: ${SEED_CHEATSHEETS:-true}
     expose:
       - "8080"
     networks:
       - internal
+      - web
+
+  web:
+    build:
+      context: ..
+      dockerfile: apps/web/Dockerfile
+      args:
+        VITE_API_URL: https://${API_DOMAIN}
+        VITE_AUTH_MODE: jwt
+    image: devdeck-web:latest
+    container_name: devdeck-web
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_started
+    expose:
+      - "80"
+    networks:
       - web
 
   caddy:
@@ -66,6 +115,8 @@ services:
       - "443:443/udp" # HTTP/3
     environment:
       DOMAIN: ${DOMAIN}
+      API_DOMAIN: ${API_DOMAIN}
+      APP_DOMAIN: ${APP_DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -505,21 +505,20 @@ CREATE INDEX idx_sessions_user ON sessions(user_id);
 |-----|-------------|---------|
 | `PORT` | Puerto del API | `8080` |
 | `DB_URL` | Conn string Postgres | required |
-| `AUTH_MODE` | `token` (Ola 1) o `jwt` (Ola 4) | `token` |
+| `AUTH_MODE` | `token` (legacy/dev) o `jwt` (modo productivo) | `token` |
 | `API_TOKEN` | Bearer token único (modo `token`) | required en modo token |
 | `GITHUB_TOKEN` | PAT para rate limit del enricher | optional |
 | `LOG_LEVEL` | debug/info/warn/error | `info` |
 | `CORS_ORIGINS` | CSV de origins permitidos | `app://.` |
 | `REFRESH_INTERVAL_HOURS` | Cron metadata refresh | `168` (7d) |
-| `OAUTH_GITHUB_CLIENT_ID` 🌊4 | OAuth App client ID | required en modo jwt |
-| `OAUTH_GITHUB_CLIENT_SECRET` 🌊4 | OAuth App secret | required en modo jwt |
-| `OAUTH_REDIRECT_URL` 🌊4 | Callback URL público | required en modo jwt |
+| `GITHUB_CLIENT_ID` 🌊4 | OAuth App client ID | required en modo jwt |
+| `GITHUB_CLIENT_SECRET` 🌊4 | OAuth App secret | required en modo jwt |
+| `GITHUB_OAUTH_CALLBACK_URL` 🌊4 | Callback GitHub → backend | required en modo jwt |
+| `APP_OAUTH_REDIRECT_URL` 🌊4 | Redirect backend → frontend | required en modo jwt |
 | `JWT_SECRET` 🌊4 | HMAC secret para firmar JWT | required en modo jwt |
-| `JWT_ACCESS_TTL` 🌊4 | TTL access token | `30d` |
-| `JWT_REFRESH_TTL` 🌊4 | TTL refresh token | `90d` |
 | `ALLOWED_GITHUB_LOGINS` 🌊4 | CSV de usernames permitidos | required en modo jwt |
 
-Cliente Electron lee `API_BASE_URL` y `API_TOKEN` de un config encriptado con `safeStorage`.
+Cliente Electron configura `baseUrl` y auth vía `configureApiClient()`; en desktop el storage de tokens usa `safeStorage` via IPC.
 
 ---
 
@@ -528,32 +527,11 @@ Cliente Electron lee `API_BASE_URL` y `API_TOKEN` de un config encriptado con `s
 `deploy/docker-compose.yml`:
 ```yaml
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_PASSWORD: ${PG_PASS}
-      POSTGRES_DB: devdeck
-    volumes: [pgdata:/var/lib/postgresql/data]
-    restart: unless-stopped
-
-  api:
-    image: ghcr.io/tfurt/devdeck-api:latest
-    environment:
-      DB_URL: postgres://postgres:${PG_PASS}@db:5432/devdeck?sslmode=disable
-      API_TOKEN: ${API_TOKEN}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
-    depends_on: [db]
-    restart: unless-stopped
-
-  caddy:
-    image: caddy:2-alpine
-    ports: ["80:80","443:443"]
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    depends_on: [api]
-    restart: unless-stopped
+  db: {}
+  migrate: {}
+  api: {}
+  web: {}
+  caddy: {}
 
 volumes:
   pgdata:
@@ -563,13 +541,18 @@ volumes:
 
 `deploy/Caddyfile`:
 ```
-api.devdeck.tu-dominio.com {
+{$API_DOMAIN} {
   reverse_proxy api:8080
-  encode gzip
+  encode gzip zstd
+}
+
+{$APP_DOMAIN} {
+  reverse_proxy web:80
+  encode gzip zstd
 }
 ```
 
-CI/CD: GitHub Action que en push a `main` → builda binario Go → push imagen a GHCR → SSH al VPS → `docker compose pull && docker compose up -d`.
+CI/CD: ver `.github/workflows/ci.yml` — backend, CLI, monorepo y E2E. El deploy self-hosted actual se documenta en `deploy/README.md` y `docs/SELF_HOSTING.md`.
 
 ---
 

--- a/docs/Runbooks/Setup Local.md
+++ b/docs/Runbooks/Setup Local.md
@@ -1,0 +1,396 @@
+---
+tags:
+  - runbook
+  - devdeck
+  - local-development
+aliases:
+  - Local Dev Setup
+  - Setup
+type: runbook
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🚀 Runbook — Setup Local Development
+
+> Cómo levantar DevDeck en tu máquina para desarrollo.
+
+---
+
+## 📋 Pre-requisitos
+
+```bash
+# Verificar que los tienes instalados:
+node --version          # v18+ (recomendado v20+)
+pnpm --version          # v10+ (package manager)
+go version              # 1.21+ (backend)
+docker --version        # Docker Desktop (database)
+git --version           # v2.37+
+```
+
+### Instalar si falta algo
+
+```bash
+# macOS (Homebrew)
+brew install node
+brew install pnpm
+brew install go
+brew install docker
+brew install git
+
+# Linux (Ubuntu/Debian)
+sudo apt-get install nodejs npm
+npm install -g pnpm
+sudo apt-get install golang-go
+sudo apt-get install docker.io
+```
+
+---
+
+## 🔧 Setup Paso a Paso
+
+### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/devdeckai/dev_deck.git
+cd dev_deck
+```
+
+### 2. Instalar dependencias (Frontend + Backend)
+
+```bash
+# Frontend: pnpm workspaces
+pnpm install
+
+# Verificar que todo está instalado
+pnpm -r list --depth=0 | grep "@devdeck"
+# Debe mostrar: @devdeck/ui, @devdeck/api-client, @devdeck/features
+```
+
+### 3. Levantar PostgreSQL (Docker)
+
+```bash
+# En la raíz del proyecto, usar el compose local
+docker compose -f deploy/docker-compose.local.yml up -d db migrate api
+
+# Verificar que PostgreSQL está corriendo
+docker ps | grep postgres
+
+# Esperar ~5 segundos para que levante completamente
+sleep 5
+
+# Ver logs (opcional)
+docker compose -f deploy/docker-compose.local.yml logs db
+```
+
+### 4. Configurar variables de entorno
+
+```bash
+# Backend
+cat > backend/.env << 'EOF'
+DB_URL=postgres://devdeck:devdeck@localhost:5432/devdeck?sslmode=disable
+PORT=8080
+AUTH_MODE=jwt
+JWT_SECRET=devdeck-local-jwt-secret
+GITHUB_CLIENT_ID=stub
+GITHUB_CLIENT_SECRET=stub
+GITHUB_OAUTH_CALLBACK_URL=http://localhost:8080/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback
+LOG_LEVEL=debug
+SEED_CHEATSHEETS=true
+EOF
+
+# Desktop
+cat > apps/desktop/.env << 'EOF'
+VITE_API_URL=http://localhost:8080
+VITE_AUTH_MODE=token
+VITE_API_TOKEN=devdeck-local-token
+VITE_ENV=development
+EOF
+
+# Web
+cat > apps/web/.env << 'EOF'
+VITE_API_URL=http://localhost:8080
+VITE_AUTH_MODE=jwt
+VITE_ENV=development
+EOF
+```
+
+### 5. Ejecutar migraciones de base de datos
+
+Con `deploy/docker-compose.local.yml`, las migraciones corren automáticamente en el servicio `migrate`.
+
+```bash
+# Verificar que migrate terminó bien
+docker compose -f deploy/docker-compose.local.yml logs migrate
+
+# Verificar que las tablas existen
+docker compose -f deploy/docker-compose.local.yml exec db \
+  psql -U devdeck -d devdeck -c "\dt"
+```
+
+### 6. Levantar el backend (Go)
+
+```bash
+# En la raíz o en backend/
+cd backend
+
+# Terminal 1: Backend API (si no querés usar el container api local)
+go run ./cmd/api
+
+# Debe mostrar algo como:
+# INFO ... msg="server starting" addr=":8080"
+
+# Verificar que está vivo
+curl http://localhost:8080/healthz
+# Respuesta: {"status":"ok"}
+```
+
+### 7. Levantar el frontend (Web o Desktop)
+
+```bash
+# Terminal 2 (desde raíz)
+
+# OPCIÓN A: Web (React + Vite)
+pnpm dev:web
+# Abre http://localhost:5173
+
+# OPCIÓN B: Desktop (Electron)
+pnpm dev:desktop
+# Se abre una ventana de Electron
+
+# Ambas: ejecutar secuencialmente si quieres ambas
+pnpm dev:web &
+pnpm dev:desktop
+```
+
+---
+
+## ✅ Verificar que todo funciona
+
+### Checklist
+
+```bash
+✅ Backend running (http://localhost:8080/healthz)
+✅ PostgreSQL running (docker ps)
+✅ Web available (http://localhost:5173)
+✅ Database has tables (psql -c "\dt")
+
+# Si algo no funciona, ver siguiente sección
+```
+
+### Test rápido
+
+```bash
+# 1. Backend API
+curl http://localhost:8080/healthz
+# {"status":"ok"}
+
+# 2. List repos (modo token para desktop dev)
+curl http://localhost:8080/api/repos \
+  -H "Authorization: Bearer devdeck-local-token"
+
+# 3. Frontend
+open http://localhost:5173
+# Verás la UI
+```
+
+---
+
+## 🐛 Troubleshooting
+
+### "Connection refused on localhost:5432"
+
+```bash
+# PostgreSQL no está corriendo
+docker compose -f deploy/docker-compose.local.yml up -d db migrate api
+
+# Esperar ~5 segundos
+sleep 5
+
+# Verificar
+docker ps | grep postgres
+```
+
+### "database does not exist"
+
+```bash
+# Revisar logs del servicio migrate
+docker compose -f deploy/docker-compose.local.yml logs migrate
+```
+
+### "pnpm: command not found"
+
+```bash
+npm install -g pnpm
+# O en macOS:
+brew install pnpm
+
+# Verificar
+pnpm --version
+```
+
+### Backend: "Address already in use :3000"
+
+```bash
+# Algo ya está usando puerto 3000
+lsof -i :3000
+kill -9 <PID>
+
+# O cambiar puerto en backend/.env
+PORT=3001
+```
+
+### Web: "CORS error" en console
+
+```bash
+# El backend CORS no está configurado correctamente
+# Verificar backend/internal/http/router.go
+
+# Asegurar que VITE_API_URL apunta al backend correcto
+echo $VITE_API_URL
+# Debe ser: http://localhost:8080
+```
+
+### Desktop: "Cannot find electron"
+
+```bash
+# No se instalaron dependencias de desktop
+cd apps/desktop
+pnpm install
+
+# O desde raíz
+pnpm install
+```
+
+---
+
+## 📁 Estructura de carpetas (overview)
+
+```
+dev_deck/
+├── backend/                 # Go API
+│   ├── cmd/api/main.go
+│   ├── internal/
+│   │   ├── domain/         # Business logic
+│   │   ├── http/           # HTTP handlers
+│   │   └── store/          # Database layer
+│   ├── migrations/         # SQL migrations (5 files)
+│   └── .env
+│
+├── apps/
+│   ├── desktop/            # Electron app
+│   │   ├── src/
+│   │   │   ├── main.ts     # Electron main process
+│   │   │   └── App.tsx     # React renderer
+│   │   └── .env
+│   │
+│   └── web/                # Web app
+│       ├── src/
+│       │   ├── main.tsx
+│       │   └── App.tsx
+│       └── .env
+│
+├── packages/
+│   ├── ui/                 # Design system
+│   ├── api-client/         # TanStack Query hooks
+│   └── features/           # Shared pages + components
+│
+├── docs/                   # Documentation
+│   ├── Architecture/
+│   ├── PRD/
+│   ├── Runbooks/
+│   └── adr/
+│
+└── deploy/
+    ├── docker-compose.yml
+    └── Caddyfile (production)
+```
+
+---
+
+## 🧪 Ejecutar tests
+
+```bash
+# Backend tests
+cd backend
+go test ./...
+
+# Frontend tests (Vitest)
+pnpm -F @devdeck/ui test
+pnpm -F @devdeck/api-client test
+pnpm -F @devdeck/features test
+pnpm -F @devdeck/desktop test
+
+# E2E tests (Playwright)
+pnpm -F @devdeck/web e2e
+
+# Todos los tests
+pnpm test
+```
+
+---
+
+## 🔧 Debugging
+
+### Backend (Go)
+
+```bash
+# Con verbose logging
+LOG_LEVEL=debug go run ./cmd/api/main.go
+
+# Con debugger (dlv)
+go install github.com/go-delve/delve/cmd/dlv@latest
+dlv debug ./cmd/api
+(dlv) continue
+(dlv) break main.main
+(dlv) c
+```
+
+### Frontend (Web)
+
+```bash
+# Chrome DevTools abre automáticamente
+pnpm dev:web
+# F12 para abrir DevTools
+
+# Debugger breakpoints
+# En el código: debugger;
+// En src/main.tsx
+debugger;
+```
+
+### Frontend (Desktop)
+
+```bash
+# Electron DevTools
+pnpm dev:desktop
+
+# Presiona: Cmd+Option+I (macOS) o Ctrl+Shift+I (Linux/Windows)
+# Para abrir DevTools
+```
+
+---
+
+## 📚 Documentos relacionados
+
+- **[[Runbooks/Testing]]** — Estrategia de tests completa
+- **[[Runbooks/Deployment]]** — Deployment a producción
+- **[[Backend/Backend MOC]]** — Estructura del backend
+- **[[Frontend/Frontend MOC]]** — Estructura del frontend
+
+---
+
+## 🎯 Próximos pasos
+
+1. **Leer el código:** Empieza en `backend/cmd/api/main.go` o `apps/web/src/App.tsx`
+2. **Crear un item:** Usa CaptureModal para guardar un repo
+3. **Escribir un test:** Agrega un test en `backend/internal/http/handlers/items_test.go`
+4. **Hacer un cambio:** Modifica un handler y verifica que los tests pasen
+
+---
+
+**Last updated:** 2026-04-29  
+**Maintained by:** @dev-team  
+**Status:** Production-ready

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -49,12 +49,12 @@ POSTGRES_PASSWORD=<password-largo-y-random>
 POSTGRES_DB=devdeck
 
 # Backend API
-DATABASE_URL=postgres://devdeck:<password>@db:5432/devdeck?sslmode=disable
 AUTH_MODE=jwt
 JWT_SECRET=<256-bit-random-hex>
 GITHUB_CLIENT_ID=<del paso 1>
 GITHUB_CLIENT_SECRET=<del paso 1>
-OAUTH_REDIRECT_URL=https://api.devdeck.tu-dominio.com/api/auth/github/callback
+GITHUB_OAUTH_CALLBACK_URL=https://api.devdeck.tu-dominio.com/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=https://app.devdeck.tu-dominio.com/auth/callback
 ALLOWED_GITHUB_LOGINS=tu-usuario,otro-usuario
 
 # Feature flags


### PR DESCRIPTION
Closes #26

## Summary
- align CI and deployment assets with the actual pnpm monorepo topology
- separate GitHub OAuth callback configuration from the frontend auth redirect
- document the self-hosted and local setup flow and isolate the darwin/arm64 DB test crash behind a platform-specific helper

## Changes
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Move CI and E2E flows from legacy npm/desktop assumptions to pnpm workspace commands |
| `apps/web/Dockerfile`, `apps/web/nginx.conf` | Add production image and SPA serving config for the web app |
| `backend/internal/config/config.go` | Split OAuth callback and frontend redirect env vars |
| `backend/internal/http/handlers/auth.go`, `backend/internal/http/router.go` | Wire the separated OAuth URLs into the auth flow |
| `backend/internal/testutil/postgres.go`, `backend/internal/testutil/postgres_darwin_arm64.go` | Add Apple Silicon-safe DB test helper split via build tags |
| `deploy/Caddyfile`, `deploy/docker-compose.local.yml`, `deploy/docker-compose.yml`, `deploy/.env.example`, `deploy/README.md` | Model production/local deploy around db + migrate + api + web + caddy |
| `docs/ARCHITECTURE.md`, `docs/Runbooks/Setup Local.md`, `docs/SELF_HOSTING.md`, `CONTRIBUTING.md`, `ROADMAP.md` | Update runbooks and architecture docs to match the real deployment and auth model |

## Test Plan
- [x] `go test ./internal/config ./internal/http/handlers ./internal/http/...`
- [x] Manual diff review against `origin/main`
- [x] Verified branch is based on `origin/main` and contains only the readiness patch
