### PR TITLE
feat: add heuristic AI enrichment for items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,33 +88,38 @@ jobs:
       - name: Smoke test (--help)
         run: /tmp/devdeck --help
 
-  desktop:
-    name: Desktop (Vitest + typecheck + build)
+  monorepo:
+    name: Monorepo (pnpm typecheck + tests)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: desktop
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
 
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        run: npm run typecheck
+        run: pnpm typecheck
 
-      - name: Vitest unit tests
-        run: npm test
+      - name: Unit tests
+        run: pnpm test
 
-      - name: Build (electron-vite)
-        run: npm run build
+      - name: Verify web build
+        run: pnpm build:web
+
+      - name: Verify desktop build
+        run: pnpm build:desktop
 
   extension:
     name: Extension (Manifest v3 + node:test)
@@ -147,7 +152,7 @@ jobs:
   e2e:
     name: E2E (Playwright + live backend)
     runs-on: ubuntu-latest
-    needs: [backend, desktop]
+    needs: [backend, monorepo]
     services:
       postgres:
         image: postgres:16-alpine
@@ -182,8 +187,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: npm
-          cache-dependency-path: desktop/package-lock.json
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
 
       - name: Apply DB migrations
         working-directory: backend
@@ -210,24 +220,23 @@ jobs:
           echo "API never became healthy" >&2
           exit 1
 
-      - name: Install desktop deps
-        working-directory: desktop
-        run: npm ci
+      - name: Install monorepo deps
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        working-directory: desktop
-        run: npx playwright install --with-deps chromium
+        working-directory: apps/desktop
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        working-directory: desktop
-        run: npm run test:e2e
+        working-directory: apps/desktop
+        run: pnpm test:e2e
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: desktop/playwright-report
+          path: apps/desktop/playwright-report
           retention-days: 7
 
       - name: Stop backend

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,10 @@ pnpm-debug.log*
 
 # Root/node workspaces
 node_modules/
+bin/
 
 # Go backend
+backend/devdeck
 backend/bin/
 backend/tmp/
 backend/*.exe
@@ -31,6 +33,8 @@ apps/*/dist/
 apps/*/out/
 apps/*/.vite/
 apps/*/coverage/
+apps/*/package-lock.json
+apps/*/pnpm-lock.yaml
 apps/desktop/build/icon.*
 packages/*/node_modules/
 packages/*/dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,7 @@ pnpm install
 
 ### Backend
 ```bash
-cd backend
-cp .env.example .env
-# editar DATABASE_URL, GITHUB_* si vas a testear auth
-docker compose -f ../deploy/docker-compose.dev.yml up -d db
-go run ./cmd/api
+docker compose -f deploy/docker-compose.local.yml up -d db migrate api
 ```
 
 ### Desktop (Electron + React)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Ambas apps importan pages y componentes del package `@devdeck/features` — solo
 ### Operación y contribución
 | Doc | Contenido |
 |-----|-----------|
+| [cli/README.md](cli/README.md) | Instalación y uso real del CLI `devdeck` (P0) |
 | [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Guía paso a paso para self-host |
 | [docs/CAPTURE.md](docs/CAPTURE.md) | Spec de canales de captura (extensión, CLI, paste, share) |
 | [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Plan de tests y CI |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -348,16 +348,20 @@
 - `GET /api/items`, `GET /api/items/:id`, `PATCH /api/items/:id`, `DELETE /api/items/:id`, `POST /api/items/:id/seen`. ✅
 - Frontend (`@devdeck/features`): `ItemsPage` con grid por tipo + filtros de tipo + search + empty state; `ItemCard` adaptada por tipo; `CaptureModal` con `why_saved` + type override. Funciona en desktop y web sin duplicación. ✅
 
-### Fase 18 — Auto-tagging + Auto-summary (IA)
+### Fase 18 — Auto-tagging + Auto-summary (IA) 🚧
 
-- `internal/ai/`: módulo de IA con interfaz `Classifier` + `Summarizer`
-- `internal/ai/openai.go`: implementación con OpenAI (GPT-4o-mini para eficiencia)
-- `internal/ai/ollama.go`: implementación con Ollama para opción local
-- `internal/config/config.go`: `AI_PROVIDER` (`openai`|`ollama`|`disabled`), `AI_OPT_IN` por usuario
-- Pipeline de enriquecimiento: al guardar un item, encolar tarea de IA → auto-tags + summary en background (no bloquea el save)
-- Endpoint `POST /api/items/:id/ai-enrich` — dispara enriquecimiento manual on-demand
-- Endpoint `PATCH /api/items/:id/ai-tags` — el usuario acepta/edita/descarta tags sugeridos
-- Frontend: indicador "analizando…" mientras la IA trabaja; UI de review de tags sugeridos (aceptar/editar/descartar)
+**Estado actual (MVP implementado):**
+- `internal/ai/`: módulo de IA con interfaces `Classifier` + `Summarizer` + providers `heuristic` y `disabled`. ✅
+- `internal/config/config.go`: `AI_PROVIDER` soporta `heuristic`/`local` y `disabled`. ✅
+- Pipeline de enriquecimiento: al guardar un item, la queue existente procesa metadata + auto-tags + summary en background sin bloquear capture/save. ✅
+- Persistencia: `ai_summary` + `ai_tags` ya se guardan en `items`; `GET /api/items` también los aprovecha en búsqueda textual. ✅
+- Frontend mínimo: `ItemCard` muestra estado `Analizando…`, prioriza `ai_summary` sobre `description` y usa `ai_tags` cuando no hay tags manuales. ✅
+
+**Pendiente para cerrar la fase como "IA real":**
+- `internal/ai/openai.go`: implementación con OpenAI (GPT-4o-mini). ⏳
+- `internal/ai/ollama.go`: implementación con Ollama local. ⏳
+- Endpoints `POST /api/items/:id/ai-enrich` y `PATCH /api/items/:id/ai-tags` para refresh/review manual. ⏳
+- UI de review de tags sugeridos (aceptar/editar/descartar) y surface de detalle para items no-repo. ⏳
 
 ### Fase 19 — Búsqueda semántica
 
@@ -437,6 +441,7 @@
 | Web | Vite + React 18 + TypeScript + react-router-dom (BrowserRouter) + AuthGuard (§16.13 — reemplaza el Vue 3 + Pinia original) |
 | Estilos | Tailwind CSS + CSS variables (neo-brutalist) — preset compartido en `@devdeck/ui/tailwind-preset.cjs` |
 | State/cache | TanStack Query v5 (hooks en `@devdeck/api-client`) |
+| IA actual | Heurística local async (`AI_PROVIDER=heuristic`) sobre la queue de enrichment existente |
 | Animaciones | framer-motion |
 | Drag & drop | @dnd-kit/core + @dnd-kit/sortable |
 | Markdown | react-markdown + remark-gfm + rehype-highlight + rehype-raw |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@
 - ✅ §16.7 Observability (slog + /metrics)
 - ✅ §16.8 SSRF guard + rate limiting
 - ✅ §16.9 `POST /api/items/capture` con detección, dedupe y enrich async
-- ⏳ §16.10 CLI `devdeck` (scaffold + P0 commands listos; falta release 0.1.0)
+- ⏳ §16.10 CLI `devdeck` (comandos P0 implementados; falta release 0.1.0)
 - ⏳ §16.11 Extensión Chrome/Firefox (P0 listo; falta publicar)
 - ✅ §16.12 Paste inteligente + CaptureModal en desktop
 - ✅ §16.13 Monorepo pnpm workspaces + Web Vue → React (ver ADR 0003)
@@ -45,7 +45,7 @@
 - Enricher: tests con `httptest.Server` mockeando GitHub + SSRF guard tests rechazando IPs privadas. ✅
 - Desktop: Vitest + `@testing-library/react` con 57 tests unitarios (format, preferences, auth, RepoCard, TagChip, PasteInterceptor, detector). Playwright config + skeleton con los 5 flows. ✅
 - Web Vue: intencionalmente sin tocar en Wave 4.5 inicial; **reemplazada por React 18 en §16.13** (ver abajo). Post-migración los 57 tests se redistribuyeron en los nuevos packages: 39 en `@devdeck/api-client`, 5 en `@devdeck/ui`, 18 en `@devdeck/features`, 5 en `apps/desktop` = **67 tests totales**. ✅
-- GitHub Actions: workflow `ci.yml` con jobs `backend`, `desktop`, `e2e` con concurrency cancel-in-progress. ✅ (TODO post-migración: agregar job `web` con `pnpm -F @devdeck/web typecheck && build`)
+- GitHub Actions: workflow `ci.yml` con jobs `backend`, `cli`, `monorepo`, `extension` y `e2e`; el job `monorepo` valida `pnpm typecheck`, `pnpm test`, `pnpm build:web` y `pnpm build:desktop`. ✅
 - Ver `docs/TESTING_STRATEGY.md` para el plan sprint-by-sprint.
 
 ### Fase 16.7 — Observability mínima ✅
@@ -70,11 +70,12 @@
 
 ### Fase 16.10 — CLI `devdeck` (P0) ⏳
 - Nuevo subproyecto `cli/` en el repo (Go, `cobra`, binario único).
-- Comandos P0: `login`, `config`, `add <url|text>`, `search <q>`, `list`, `open <id>`, `status`.
+- Implementado hoy: `login`, `logout`, `config`, `add <url|text>`, `search <q>`, `list`, `open <id>`, `status`, `import github-stars`.
+- `open <id>` en P0 abre la URL fuente del repo/item; no intenta deducir rutas internas del web app desde `api_url`.
 - Token en OS keychain via `zalando/go-keyring`.
 - Config en `~/.config/devdeck/config.toml`.
-- SQLite local en `~/.local/share/devdeck/` para queue offline y cache.
-- Distribución: `go install`, Homebrew tap, Scoop manifest.
+- SQLite local en `~/.local/share/devdeck/` para queue offline y cache. **Pendiente / no implementado todavía.**
+- Distribución: `go install`, Homebrew tap, Scoop manifest. **Pendiente como parte del release 0.1.0.**
 - Ver `docs/CAPTURE.md §Canal 2` para spec completa.
 
 ### Fase 16.11 — Extensión de browser (P0) ⏳
@@ -118,12 +119,12 @@
 - Commit: `698b432 feat(monorepo): pnpm workspaces + Vue→React web migration` en branch `claude/setup-react-web-app-LVWhi`.
 
 ### Criterio de salida de Ola 4.5
-- [x] CI verde en cada push, bloqueante para merge (GitHub Actions `ci.yml` con backend + desktop + e2e). Post-§16.13 falta agregar job `web`.
+- [x] CI verde en cada push, bloqueante para merge (GitHub Actions `ci.yml` con `backend`, `cli`, `monorepo`, `extension` y `e2e`).
 - [x] ≥ 60% cobertura en `backend/internal/http/handlers` y `backend/internal/store` (handler matrix + store tests con testcontainers).
 - [x] ≥ 5 flows E2E pasando en Electron (Playwright skeleton con los 5 flows).
 - [x] Endpoint `/api/items/capture` en producción con tests.
 - [x] Web client migrado a React y compartiendo código con desktop (§16.13).
-- [ ] CLI `devdeck` en release 0.1.0 con los comandos P0.
+- [ ] CLI `devdeck` en release 0.1.0 con distribución mínima (`go install` + docs claras; Homebrew/Scoop opcionales si no entran en el primer corte).
 - [ ] Extensión Chrome en Chrome Web Store (o sideload con instructions claras).
 - [ ] README con screenshots (no bloquea CI, agendado para antes del release público).
 - [x] `api.exe` fuera del repo.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -263,7 +263,7 @@
 - `internal/store/auth.go`: UpsertUser, GetUserByGitHubID, CreateRefreshSession, GetRefreshSession, DeleteAllRefreshSessions
 - `internal/http/handlers/auth.go`: GitHub OAuth login/callback/refresh/logout/me endpoints
 - `internal/http/middleware/auth.go`: Dual mode — static token (Wave 1) + JWT with context injection
-- `internal/config/config.go`: JWT_SECRET, GITHUB_CLIENT_ID/SECRET, OAUTH_REDIRECT_URL, ALLOWED_GITHUB_LOGINS
+- `internal/config/config.go`: JWT_SECRET, GITHUB_CLIENT_ID/SECRET, GITHUB_OAUTH_CALLBACK_URL, APP_OAUTH_REDIRECT_URL, ALLOWED_GITHUB_LOGINS
 - `internal/http/router.go`: Auth routes under /api/auth/*, public OAuth endpoints, JWT-protected /me
 - `cmd/api/main.go`: AuthService wiring, JWT mode initialization
 
@@ -292,7 +292,7 @@
 - Cheatsheet detail: entries con copy button + filtro por tag/search
 - Discovery mode: skip/keep flow
 - Mascota Snarkel — componente Vue con 5 moods, bubble con transición, click-to-interact
-- Deploy a `app.devdeck.tu-dominio.com` via Caddy (pendiente config)
+- Deploy web + api vía Caddy y Docker Compose (ver `deploy/README.md` y `docs/SELF_HOSTING.md`)
 
 ### Fase 16 — Pulido cross-platform ⏳
 - Verificación paridad Electron ↔ Web
@@ -306,7 +306,7 @@
 - OS-level global shortcuts: `Ctrl/Cmd+K` → search, `Ctrl/Cmd+N` → add (fire en background)
 - `auth.ts` detecta Electron y delega a `window.electronAPI`, fallback a localStorage
 - `electron.d.ts` con tipos para `window.electronAPI`
-- JWT mode no activado por defecto (`VITE_AUTH_MODE=token` → static)
+- Desktop mantiene fallback `VITE_AUTH_MODE=token` para dev/E2E; web usa `jwt` como modo productivo
 
 **Web Vue P1 — COMPLETADO:**
 - `GlobalSearchModal.vue` — Ctrl+K, búsqueda cross-entity, resultados agrupados

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps/web/package.json ./apps/web/package.json
+COPY packages/api-client/package.json ./packages/api-client/package.json
+COPY packages/features/package.json ./packages/features/package.json
+COPY packages/ui/package.json ./packages/ui/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY apps/web ./apps/web
+COPY packages/api-client ./packages/api-client
+COPY packages/features ./packages/features
+COPY packages/ui ./packages/ui
+
+ARG VITE_API_URL=https://api.devdeck.ai
+ARG VITE_AUTH_MODE=jwt
+
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_AUTH_MODE=$VITE_AUTH_MODE
+
+RUN pnpm -F @devdeck/web build
+
+FROM nginx:1.27-alpine
+
+COPY apps/web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"devdeck/internal/authservice"
+	"devdeck/internal/ai"
 	"devdeck/internal/config"
 	"devdeck/internal/cron"
 	"devdeck/internal/enricher"
@@ -65,6 +66,7 @@ func main() {
 
 	st := store.New(pool)
 	en := enricher.New(cfg.GithubToken)
+	aiSvc := ai.New(cfg.AIProvider)
 
 	// JWT auth service (Wave 4). Only active when AUTH_MODE=jwt.
 	var authService *authservice.Service
@@ -92,7 +94,7 @@ func main() {
 
 	// Background enrich queue (Wave 4.5 §16.9) — handlers that need
 	// async metadata fetches (capture + create repo) push jobs here.
-	enrichQueue := jobs.NewEnrichQueue(st, en, 128)
+	enrichQueue := jobs.NewEnrichQueue(st, en, aiSvc, 128)
 	enrichQueue.Start(ctx)
 
 	router := httpapi.NewRouterWithDeps(cfg, httpapi.Deps{
@@ -109,6 +111,7 @@ func main() {
 	logger.Info("enricher + refresher initialized",
 		"stale_after", staleAfter,
 		"github_token", cfg.GithubToken != "",
+		"ai_provider", cfg.AIProvider,
 	)
 
 	srv := &http.Server{

--- a/backend/internal/ai/disabled.go
+++ b/backend/internal/ai/disabled.go
@@ -1,0 +1,15 @@
+package ai
+
+import "context"
+
+type disabledProvider struct{}
+
+func (disabledProvider) Enabled() bool { return false }
+
+func (disabledProvider) SuggestTags(context.Context, Input) ([]string, error) {
+	return nil, nil
+}
+
+func (disabledProvider) Summarize(context.Context, Input) (string, error) {
+	return "", nil
+}

--- a/backend/internal/ai/heuristic.go
+++ b/backend/internal/ai/heuristic.go
@@ -1,0 +1,316 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"devdeck/internal/domain/items"
+)
+
+type heuristicProvider struct{}
+
+func (heuristicProvider) Enabled() bool { return true }
+
+func (heuristicProvider) Summarize(_ context.Context, in Input) (string, error) {
+	desc := cleanSentence(in.Description)
+	title := strings.TrimSpace(in.Title)
+	host := hostTag(in.URL)
+
+	if desc != "" {
+		return truncate(desc, 160), nil
+	}
+
+	switch in.Type {
+	case items.TypeRepo:
+		if title == "" {
+			return "GitHub repository saved for later.", nil
+		}
+		return truncate(fmt.Sprintf("GitHub repository saved for later: %s.", title), 160), nil
+	case items.TypeArticle:
+		if host != "" && title != "" {
+			return truncate(fmt.Sprintf("Article saved from %s: %s.", host, title), 160), nil
+		}
+		return truncate(fmt.Sprintf("Article saved for later: %s.", fallbackTitle(title, "untitled article")), 160), nil
+	case items.TypeCLI:
+		return truncate(fmt.Sprintf("CLI command or install snippet: %s.", fallbackTitle(title, "command")), 160), nil
+	case items.TypeSnippet:
+		return truncate(fmt.Sprintf("Code snippet saved for reuse: %s.", fallbackTitle(title, "snippet")), 160), nil
+	case items.TypeShortcut:
+		return truncate(fmt.Sprintf("Keyboard shortcut saved for quick recall: %s.", fallbackTitle(title, "shortcut")), 160), nil
+	case items.TypePlugin:
+		return truncate(fmt.Sprintf("Plugin saved for evaluation: %s.", fallbackTitle(title, "plugin")), 160), nil
+	case items.TypeWorkflow:
+		return truncate(fmt.Sprintf("Workflow reference saved for later: %s.", fallbackTitle(title, "workflow")), 160), nil
+	case items.TypeAgent:
+		return truncate(fmt.Sprintf("Agent/tooling reference saved for later: %s.", fallbackTitle(title, "agent")), 160), nil
+	case items.TypePrompt:
+		return truncate(fmt.Sprintf("Prompt saved for reuse: %s.", fallbackTitle(title, "prompt")), 160), nil
+	case items.TypeTool:
+		if host != "" && title != "" {
+			return truncate(fmt.Sprintf("Tool saved from %s: %s.", host, title), 160), nil
+		}
+		return truncate(fmt.Sprintf("Tool saved for later: %s.", fallbackTitle(title, "tool")), 160), nil
+	default:
+		return truncate(fmt.Sprintf("Reference saved for later: %s.", fallbackTitle(title, "note")), 160), nil
+	}
+}
+
+func (heuristicProvider) SuggestTags(_ context.Context, in Input) ([]string, error) {
+	var tags []string
+
+	if lang := normalizeTag(stringMeta(in.Meta, "language")); lang != "" {
+		tags = append(tags, lang)
+	}
+	for _, topic := range sliceMeta(in.Meta, "topics") {
+		if tag := normalizeTag(topic); tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	if host := hostTag(in.URL); host != "" {
+		tags = append(tags, host)
+	}
+
+	switch in.Type {
+	case items.TypeRepo:
+		tags = append(tags, "repository")
+		if repoName := repoNameTag(in.Title); repoName != "" {
+			tags = append(tags, repoName)
+		}
+	case items.TypeArticle:
+		tags = append(tags, "reading")
+	case items.TypeCLI:
+		tags = append(tags, "cli")
+		if cmd := commandTag(in.Title); cmd != "" {
+			tags = append(tags, cmd)
+		}
+	case items.TypeSnippet:
+		tags = append(tags, "code")
+		if fenced := fencedLanguageTag(in.Title); fenced != "" {
+			tags = append(tags, fenced)
+		}
+	case items.TypeShortcut:
+		tags = append(tags, "shortcut")
+		if platform := shortcutPlatformTag(in.Title); platform != "" {
+			tags = append(tags, platform)
+		}
+	case items.TypePlugin:
+		tags = append(tags, "plugin")
+	case items.TypeWorkflow:
+		tags = append(tags, "workflow")
+	case items.TypePrompt:
+		tags = append(tags, "prompt")
+	case items.TypeAgent:
+		tags = append(tags, "agent")
+	case items.TypeTool:
+		tags = append(tags, "tool")
+	}
+
+	for _, word := range keywordTags(in.Type, in.Title) {
+		tags = append(tags, word)
+	}
+
+	return uniqueTags(tags), nil
+}
+
+func fallbackTitle(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return strings.TrimSpace(s)
+}
+
+func cleanSentence(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	if strings.HasSuffix(s, ".") || strings.HasSuffix(s, "!") || strings.HasSuffix(s, "?") {
+		return s
+	}
+	return s + "."
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return strings.TrimSpace(s[:n-1]) + "…"
+}
+
+func hostTag(raw *string) string {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return ""
+	}
+	u, err := url.Parse(*raw)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := strings.ToLower(strings.TrimPrefix(u.Hostname(), "www."))
+	switch host {
+	case "github.com":
+		return "github"
+	case "dev.to":
+		return "devto"
+	case "medium.com":
+		return "medium"
+	case "plugins.jetbrains.com":
+		return "jetbrains"
+	case "marketplace.visualstudio.com":
+		return "vscode"
+	case "chromewebstore.google.com", "chrome.google.com":
+		return "chrome"
+	case "addons.mozilla.org":
+		return "firefox"
+	default:
+		parts := strings.Split(host, ".")
+		if len(parts) >= 2 {
+			return normalizeTag(parts[len(parts)-2])
+		}
+		return normalizeTag(host)
+	}
+}
+
+func repoNameTag(title string) string {
+	parts := strings.Split(strings.TrimSpace(title), "/")
+	if len(parts) >= 2 {
+		return normalizeTag(parts[1])
+	}
+	return ""
+}
+
+func commandTag(title string) string {
+	fields := strings.Fields(strings.ToLower(title))
+	stop := map[string]bool{
+		"$": true, ">": true, "brew": true, "install": true, "tap": true,
+		"apt": true, "apt-get": true, "npm": true, "pnpm": true, "yarn": true,
+		"global": true, "add": true, "-g": true, "cargo": true, "go": true,
+		"pip": true, "pipx": true, "gem": true, "docker": true, "run": true,
+		"pull": true, "kubectl": true, "curl": true, "wget": true,
+	}
+	for _, f := range fields {
+		f = strings.Trim(f, "`'\".,;:()[]{}")
+		if f == "" || stop[f] {
+			continue
+		}
+		return normalizeTag(f)
+	}
+	return ""
+}
+
+func fencedLanguageTag(title string) string {
+	line := strings.TrimSpace(strings.Split(title, "\n")[0])
+	if !strings.HasPrefix(line, "```") {
+		return ""
+	}
+	return normalizeTag(strings.TrimPrefix(line, "```"))
+}
+
+func shortcutPlatformTag(title string) string {
+	lower := strings.ToLower(title)
+	switch {
+	case strings.Contains(lower, "cmd"), strings.Contains(lower, "option"):
+		return "mac"
+	case strings.Contains(lower, "ctrl"), strings.Contains(lower, "win"):
+		return "windows"
+	default:
+		return ""
+	}
+}
+
+var nonTagRE = regexp.MustCompile(`[^a-z0-9.+#-]+`)
+
+func normalizeTag(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "_", "-")
+	s = strings.ReplaceAll(s, " ", "-")
+	s = nonTagRE.ReplaceAllString(s, "")
+	s = strings.Trim(s, "-.")
+	return s
+}
+
+func keywordTags(itemType items.Type, title string) []string {
+	if itemType == items.TypeRepo {
+		return nil
+	}
+	words := strings.FieldsFunc(strings.ToLower(title), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	})
+	stop := map[string]bool{
+		"the": true, "and": true, "for": true, "with": true, "from": true,
+		"your": true, "this": true, "that": true, "into": true, "using": true,
+		"save": true, "saved": true, "later": true,
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, 2)
+	for _, w := range words {
+		if len(w) < 3 || stop[w] || seen[w] {
+			continue
+		}
+		seen[w] = true
+		out = append(out, normalizeTag(w))
+		if len(out) == 2 {
+			break
+		}
+	}
+	return out
+}
+
+func stringMeta(meta map[string]any, key string) string {
+	if meta == nil {
+		return ""
+	}
+	v, _ := meta[key].(string)
+	return v
+}
+
+func sliceMeta(meta map[string]any, key string) []string {
+	if meta == nil {
+		return nil
+	}
+	switch v := meta[key].(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, raw := range v {
+			if s, ok := raw.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func uniqueTags(tags []string) []string {
+	if len(tags) == 0 {
+		return []string{}
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		norm := normalizeTag(tag)
+		if norm == "" || seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		out = append(out, norm)
+	}
+	sort.Strings(out)
+	if len(out) > 6 {
+		out = out[:6]
+	}
+	return out
+}

--- a/backend/internal/ai/heuristic_test.go
+++ b/backend/internal/ai/heuristic_test.go
@@ -1,0 +1,132 @@
+package ai
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"devdeck/internal/domain/items"
+)
+
+func TestHeuristicSummarize(t *testing.T) {
+	h := heuristicProvider{}
+	tests := []struct {
+		name string
+		in   Input
+		want string
+	}{
+		{
+			name: "description wins for repo",
+			in: Input{
+				Type:        items.TypeRepo,
+				Title:       "charmbracelet/bubbletea",
+				Description: "A powerful TUI framework for Go",
+			},
+			want: "A powerful TUI framework for Go.",
+		},
+		{
+			name: "article fallback includes host",
+			in: Input{
+				Type:  items.TypeArticle,
+				Title: "How to test CLIs",
+				URL:   ptr("https://dev.to/foo/how-to-test-clis"),
+			},
+			want: "Article saved from devto: How to test CLIs.",
+		},
+		{
+			name: "shortcut fallback",
+			in: Input{
+				Type:  items.TypeShortcut,
+				Title: "Cmd+Shift+P",
+			},
+			want: "Keyboard shortcut saved for quick recall: Cmd+Shift+P.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := h.Summarize(context.Background(), tt.in)
+			if err != nil {
+				t.Fatalf("Summarize() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("Summarize() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeuristicSuggestTags(t *testing.T) {
+	h := heuristicProvider{}
+	tests := []struct {
+		name string
+		in   Input
+		want []string
+	}{
+		{
+			name: "repo pulls language topics and host",
+			in: Input{
+				Type:  items.TypeRepo,
+				Title: "charmbracelet/bubbletea",
+				URL:   ptr("https://github.com/charmbracelet/bubbletea"),
+				Meta: map[string]any{
+					"language": "Go",
+					"topics":   []any{"tui", "terminal"},
+				},
+			},
+			want: []string{"bubbletea", "github", "go", "repository", "terminal", "tui"},
+		},
+		{
+			name: "cli extracts command name",
+			in: Input{
+				Type:  items.TypeCLI,
+				Title: "brew install ripgrep",
+			},
+			want: []string{"brew", "cli", "install", "ripgrep"},
+		},
+		{
+			name: "shortcut adds platform",
+			in: Input{
+				Type:  items.TypeShortcut,
+				Title: "Cmd+Shift+P",
+			},
+			want: []string{"cmd", "mac", "shift", "shortcut"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := h.SuggestTags(context.Background(), tt.in)
+			if err != nil {
+				t.Fatalf("SuggestTags() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("SuggestTags() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceEnrichItem(t *testing.T) {
+	svc := NewHeuristic()
+	item := &items.Item{
+		Type:  items.TypeRepo,
+		Title: "charmbracelet/bubbletea",
+		URL:   ptr("https://github.com/charmbracelet/bubbletea"),
+		Description: ptr("A powerful TUI framework for Go"),
+		Meta: map[string]any{"language": "Go", "topics": []any{"tui"}},
+	}
+
+	out, err := svc.EnrichItem(context.Background(), item)
+	if err != nil {
+		t.Fatalf("EnrichItem() error = %v", err)
+	}
+	if out.Summary != "A powerful TUI framework for Go." {
+		t.Fatalf("summary = %q", out.Summary)
+	}
+	if len(out.Tags) == 0 {
+		t.Fatal("expected tags")
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/backend/internal/ai/service.go
+++ b/backend/internal/ai/service.go
@@ -1,0 +1,122 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"devdeck/internal/domain/items"
+)
+
+// Input is the sanitized subset of an item we allow the AI layer to see.
+// Even for the local heuristic provider we keep the same boundary so future
+// external providers don't accidentally start depending on private fields.
+type Input struct {
+	Type        items.Type
+	Title       string
+	Description string
+	URL         *string
+	Meta        map[string]any
+}
+
+// Output is the suggestion payload written back to the item row.
+type Output struct {
+	Summary string
+	Tags    []string
+}
+
+type Classifier interface {
+	SuggestTags(ctx context.Context, in Input) ([]string, error)
+	Enabled() bool
+}
+
+type Summarizer interface {
+	Summarize(ctx context.Context, in Input) (string, error)
+	Enabled() bool
+}
+
+// Service coordinates tag + summary generation.
+type Service struct {
+	classifier Classifier
+	summarizer Summarizer
+}
+
+func New(provider string) *Service {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", "heuristic", "local":
+		return NewHeuristic()
+	case "disabled", "off", "none":
+		return NewDisabled()
+	default:
+		return NewDisabled()
+	}
+}
+
+func NewWith(classifier Classifier, summarizer Summarizer) *Service {
+	return &Service{classifier: classifier, summarizer: summarizer}
+}
+
+func NewDisabled() *Service {
+	d := disabledProvider{}
+	return NewWith(d, d)
+}
+
+func NewHeuristic() *Service {
+	h := heuristicProvider{}
+	return NewWith(h, h)
+}
+
+func (s *Service) Enabled() bool {
+	if s == nil {
+		return false
+	}
+	return (s.classifier != nil && s.classifier.Enabled()) ||
+		(s.summarizer != nil && s.summarizer.Enabled())
+}
+
+func (s *Service) EnrichItem(ctx context.Context, item *items.Item) (Output, error) {
+	if item == nil {
+		return Output{}, errors.New("nil item")
+	}
+	if s == nil || !s.Enabled() {
+		return Output{}, nil
+	}
+
+	in := Input{
+		Type:        item.Type,
+		Title:       strings.TrimSpace(item.Title),
+		Description: strings.TrimSpace(deref(item.Description)),
+		URL:         item.URL,
+		Meta:        item.Meta,
+	}
+
+	var out Output
+	var errs []error
+
+	if s.summarizer != nil && s.summarizer.Enabled() {
+		summary, err := s.summarizer.Summarize(ctx, in)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			out.Summary = strings.TrimSpace(summary)
+		}
+	}
+
+	if s.classifier != nil && s.classifier.Enabled() {
+		tags, err := s.classifier.SuggestTags(ctx, in)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			out.Tags = uniqueTags(tags)
+		}
+	}
+
+	return out, errors.Join(errs...)
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	GitHubOAuthCallbackURL string `env:"GITHUB_OAUTH_CALLBACK_URL" envDefault:"http://localhost:8080/api/auth/github/callback"`
 	AppOAuthRedirectURL    string `env:"APP_OAUTH_REDIRECT_URL" envDefault:"http://localhost:5173/auth/callback"`
 	AllowedGitHubLogins    string `env:"ALLOWED_GITHUB_LOGINS"` // comma-separated, empty = allow all
+
+	// ─── Wave 5 Fase 18: local AI enrichment ───
+	AIProvider string `env:"AI_PROVIDER" envDefault:"heuristic"`
 }
 
 func (c Config) CORSOriginList() []string {
@@ -78,6 +81,11 @@ func Load() (Config, error) {
 	}
 	if c.AuthMode != "token" && c.AuthMode != "jwt" {
 		return c, errors.New("AUTH_MODE must be 'token' or 'jwt'")
+	}
+	switch strings.ToLower(strings.TrimSpace(c.AIProvider)) {
+	case "", "heuristic", "local", "disabled", "off", "none":
+	default:
+		return c, errors.New("AI_PROVIDER must be one of: heuristic, local, disabled")
 	}
 	return c, nil
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -34,11 +34,12 @@ type Config struct {
 	RateLimitDisabled  bool `env:"RATE_LIMIT_DISABLED" envDefault:"false"`
 
 	// ─── Wave 4: Auth ───
-	JWTSecret           string `env:"JWT_SECRET"`
-	GitHubClientID      string `env:"GITHUB_CLIENT_ID"`
-	GitHubClientSecret  string `env:"GITHUB_CLIENT_SECRET"`
-	OAuthRedirectURL    string `env:"OAUTH_REDIRECT_URL" envDefault:"http://localhost:5173/auth/callback"`
-	AllowedGitHubLogins string `env:"ALLOWED_GITHUB_LOGINS"` // comma-separated, empty = allow all
+	JWTSecret              string `env:"JWT_SECRET"`
+	GitHubClientID         string `env:"GITHUB_CLIENT_ID"`
+	GitHubClientSecret     string `env:"GITHUB_CLIENT_SECRET"`
+	GitHubOAuthCallbackURL string `env:"GITHUB_OAUTH_CALLBACK_URL" envDefault:"http://localhost:8080/api/auth/github/callback"`
+	AppOAuthRedirectURL    string `env:"APP_OAUTH_REDIRECT_URL" envDefault:"http://localhost:5173/auth/callback"`
+	AllowedGitHubLogins    string `env:"ALLOWED_GITHUB_LOGINS"` // comma-separated, empty = allow all
 }
 
 func (c Config) CORSOriginList() []string {

--- a/backend/internal/http/handlers/auth.go
+++ b/backend/internal/http/handlers/auth.go
@@ -23,7 +23,8 @@ type AuthHandler struct {
 type AuthConfig struct {
 	GitHubClientID     string
 	GitHubClientSecret string
-	RedirectURL        string
+	GitHubCallbackURL  string
+	AppRedirectURL     string
 	AllowedLogins      map[string]bool // empty = allow all
 }
 
@@ -48,7 +49,7 @@ func (h *AuthHandler) GitHubLogin(w http.ResponseWriter, r *http.Request) {
 
 	url := fmt.Sprintf(
 		"https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&state=%s&scope=read:user",
-		h.config.GitHubClientID, h.config.RedirectURL, state,
+		h.config.GitHubClientID, h.config.GitHubCallbackURL, state,
 	)
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 }
@@ -109,7 +110,7 @@ func (h *AuthHandler) GitHubCallback(w http.ResponseWriter, r *http.Request) {
 	// Redirect to the frontend with tokens in URL fragment.
 	// The frontend reads the fragment and stores the tokens.
 	redirectTo := fmt.Sprintf("%s#access_token=%s&refresh_token=%s&expires_in=%d",
-		h.config.RedirectURL, pair.AccessToken, pair.RefreshToken, pair.ExpiresIn)
+		h.config.AppRedirectURL, pair.AccessToken, pair.RefreshToken, pair.ExpiresIn)
 	http.Redirect(w, r, redirectTo, http.StatusTemporaryRedirect)
 }
 

--- a/backend/internal/http/handlers/capture.go
+++ b/backend/internal/http/handlers/capture.go
@@ -145,16 +145,18 @@ func (h *CaptureHandler) Capture(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ─── Enqueue enrichment ───
-	// Only for item types where enrichment makes sense — a keyboard
-	// shortcut or a plain note has nothing to fetch.
+	// ─── Enqueue enrichment / AI analysis ───
 	enrichStatus := items.EnrichmentSkipped
-	if shouldEnrich(item.Type) && item.URL != nil && h.queue != nil {
-		h.queue.Enqueue(jobs.EnrichJob{
+	job := jobs.EnrichJob{
 			Kind: jobs.KindItem,
 			ID:   item.ID,
-			URL:  *item.URL,
-		})
+			Type: item.Type,
+		}
+	if item.URL != nil {
+		job.URL = *item.URL
+	}
+	if h.queue != nil && h.queue.CanProcess(job) {
+		h.queue.Enqueue(job)
 		enrichStatus = items.EnrichmentQueued
 		if err := h.store.UpdateItemEnrichmentStatus(r.Context(), item.ID, enrichStatus); err != nil {
 			// Non-fatal: we already created the item, just note the drift.
@@ -173,17 +175,6 @@ func (h *CaptureHandler) Capture(w http.ResponseWriter, r *http.Request) {
 		EnrichmentStatus: enrichStatus,
 		DuplicateOf:      nil,
 	})
-}
-
-// shouldEnrich returns true if the type has data worth fetching from
-// upstream (GitHub API, Open Graph scraping, etc.). Shortcut/snippet/
-// note/prompt are local-only and skip enrichment.
-func shouldEnrich(t items.Type) bool {
-	switch t {
-	case items.TypeRepo, items.TypePlugin, items.TypeArticle, items.TypeTool, items.TypeAgent, items.TypeWorkflow, items.TypeCLI:
-		return true
-	}
-	return false
 }
 
 // sourceLabel caps the cardinality of the source label on the metrics.

--- a/backend/internal/http/handlers/capture_test.go
+++ b/backend/internal/http/handlers/capture_test.go
@@ -217,6 +217,10 @@ func TestCapture_ThreadsSourceAndWhySavedAndTags(t *testing.T) {
 		URL:      "https://dev.to/foo/some-post",
 		Tags:     []string{"go", "productivity"},
 		WhySaved: "for the terminal section",
+		MetaHints: map[string]any{
+			"capture_context": "popup",
+			"page_url":        "https://dev.to/foo/some-post",
+		},
 	})
 	if resp.Item == nil {
 		t.Fatal("nil item")
@@ -229,5 +233,11 @@ func TestCapture_ThreadsSourceAndWhySavedAndTags(t *testing.T) {
 	}
 	if len(resp.Item.Tags) != 2 {
 		t.Errorf("expected 2 tags, got %d", len(resp.Item.Tags))
+	}
+	if got := resp.Item.Meta["capture_context"]; got != "popup" {
+		t.Errorf("capture_context not threaded: %#v", got)
+	}
+	if got := resp.Item.Meta["page_url"]; got != "https://dev.to/foo/some-post" {
+		t.Errorf("page_url not threaded: %#v", got)
 	}
 }

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -71,7 +71,8 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 		authH = handlers.NewAuthHandler(st, as, handlers.AuthConfig{
 			GitHubClientID:     cfg.GitHubClientID,
 			GitHubClientSecret: cfg.GitHubClientSecret,
-			RedirectURL:        cfg.OAuthRedirectURL,
+			GitHubCallbackURL:  cfg.GitHubOAuthCallbackURL,
+			AppRedirectURL:     cfg.AppOAuthRedirectURL,
 			AllowedLogins:      cfg.AllowedLoginsMap(),
 		})
 		r.Route("/api/auth", func(ar chi.Router) {

--- a/backend/internal/jobs/enrich.go
+++ b/backend/internal/jobs/enrich.go
@@ -18,6 +18,8 @@ import (
 	"log/slog"
 	"time"
 
+	"devdeck/internal/ai"
+	"devdeck/internal/domain/items"
 	"devdeck/internal/enricher"
 	"devdeck/internal/metrics"
 	"devdeck/internal/store"
@@ -41,6 +43,7 @@ type EnrichJob struct {
 	Kind EnrichKind
 	ID   uuid.UUID
 	URL  string
+	Type items.Type
 }
 
 // EnrichQueue is the producer-facing handle. Handlers call Enqueue;
@@ -48,6 +51,7 @@ type EnrichJob struct {
 type EnrichQueue struct {
 	ch       chan EnrichJob
 	store    *store.Store
+	ai       *ai.Service
 	enricher *enricher.Service
 	timeout  time.Duration
 }
@@ -55,16 +59,26 @@ type EnrichQueue struct {
 // NewEnrichQueue allocates a queue with the given buffer size. A buffer
 // of 64 is plenty for a single-node deployment; enqueues beyond that
 // drop the oldest waiting job instead of blocking the handler.
-func NewEnrichQueue(st *store.Store, en *enricher.Service, buffer int) *EnrichQueue {
+func NewEnrichQueue(st *store.Store, en *enricher.Service, aiSvc *ai.Service, buffer int) *EnrichQueue {
 	if buffer <= 0 {
 		buffer = 64
 	}
 	return &EnrichQueue{
 		ch:       make(chan EnrichJob, buffer),
 		store:    st,
+		ai:       aiSvc,
 		enricher: en,
 		timeout:  15 * time.Second,
 	}
+}
+
+// CanProcess returns true when the queue has at least one stage that can do
+// useful work for the given job.
+func (q *EnrichQueue) CanProcess(job EnrichJob) bool {
+	if q == nil {
+		return false
+	}
+	return q.canFetchMetadata(job) || q.canRunAI(job)
 }
 
 // Enqueue pushes a job onto the queue without blocking. If the buffer
@@ -105,40 +119,96 @@ func (q *EnrichQueue) run(parent context.Context, job EnrichJob) {
 	ctx, cancel := context.WithTimeout(parent, q.timeout)
 	defer cancel()
 
-	if q.enricher == nil {
+	if !q.CanProcess(job) {
 		metrics.EnrichJobs.WithLabelValues(string(job.Kind), "skipped").Inc()
 		return
 	}
-	md, err := q.enricher.Enrich(ctx, job.URL)
-	if err != nil {
-		level := slog.LevelWarn
-		if errors.Is(err, enricher.ErrNotFound) {
-			level = slog.LevelInfo
+
+	processed := false
+	hadError := false
+
+	if q.canFetchMetadata(job) {
+		md, err := q.enricher.Enrich(ctx, job.URL)
+		if err != nil {
+			level := slog.LevelWarn
+			if errors.Is(err, enricher.ErrNotFound) {
+				level = slog.LevelInfo
+			}
+			slog.Log(ctx, level, "enrich: fetch failed",
+				"err", err, "kind", job.Kind, "id", job.ID, "url", job.URL)
+			hadError = true
+		} else {
+			switch job.Kind {
+			case KindRepo:
+				if _, err := q.store.UpdateMetadata(ctx, job.ID, md); err != nil {
+					slog.Warn("enrich: update repo metadata failed", "err", err, "id", job.ID)
+					hadError = true
+				} else {
+					processed = true
+				}
+			case KindItem:
+				if err := q.store.UpdateItemFromMetadata(ctx, job.ID, md); err != nil {
+					slog.Warn("enrich: update item metadata failed", "err", err, "id", job.ID)
+					hadError = true
+				} else {
+					processed = true
+				}
+			default:
+				slog.Warn("enrich: unknown job kind", "kind", job.Kind)
+				hadError = true
+			}
 		}
-		slog.Log(ctx, level, "enrich: fetch failed",
-			"err", err, "kind", job.Kind, "id", job.ID, "url", job.URL)
-		metrics.EnrichJobs.WithLabelValues(string(job.Kind), "error").Inc()
-		return
 	}
 
-	switch job.Kind {
-	case KindRepo:
-		if _, err := q.store.UpdateMetadata(ctx, job.ID, md); err != nil {
-			slog.Warn("enrich: update repo metadata failed", "err", err, "id", job.ID)
-			metrics.EnrichJobs.WithLabelValues(string(job.Kind), "error").Inc()
-			return
+	if job.Kind == KindItem && q.canRunAI(job) {
+		it, err := q.store.GetItem(ctx, job.ID)
+		if err != nil {
+			slog.Warn("enrich: load item for ai failed", "err", err, "id", job.ID)
+			hadError = true
+		} else {
+			out, err := q.ai.EnrichItem(ctx, it)
+			if err != nil {
+				slog.Warn("enrich: ai enrich failed", "err", err, "id", job.ID)
+				hadError = true
+			}
+			if err := q.store.UpdateItemAIFields(ctx, job.ID, out.Summary, out.Tags); err != nil {
+				slog.Warn("enrich: update item ai fields failed", "err", err, "id", job.ID)
+				hadError = true
+			} else {
+				processed = true
+			}
 		}
-	case KindItem:
-		if err := q.store.UpdateItemFromMetadata(ctx, job.ID, md); err != nil {
-			slog.Warn("enrich: update item metadata failed", "err", err, "id", job.ID)
-			metrics.EnrichJobs.WithLabelValues(string(job.Kind), "error").Inc()
-			return
+	}
+
+	status := "skipped"
+	if processed {
+		status = "ok"
+	} else if hadError {
+		status = "error"
+	}
+	if job.Kind == KindItem {
+		if err := q.store.UpdateItemEnrichmentStatus(ctx, job.ID, items.EnrichmentStatus(status)); err != nil {
+			slog.Warn("enrich: update item status failed", "err", err, "id", job.ID, "status", status)
 		}
+	}
+	metrics.EnrichJobs.WithLabelValues(string(job.Kind), status).Inc()
+}
+
+func (q *EnrichQueue) canRunAI(job EnrichJob) bool {
+	return q != nil && job.Kind == KindItem && q.ai != nil && q.ai.Enabled()
+}
+
+func (q *EnrichQueue) canFetchMetadata(job EnrichJob) bool {
+	if q == nil || q.enricher == nil || job.URL == "" {
+		return false
+	}
+	if job.Kind == KindRepo {
+		return true
+	}
+	switch job.Type {
+	case items.TypeRepo, items.TypePlugin, items.TypeArticle, items.TypeTool, items.TypeAgent, items.TypeWorkflow, items.TypeCLI:
+		return true
 	default:
-		slog.Warn("enrich: unknown job kind", "kind", job.Kind)
-		metrics.EnrichJobs.WithLabelValues(string(job.Kind), "error").Inc()
-		return
+		return false
 	}
-
-	metrics.EnrichJobs.WithLabelValues(string(job.Kind), "ok").Inc()
 }

--- a/backend/internal/store/items.go
+++ b/backend/internal/store/items.go
@@ -210,7 +210,7 @@ func (s *Store) ListItems(ctx context.Context, p items.ListParams) (*items.ListR
 	}
 	if p.Q != "" {
 		where = append(where, fmt.Sprintf(
-			"(title || ' ' || COALESCE(description,'') || ' ' || COALESCE(array_to_string(tags,' '),'')) %% $%d",
+			"(title || ' ' || COALESCE(description,'') || ' ' || COALESCE(ai_summary,'') || ' ' || COALESCE(array_to_string(tags,' '),'') || ' ' || COALESCE(array_to_string(ai_tags,' '),'')) %% $%d",
 			idx,
 		))
 		args = append(args, p.Q)
@@ -415,4 +415,25 @@ func (s *Store) UpdateItemFromMetadata(ctx context.Context, id uuid.UUID, md *re
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+// UpdateItemAIFields stores AI-generated summary and suggestion tags.
+func (s *Store) UpdateItemAIFields(ctx context.Context, id uuid.UUID, summary string, tags []string) error {
+	if tags == nil {
+		tags = []string{}
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE items
+		SET ai_summary = $1,
+		    ai_tags = $2,
+		    updated_at = NOW()
+		WHERE id = $3
+	`, summary, tags, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
 }

--- a/backend/internal/testutil/postgres.go
+++ b/backend/internal/testutil/postgres.go
@@ -1,3 +1,5 @@
+//go:build !(darwin && arm64)
+
 // Package testutil provides shared test infrastructure.
 //
 // The Postgres helper boots a real Postgres container via testcontainers-go,

--- a/backend/internal/testutil/postgres_darwin_arm64.go
+++ b/backend/internal/testutil/postgres_darwin_arm64.go
@@ -1,0 +1,30 @@
+//go:build darwin && arm64
+
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SetupPostgres is a darwin/arm64-specific stub.
+//
+// testcontainers-go currently pulls a native dependency chain that crashes
+// during package initialization on some macOS Apple Silicon environments
+// (`github.com/shoenig/go-m1cpu` via gopsutil). We avoid importing that stack
+// entirely on this platform so local `go test` stays usable.
+//
+// CI runs on Linux and still exercises the real testcontainers-backed helper
+// from postgres.go.
+func SetupPostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	msg := "DB-backed tests disabled on darwin/arm64: testcontainers-go pulls a native dependency that crashes during init (go-m1cpu via gopsutil). Run these tests in Linux CI or another non-Apple-Silicon environment."
+	if os.Getenv("DEVDECK_REQUIRE_DB") == "1" {
+		t.Fatalf(msg)
+	}
+	t.Skip(msg)
+	return nil
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,11 +12,15 @@ Spec completa: [`docs/CAPTURE.md §Canal 2`](../docs/CAPTURE.md#canal-2--cli-dev
 ## Instalación
 
 ```bash
-# Desde el repo:
-go install ./cli/cmd/devdeck
+# Desde el submódulo cli/
+cd cli
+go install ./cmd/devdeck
 
 # (Homebrew tap + Scoop manifest — pendientes)
 ```
+
+> Hoy el CLI se distribuye razonablemente vía `go install` o `go build` dentro de `cli/`.
+> La distribución empaquetada (Homebrew/Scoop) queda para el release público.
 
 ## Primer uso
 
@@ -33,6 +37,7 @@ devdeck status                                          # verificar setup
 | `devdeck add <url\|text>` | Captura un item. Detecta tipo automáticamente. |
 | `devdeck search <query>` | Busca cross-entity en repos + cheatsheets + entries. |
 | `devdeck list` | Lista tus repos (filtros `--lang`, `--tag`, `--query`, `--limit`). |
+| `devdeck open <id>` | Abre la URL fuente de un repo/item en el browser. |
 | `devdeck status` | Imprime config, token y estado del backend. |
 | `devdeck login` / `logout` | Maneja el token en el keychain del OS. |
 | `devdeck config [get\|set]` | Edita `~/.config/devdeck/config.toml`. |
@@ -55,7 +60,16 @@ devdeck import github-stars --user charmbracelet --limit 50
 
 # Buscar
 devdeck search "tui framework"
+
+# Abrir la URL fuente de un repo/item conocido
+devdeck open 2f4d8f3d-7e8a-4f1b-aef7-2d4f4174a123
 ```
+
+## Alcance actual del P0
+
+- El CLI trabaja **online** contra la API; no hay SQLite local ni sync offline todavía.
+- `devdeck open <id>` abre la **URL fuente** del recurso cuando existe.
+- El CLI **no** intenta deducir rutas internas del web app desde `api_url`; si un recurso no tiene `url`, el comando falla con error claro.
 
 ## Dónde vive el estado
 

--- a/cli/cmd/devdeck/open.go
+++ b/cli/cmd/devdeck/open.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"devdeck-cli/internal/apiclient"
+
+	"github.com/spf13/cobra"
+)
+
+var openFlags struct {
+	itemType string
+	print    bool
+}
+
+var openCmd = &cobra.Command{
+	Use:   "open <id>",
+	Short: "Open an item's source URL in the browser",
+	Long: `Resolves a repo or item by ID, extracts its source URL, and opens it
+in the system browser.
+
+P0 behavior is intentionally narrow: if the resource has no source URL,
+the command fails with a clear error instead of guessing an app route from
+the API base URL. That keeps the CLI honest while the hosted/app URL model
+is still evolving.`,
+	Example: `  devdeck open 2f4d8f3d-7e8a-4f1b-aef7-2d4f4174a123
+  devdeck open 2f4d8f3d-7e8a-4f1b-aef7-2d4f4174a123 --type item
+  devdeck open 2f4d8f3d-7e8a-4f1b-aef7-2d4f4174a123 --print`,
+	Args: cobra.ExactArgs(1),
+	RunE: runOpen,
+}
+
+func init() {
+	openCmd.Flags().StringVar(&openFlags.itemType, "type", "auto", "resource type to resolve (auto|repo|item)")
+	openCmd.Flags().BoolVar(&openFlags.print, "print", false, "print the resolved URL instead of opening the browser")
+}
+
+func runOpen(cmd *cobra.Command, args []string) error {
+	client, _, err := loadClient()
+	if err != nil {
+		return err
+	}
+	id := args[0]
+
+	ctx, cancel := withTimeout(cmd.Context(), 10*time.Second)
+	defer cancel()
+
+	resolvedURL, err := resolveOpenURL(ctx, client, id, openFlags.itemType)
+	if err != nil {
+		return err
+	}
+	if openFlags.print {
+		fmt.Fprintln(cmd.OutOrStdout(), resolvedURL)
+		return nil
+	}
+	if err := openBrowser(resolvedURL); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "✓ opened %s\n", resolvedURL)
+	return nil
+}
+
+func resolveOpenURL(ctx context.Context, client *apiclient.Client, id, kind string) (string, error) {
+	switch kind {
+	case "auto":
+		if url, err := resolveRepoURL(ctx, client, id); err == nil {
+			return url, nil
+		} else if !isNotFound(err) {
+			return "", err
+		}
+		return resolveItemURL(ctx, client, id)
+	case "repo":
+		return resolveRepoURL(ctx, client, id)
+	case "item":
+		return resolveItemURL(ctx, client, id)
+	default:
+		return "", fmt.Errorf("invalid --type %q (want auto|repo|item)", kind)
+	}
+}
+
+func resolveRepoURL(ctx context.Context, client *apiclient.Client, id string) (string, error) {
+	repo, err := client.GetRepo(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if repo.URL == "" {
+		return "", errors.New("repo has no source URL")
+	}
+	return repo.URL, nil
+}
+
+func resolveItemURL(ctx context.Context, client *apiclient.Client, id string) (string, error) {
+	item, err := client.GetItem(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if item.URL == nil || *item.URL == "" {
+		return "", fmt.Errorf("item %s (%s) has no source URL to open", item.Title, item.Type)
+	}
+	return *item.URL, nil
+}
+
+func isNotFound(err error) bool {
+	var apiErr *apiclient.APIError
+	return errors.As(err, &apiErr) && apiErr.Status == http.StatusNotFound
+}
+
+func openBrowser(target string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("open", target)
+	case "windows":
+		c = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		c = exec.Command("xdg-open", target)
+	}
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Start(); err != nil {
+		return fmt.Errorf("open browser: %w", err)
+	}
+	return nil
+}

--- a/cli/cmd/devdeck/root.go
+++ b/cli/cmd/devdeck/root.go
@@ -37,6 +37,7 @@ func init() {
 		logoutCmd,
 		configCmd,
 		addCmd,
+		openCmd,
 		searchCmd,
 		listCmd,
 		statusCmd,

--- a/cli/internal/apiclient/client.go
+++ b/cli/internal/apiclient/client.go
@@ -138,6 +138,15 @@ type Repo struct {
 	Tags        []string `json:"tags"`
 }
 
+// GetRepo returns one repo by ID from /api/repos/{id}.
+func (c *Client) GetRepo(ctx context.Context, id string) (*Repo, error) {
+	var body Repo
+	if err := c.do(ctx, http.MethodGet, "/api/repos/"+url.PathEscape(id), nil, &body); err != nil {
+		return nil, err
+	}
+	return &body, nil
+}
+
 type listReposResponse struct {
 	Total int    `json:"total"`
 	Items []Repo `json:"items"`
@@ -167,6 +176,25 @@ func (c *Client) ListRepos(ctx context.Context, p ListReposParams) ([]Repo, int,
 		return nil, 0, err
 	}
 	return body.Items, body.Total, nil
+}
+
+// ─── Items ───
+
+// ItemDetail is the subset the CLI needs from GET /api/items/{id}.
+type ItemDetail struct {
+	ID    string  `json:"id"`
+	Type  string  `json:"item_type"`
+	Title string  `json:"title"`
+	URL   *string `json:"url"`
+}
+
+// GetItem returns one polymorphic item by ID from /api/items/{id}.
+func (c *Client) GetItem(ctx context.Context, id string) (*ItemDetail, error) {
+	var body ItemDetail
+	if err := c.do(ctx, http.MethodGet, "/api/items/"+url.PathEscape(id), nil, &body); err != nil {
+		return nil, err
+	}
+	return &body, nil
 }
 
 // ─── Health ───

--- a/cli/internal/apiclient/client_test.go
+++ b/cli/internal/apiclient/client_test.go
@@ -173,6 +173,40 @@ func TestListRepos_BuildsFilters(t *testing.T) {
 	}
 }
 
+func TestGetRepo_FetchesByID(t *testing.T) {
+	fb := newFakeBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"1","name":"foo","url":"https://github.com/u/foo","stars":42}`))
+	})
+	client := New(fb.server.URL, "t")
+	repo, err := client.GetRepo(context.Background(), "repo-123")
+	if err != nil {
+		t.Fatalf("GetRepo: %v", err)
+	}
+	if fb.lastReq.path != "/api/repos/repo-123" {
+		t.Errorf("path = %s", fb.lastReq.path)
+	}
+	if repo.URL != "https://github.com/u/foo" {
+		t.Errorf("url = %q", repo.URL)
+	}
+}
+
+func TestGetItem_FetchesByID(t *testing.T) {
+	fb := newFakeBackend(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"1","item_type":"article","title":"rg docs","url":"https://rg.dev"}`))
+	})
+	client := New(fb.server.URL, "t")
+	item, err := client.GetItem(context.Background(), "item-123")
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if fb.lastReq.path != "/api/items/item-123" {
+		t.Errorf("path = %s", fb.lastReq.path)
+	}
+	if item.URL == nil || *item.URL != "https://rg.dev" {
+		t.Errorf("url = %+v", item.URL)
+	}
+}
+
 func TestHealth_OK(t *testing.T) {
 	fb := newFakeBackend(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,16 +1,22 @@
 # DevDeck local dev environment
 # Copy to deploy/.env and adjust as needed
 
-PG_PASS=devdeck_local_pass
-AUTH_MODE=token
-API_TOKEN=change_me_use_openssl_rand_hex_32
+DOMAIN=devdeck.local
+APP_DOMAIN=app.devdeck.local
+API_DOMAIN=api.devdeck.local
+POSTGRES_USER=devdeck
+POSTGRES_PASSWORD=devdeck_local_pass
+POSTGRES_DB=devdeck
+AUTH_MODE=jwt
+API_TOKEN=
 JWT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback
+GITHUB_OAUTH_CALLBACK_URL=http://localhost:8080/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback
 ALLOWED_GITHUB_LOGINS=
 GITHUB_TOKEN=
 LOG_LEVEL=info
 REFRESH_INTERVAL_HOURS=168
 SEED_CHEATSHEETS=true
-CORS_ORIGINS=app://.,http://localhost:5173,http://localhost:4173
+CORS_ORIGINS=http://localhost:5173,http://localhost:4173,app://.

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -4,10 +4,9 @@
 # Caddy provisions a Let's Encrypt cert automatically the first time
 # the domain resolves to this server.
 
-{$DOMAIN} {
+{$API_DOMAIN} {
     encode gzip zstd
 
-    # Health check is public; everything else hits the API which enforces auth.
     handle /healthz {
         reverse_proxy api:8080
     }
@@ -16,7 +15,6 @@
         reverse_proxy api:8080
     }
 
-    # Anything else gets a 404 from Caddy (we don't serve a web client yet).
     handle {
         respond "DevDeck API" 200
     }
@@ -26,4 +24,19 @@
         format console
         level INFO
     }
+}
+
+{$APP_DOMAIN} {
+    encode gzip zstd
+    reverse_proxy web:80
+
+    log {
+        output stdout
+        format console
+        level INFO
+    }
+}
+
+{$DOMAIN} {
+    redir https://{$APP_DOMAIN}{uri} permanent
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,13 +1,14 @@
 # DevDeck — Deploy
 
-Deploy del backend Go + Postgres + Caddy a un VPS Linux.
+Deploy de DevDeck web + API + Postgres + Caddy a un VPS Linux.
 
 ## 0. Requisitos en el VPS
 
 - Ubuntu 22.04+ / Debian 12+ (cualquier distro con Docker funciona)
 - Docker + Docker Compose plugin instalados
 - Puertos `80` y `443` abiertos
-- Un dominio (o subdominio) apuntando al IP del VPS via registro `A`
+- Dominios apuntando al IP del VPS via registro `A`
+  - Ejemplo: `app.devdeck.tudominio.com  →  1.2.3.4`
   - Ejemplo: `api.devdeck.tudominio.com  →  1.2.3.4`
 
 ### Instalar Docker (si no lo tenés)
@@ -28,7 +29,7 @@ cd devdeck/deploy
 ## 2. Generar secretos
 
 ```bash
-# API token (largo, random)
+# JWT secret
 openssl rand -hex 32
 
 # Postgres password
@@ -42,20 +43,31 @@ Guardalos a mano — los vas a necesitar en el siguiente paso.
 Creá `deploy/.env` con este contenido:
 
 ```env
-# Dominio que apunta al VPS
-DOMAIN=api.devdeck.tudominio.com
+# Dominios que apuntan al VPS
+DOMAIN=devdeck.tudominio.com
+APP_DOMAIN=app.devdeck.tudominio.com
+API_DOMAIN=api.devdeck.tudominio.com
 
 # Postgres
-PG_PASS=<el-base64-de-arriba>
+POSTGRES_USER=devdeck
+POSTGRES_PASSWORD=<el-base64-de-arriba>
+POSTGRES_DB=devdeck
 
 # Backend
-API_TOKEN=<el-hex-de-arriba>
+AUTH_MODE=jwt
+JWT_SECRET=<el-hex-de-arriba>
+GITHUB_CLIENT_ID=<oauth-app-client-id>
+GITHUB_CLIENT_SECRET=<oauth-app-client-secret>
+GITHUB_OAUTH_CALLBACK_URL=https://api.devdeck.tudominio.com/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=https://app.devdeck.tudominio.com/auth/callback
+ALLOWED_GITHUB_LOGINS=tu-login
 GITHUB_TOKEN=                # opcional, ghp_... para 5000 req/h en lugar de 60
 
 # Optional tuning
 LOG_LEVEL=info
-CORS_ORIGINS=app://.,http://localhost:5173
+CORS_ORIGINS=https://app.devdeck.tudominio.com,app://.
 REFRESH_INTERVAL_HOURS=168
+SEED_CHEATSHEETS=true
 ```
 
 > ⚠️ **Nunca** commitees `.env`. Está en `.gitignore`.
@@ -68,9 +80,9 @@ docker compose up -d --build
 
 Esto va a:
 1. Buildear `devdeck-api:latest` desde `../backend/Dockerfile`
-2. Bajar `postgres:16-alpine` y `caddy:2-alpine`
-3. Levantar los 3 servicios
-4. **Caddy provisiona el certificado TLS automáticamente** la primera vez que tu dominio resuelva al VPS (Let's Encrypt)
+2. Buildear `devdeck-web:latest` desde `../apps/web/Dockerfile`
+3. Levantar `db`, `migrate`, `api`, `web`, `caddy`
+4. **Caddy provisiona los certificados TLS automáticamente** la primera vez que los dominios resuelvan al VPS (Let's Encrypt)
 
 Verificá que arrancaron:
 
@@ -79,33 +91,25 @@ docker compose ps
 docker compose logs -f api
 ```
 
-## 5. Aplicar la migración inicial (solo la primera vez)
-
-```bash
-docker compose exec -T db psql -U devdeck devdeck \
-  < ../backend/migrations/0001_init.sql
-```
-
-## 6. Probar que está vivo
+## 5. Probar que está vivo
 
 ```bash
 # Health (público)
 curl https://api.devdeck.tudominio.com/healthz
 
-# Auth check
-curl -H "Authorization: Bearer $API_TOKEN" \
-  https://api.devdeck.tudominio.com/api/repos
+# Frontend
+curl -I https://app.devdeck.tudominio.com
 ```
 
-Si todo está bien, vas a ver `{"status":"ok"}` y `{"total":0,"items":[]}`.
+Si todo está bien, vas a ver `{"status":"ok"}` y un `200 OK` del frontend.
 
-## 7. Apuntar el cliente Electron al VPS
+## 6. Apuntar el cliente Electron al VPS
 
 En tu máquina local, en `desktop/.env`:
 
 ```env
 VITE_API_URL=https://api.devdeck.tudominio.com
-VITE_API_TOKEN=<el-mismo-API_TOKEN-del-VPS>
+VITE_AUTH_MODE=jwt
 ```
 
 Después rebuildeás el desktop con `npm run build:win` (Fase 6) y listo: tu DevDeck instalado en Windows habla con tu VPS.
@@ -143,11 +147,11 @@ gunzip -c backups/devdeck-2026-04-07.sql.gz \
 docker compose exec db psql -U devdeck devdeck
 ```
 
-### Rotar el API token
+### Rotar el JWT secret
 1. Generá uno nuevo con `openssl rand -hex 32`
 2. Editá `.env`
 3. `docker compose up -d api` (recrea solo el container del api)
-4. Actualizá también `desktop/.env` y rebuildeá el cliente
+4. Todos los tokens existentes quedan inválidos; los users deben reloguearse
 
 ---
 
@@ -162,8 +166,10 @@ docker compose exec db psql -U devdeck devdeck
 - Casi siempre es `DB_URL` mal escrito o el container `db` todavía no terminó de inicializar (la primera vez puede tardar 10-20s)
 - `docker compose logs db` y `docker compose logs api` te dicen qué pasa
 
-### "API_TOKEN is required when AUTH_MODE=token"
-- Olvidaste setear `API_TOKEN` en `.env`. Editá y `docker compose up -d api`.
+### Login OAuth falla o vuelve mal al frontend
+- Verificá que `GITHUB_OAUTH_CALLBACK_URL` sea `https://api.../api/auth/github/callback`.
+- Verificá que `APP_OAUTH_REDIRECT_URL` sea `https://app.../auth/callback`.
+- Si usás un dominio raíz, `DOMAIN` redirige al `APP_DOMAIN`.
 
 ### Quedé fuera por rate limit de GitHub
 - Conseguite un PAT (Settings → Developer settings → Personal access tokens → Generate new) con scope `public_repo`

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: devdeck
-      POSTGRES_PASSWORD: ${PG_PASS}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-devdeck}
       POSTGRES_DB: devdeck
     ports:
       - "5432:5432"
@@ -24,7 +24,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      PGPASSWORD: ${PG_PASS}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-devdeck}
     volumes:
       - ../backend/migrations:/migrations:ro
     # Extract only the +goose Up section (stop at +goose Down) before running.
@@ -52,13 +52,14 @@ services:
         condition: service_completed_successfully
     environment:
       PORT: "8080"
-      DB_URL: postgres://devdeck:${PG_PASS}@db:5432/devdeck?sslmode=disable
+      DB_URL: postgres://devdeck:${POSTGRES_PASSWORD:-devdeck}@db:5432/devdeck?sslmode=disable
       AUTH_MODE: ${AUTH_MODE:-token}
       API_TOKEN: ${API_TOKEN}
       JWT_SECRET: ${JWT_SECRET:-}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
-      OAUTH_REDIRECT_URL: ${OAUTH_REDIRECT_URL:-http://localhost:5173/auth/callback}
+      GITHUB_OAUTH_CALLBACK_URL: ${GITHUB_OAUTH_CALLBACK_URL:-http://localhost:8080/api/auth/github/callback}
+      APP_OAUTH_REDIRECT_URL: ${APP_OAUTH_REDIRECT_URL:-http://localhost:5173/auth/callback}
       ALLOWED_GITHUB_LOGINS: ${ALLOWED_GITHUB_LOGINS:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       LOG_LEVEL: ${LOG_LEVEL:-debug}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,15 +1,15 @@
 # DevDeck production stack — runs on the VPS.
 #
-# Three services:
-#   db     — Postgres 16, persistent volume
-#   api    — Go API, built from ../backend/Dockerfile
-#   caddy  — Reverse proxy with automatic Let's Encrypt TLS
+# Five services:
+#   db       — Postgres 16, persistent volume
+#   migrate  — one-shot SQL migrations runner
+#   api      — Go API, built from ../backend/Dockerfile
+#   web      — React SPA, built from ../apps/web/Dockerfile
+#   caddy    — Reverse proxy with automatic Let's Encrypt TLS
 #
 # Setup:
 #   1. cp .env.example .env  &&  edit values
 #   2. docker compose up -d
-#   3. (first time only) apply migration:
-#      docker compose exec -T db psql -U devdeck devdeck < ../backend/migrations/0001_init.sql
 
 services:
   db:
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: devdeck
-      POSTGRES_PASSWORD: ${PG_PASS}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: devdeck
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -31,6 +31,30 @@ services:
     networks:
       - internal
 
+  migrate:
+    image: postgres:16-alpine
+    container_name: devdeck-migrate
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ../backend/migrations:/migrations:ro
+    command: >-
+      sh -c '
+        set -e
+        run() { awk "/-- [+]goose Down/{exit} {print}" "/migrations/$1" | psql -h db -U "$POSTGRES_USER" -d "$POSTGRES_DB"; }
+        for f in $(ls /migrations/*.sql | xargs -n1 basename | sort); do
+          echo "Applying $$f"
+          run "$$f"
+        done
+        echo "All migrations applied."
+      '
+    restart: "no"
+    networks:
+      - internal
+
   api:
     build:
       context: ../backend
@@ -39,21 +63,46 @@ services:
     container_name: devdeck-api
     restart: unless-stopped
     depends_on:
-      db:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     environment:
       PORT: "8080"
-      DB_URL: postgres://devdeck:${PG_PASS}@db:5432/devdeck?sslmode=disable
-      AUTH_MODE: token
-      API_TOKEN: ${API_TOKEN}
+      DB_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable
+      AUTH_MODE: ${AUTH_MODE:-jwt}
+      API_TOKEN: ${API_TOKEN:-}
+      JWT_SECRET: ${JWT_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      GITHUB_OAUTH_CALLBACK_URL: https://${API_DOMAIN}/api/auth/github/callback
+      APP_OAUTH_REDIRECT_URL: https://${APP_DOMAIN}/auth/callback
+      ALLOWED_GITHUB_LOGINS: ${ALLOWED_GITHUB_LOGINS:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      CORS_ORIGINS: ${CORS_ORIGINS:-app://.}
+      CORS_ORIGINS: ${CORS_ORIGINS:-https://${APP_DOMAIN},app://.}
       REFRESH_INTERVAL_HOURS: ${REFRESH_INTERVAL_HOURS:-168}
+      SEED_CHEATSHEETS: ${SEED_CHEATSHEETS:-true}
     expose:
       - "8080"
     networks:
       - internal
+      - web
+
+  web:
+    build:
+      context: ..
+      dockerfile: apps/web/Dockerfile
+      args:
+        VITE_API_URL: https://${API_DOMAIN}
+        VITE_AUTH_MODE: jwt
+    image: devdeck-web:latest
+    container_name: devdeck-web
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_started
+    expose:
+      - "80"
+    networks:
       - web
 
   caddy:
@@ -66,6 +115,8 @@ services:
       - "443:443/udp" # HTTP/3
     environment:
       DOMAIN: ${DOMAIN}
+      API_DOMAIN: ${API_DOMAIN}
+      APP_DOMAIN: ${APP_DOMAIN}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -505,21 +505,20 @@ CREATE INDEX idx_sessions_user ON sessions(user_id);
 |-----|-------------|---------|
 | `PORT` | Puerto del API | `8080` |
 | `DB_URL` | Conn string Postgres | required |
-| `AUTH_MODE` | `token` (Ola 1) o `jwt` (Ola 4) | `token` |
+| `AUTH_MODE` | `token` (legacy/dev) o `jwt` (modo productivo) | `token` |
 | `API_TOKEN` | Bearer token único (modo `token`) | required en modo token |
 | `GITHUB_TOKEN` | PAT para rate limit del enricher | optional |
 | `LOG_LEVEL` | debug/info/warn/error | `info` |
 | `CORS_ORIGINS` | CSV de origins permitidos | `app://.` |
 | `REFRESH_INTERVAL_HOURS` | Cron metadata refresh | `168` (7d) |
-| `OAUTH_GITHUB_CLIENT_ID` 🌊4 | OAuth App client ID | required en modo jwt |
-| `OAUTH_GITHUB_CLIENT_SECRET` 🌊4 | OAuth App secret | required en modo jwt |
-| `OAUTH_REDIRECT_URL` 🌊4 | Callback URL público | required en modo jwt |
+| `GITHUB_CLIENT_ID` 🌊4 | OAuth App client ID | required en modo jwt |
+| `GITHUB_CLIENT_SECRET` 🌊4 | OAuth App secret | required en modo jwt |
+| `GITHUB_OAUTH_CALLBACK_URL` 🌊4 | Callback GitHub → backend | required en modo jwt |
+| `APP_OAUTH_REDIRECT_URL` 🌊4 | Redirect backend → frontend | required en modo jwt |
 | `JWT_SECRET` 🌊4 | HMAC secret para firmar JWT | required en modo jwt |
-| `JWT_ACCESS_TTL` 🌊4 | TTL access token | `30d` |
-| `JWT_REFRESH_TTL` 🌊4 | TTL refresh token | `90d` |
 | `ALLOWED_GITHUB_LOGINS` 🌊4 | CSV de usernames permitidos | required en modo jwt |
 
-Cliente Electron lee `API_BASE_URL` y `API_TOKEN` de un config encriptado con `safeStorage`.
+Cliente Electron configura `baseUrl` y auth vía `configureApiClient()`; en desktop el storage de tokens usa `safeStorage` via IPC.
 
 ---
 
@@ -528,32 +527,11 @@ Cliente Electron lee `API_BASE_URL` y `API_TOKEN` de un config encriptado con `s
 `deploy/docker-compose.yml`:
 ```yaml
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_PASSWORD: ${PG_PASS}
-      POSTGRES_DB: devdeck
-    volumes: [pgdata:/var/lib/postgresql/data]
-    restart: unless-stopped
-
-  api:
-    image: ghcr.io/tfurt/devdeck-api:latest
-    environment:
-      DB_URL: postgres://postgres:${PG_PASS}@db:5432/devdeck?sslmode=disable
-      API_TOKEN: ${API_TOKEN}
-      GITHUB_TOKEN: ${GITHUB_TOKEN}
-    depends_on: [db]
-    restart: unless-stopped
-
-  caddy:
-    image: caddy:2-alpine
-    ports: ["80:80","443:443"]
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    depends_on: [api]
-    restart: unless-stopped
+  db: {}
+  migrate: {}
+  api: {}
+  web: {}
+  caddy: {}
 
 volumes:
   pgdata:
@@ -563,13 +541,18 @@ volumes:
 
 `deploy/Caddyfile`:
 ```
-api.devdeck.tu-dominio.com {
+{$API_DOMAIN} {
   reverse_proxy api:8080
-  encode gzip
+  encode gzip zstd
+}
+
+{$APP_DOMAIN} {
+  reverse_proxy web:80
+  encode gzip zstd
 }
 ```
 
-CI/CD: GitHub Action que en push a `main` → builda binario Go → push imagen a GHCR → SSH al VPS → `docker compose pull && docker compose up -d`.
+CI/CD: ver `.github/workflows/ci.yml` — backend, CLI, monorepo y E2E. El deploy self-hosted actual se documenta en `deploy/README.md` y `docs/SELF_HOSTING.md`.
 
 ---
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -117,10 +117,10 @@ Solo Chrome, solo captura de tab activa, solo `repo`/`article`/`tool`, sin detec
 ## Canal 2 — CLI `devdeck`
 
 ### Spec
-Binario Go único, distribuido via Homebrew (`brew install devdeck`), Scoop (Windows), y `go install github.com/user/devdeck/cli@latest`.
+Binario Go único. El estado actual del repo soporta `go install`/`go build`; Homebrew y Scoop siguen como objetivo de release, no como distribución ya cerrada.
 
 ```bash
-devdeck login                              # OAuth flow, abre browser
+devdeck login --token <api-token>          # guarda token en OS keychain
 devdeck config set api-url https://api.devdeck.ai
 devdeck config set api-url http://localhost:8080   # self-hosters
 
@@ -129,25 +129,25 @@ devdeck add https://rg.dev --type=cli      # forzar tipo
 devdeck add "Cmd+Shift+P" --type=shortcut --tags=vscode,productivity
 echo 'rg --glob "*.go" "TODO"' | devdeck add --type=snippet --lang=bash
 
-devdeck search "debugging go"              # devuelve top 10, abrir con número
-devdeck open <id>                          # abre en browser / en la app
-devdeck run <alias>                        # ejecuta un comando guardado
-devdeck run deploy --env=staging           # con variables
+devdeck search "debugging go"              # devuelve top 10
+devdeck open <id>                           # abre la URL fuente del repo/item en el browser
+# devdeck run <alias>                      # futuro, no implementado
+# devdeck run deploy --env=staging         # futuro, no implementado
 
 devdeck list --type=cli
 devdeck import github-stars                # importa GitHub Stars del user
-devdeck import pocket ~/exports/pocket.html
+# devdeck import pocket ~/exports/pocket.html  # futuro, no implementado
 
-devdeck sync                               # fuerza sync manual (normalmente automático)
-devdeck status                             # qué tiene en cola, última sync
+# devdeck sync                             # futuro, no implementado
+devdeck status                             # config, token y health del backend
 ```
 
 ### Implementación
-- `cobra` para CLI, `charmbracelet/bubbletea` para TUI opcional (`devdeck ui`).
+- `cobra` para CLI. Bubbletea/TUI sigue como opción futura (`devdeck ui`), no implementada.
 - Token guardado en OS keychain via `zalando/go-keyring`.
 - Config en `~/.config/devdeck/config.toml`.
-- SQLite local en `~/.local/share/devdeck/devdeck.db` para queue offline y cache read.
-- Todas las operaciones locales primero, sync al servidor después.
+- Hoy no hay SQLite local ni cola offline en el CLI; eso queda para una etapa posterior si el canal terminal demuestra suficiente uso.
+- Hoy el CLI opera online contra la API: una request por comando, sin sync local.
 
 ### `devdeck run <alias>` — ejecutor de comandos
 - Busca el comando por alias/título en el vault.
@@ -181,7 +181,9 @@ cli/
 ```
 
 ### Primer milestone (P0)
-`login`, `add <url>`, `search`, `list`. El resto (import, run, TUI) viene después.
+Implementado hoy: `login`, `logout`, `config`, `add <url|text>`, `search`, `list`, `open <id>`, `status`, `import github-stars`.
+
+**Nota de alcance:** el `open <id>` actual abre la **URL fuente** del repo/item cuando existe. No intenta deducir rutas internas de la app (`app.devdeck...`) desde `api_url`; si el recurso no tiene `url`, falla con error claro.
 
 ---
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -87,9 +87,11 @@ Entrada polimórfica, detección de tipo automática en el servidor.
   - Textarea `why_saved` (autofocus).
   - Chips de tags sugeridos (vienen del vault del user via `/api/tags/suggest`).
   - Botón `Save` (Enter).
-- Autenticación: login inicial vía `/api/auth/github/login` con redirect al popup; token guardado en `chrome.storage.local` + sync.
+- Autenticación hoy: token/JWT manual configurado en Options y guardado en `chrome.storage.local`. Futuro: login vía `/api/auth/github/login` con redirect al popup.
 - Backend URL configurable (para self-hosters).
 - **Offline queue:** si el POST falla, guardar en `chrome.storage.local` y reintentar cada 60s o cuando vuelva la red.
+- Context menu: guardar link y guardar selección como snippet sin abrir el popup.
+- Los canales de extensión pueden adjuntar `meta_hints` con contexto de página (`page_url`, `page_title`, `capture_context`) para mejorar trazabilidad y enriquecimiento posterior.
 
 ### Estructura
 ```
@@ -110,7 +112,7 @@ extension/
 ```
 
 ### Primer milestone (P0)
-Solo Chrome, solo captura de tab activa, solo `repo`/`article`/`tool`, sin detección avanzada. Cuando funciona, expandir a selección, shortcuts, Firefox.
+Estado actual: Chrome/Chromium con captura de tab activa por shortcut o popup, cola offline, badge de pendientes, context menu para links/selección y configuración manual de backend + token/JWT. Cuando esto quede sólido, expandir a Firefox/OAuth/tags sugeridos.
 
 ---
 

--- a/docs/CAPTURE.md
+++ b/docs/CAPTURE.md
@@ -69,8 +69,9 @@ Entrada polimórfica, detección de tipo automática en el servidor.
 - Encolar job en background worker.
 - Para `repo`: llamar GitHub API como ya hace `enricher/github.go`.
 - Para `tool`/`article`: scraping Open Graph (con SSRF guard, ver REVIEW §3.4).
-- Para todos: auto-tagging + summary con IA (si habilitada, ver Ola 6).
-- Al terminar, emitir evento a través de SSE/WebSocket: `item.enriched { id }` para que el cliente refresque.
+- Para todos: auto-tagging + summary local/heurístico si `AI_PROVIDER=heuristic` (o `local`).
+- Si `AI_PROVIDER=disabled`, solo corre el enrichment clásico de metadata cuando aplique.
+- Hoy NO hay SSE/WebSocket para refresco automático de items; el cliente ve el resultado al refetchear la lista/detalle.
 
 ---
 

--- a/docs/Runbooks/Setup Local.md
+++ b/docs/Runbooks/Setup Local.md
@@ -1,0 +1,396 @@
+---
+tags:
+  - runbook
+  - devdeck
+  - local-development
+aliases:
+  - Local Dev Setup
+  - Setup
+type: runbook
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🚀 Runbook — Setup Local Development
+
+> Cómo levantar DevDeck en tu máquina para desarrollo.
+
+---
+
+## 📋 Pre-requisitos
+
+```bash
+# Verificar que los tienes instalados:
+node --version          # v18+ (recomendado v20+)
+pnpm --version          # v10+ (package manager)
+go version              # 1.21+ (backend)
+docker --version        # Docker Desktop (database)
+git --version           # v2.37+
+```
+
+### Instalar si falta algo
+
+```bash
+# macOS (Homebrew)
+brew install node
+brew install pnpm
+brew install go
+brew install docker
+brew install git
+
+# Linux (Ubuntu/Debian)
+sudo apt-get install nodejs npm
+npm install -g pnpm
+sudo apt-get install golang-go
+sudo apt-get install docker.io
+```
+
+---
+
+## 🔧 Setup Paso a Paso
+
+### 1. Clonar el repositorio
+
+```bash
+git clone https://github.com/devdeckai/dev_deck.git
+cd dev_deck
+```
+
+### 2. Instalar dependencias (Frontend + Backend)
+
+```bash
+# Frontend: pnpm workspaces
+pnpm install
+
+# Verificar que todo está instalado
+pnpm -r list --depth=0 | grep "@devdeck"
+# Debe mostrar: @devdeck/ui, @devdeck/api-client, @devdeck/features
+```
+
+### 3. Levantar PostgreSQL (Docker)
+
+```bash
+# En la raíz del proyecto, usar el compose local
+docker compose -f deploy/docker-compose.local.yml up -d db migrate api
+
+# Verificar que PostgreSQL está corriendo
+docker ps | grep postgres
+
+# Esperar ~5 segundos para que levante completamente
+sleep 5
+
+# Ver logs (opcional)
+docker compose -f deploy/docker-compose.local.yml logs db
+```
+
+### 4. Configurar variables de entorno
+
+```bash
+# Backend
+cat > backend/.env << 'EOF'
+DB_URL=postgres://devdeck:devdeck@localhost:5432/devdeck?sslmode=disable
+PORT=8080
+AUTH_MODE=jwt
+JWT_SECRET=devdeck-local-jwt-secret
+GITHUB_CLIENT_ID=stub
+GITHUB_CLIENT_SECRET=stub
+GITHUB_OAUTH_CALLBACK_URL=http://localhost:8080/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=http://localhost:5173/auth/callback
+LOG_LEVEL=debug
+SEED_CHEATSHEETS=true
+EOF
+
+# Desktop
+cat > apps/desktop/.env << 'EOF'
+VITE_API_URL=http://localhost:8080
+VITE_AUTH_MODE=token
+VITE_API_TOKEN=devdeck-local-token
+VITE_ENV=development
+EOF
+
+# Web
+cat > apps/web/.env << 'EOF'
+VITE_API_URL=http://localhost:8080
+VITE_AUTH_MODE=jwt
+VITE_ENV=development
+EOF
+```
+
+### 5. Ejecutar migraciones de base de datos
+
+Con `deploy/docker-compose.local.yml`, las migraciones corren automáticamente en el servicio `migrate`.
+
+```bash
+# Verificar que migrate terminó bien
+docker compose -f deploy/docker-compose.local.yml logs migrate
+
+# Verificar que las tablas existen
+docker compose -f deploy/docker-compose.local.yml exec db \
+  psql -U devdeck -d devdeck -c "\dt"
+```
+
+### 6. Levantar el backend (Go)
+
+```bash
+# En la raíz o en backend/
+cd backend
+
+# Terminal 1: Backend API (si no querés usar el container api local)
+go run ./cmd/api
+
+# Debe mostrar algo como:
+# INFO ... msg="server starting" addr=":8080"
+
+# Verificar que está vivo
+curl http://localhost:8080/healthz
+# Respuesta: {"status":"ok"}
+```
+
+### 7. Levantar el frontend (Web o Desktop)
+
+```bash
+# Terminal 2 (desde raíz)
+
+# OPCIÓN A: Web (React + Vite)
+pnpm dev:web
+# Abre http://localhost:5173
+
+# OPCIÓN B: Desktop (Electron)
+pnpm dev:desktop
+# Se abre una ventana de Electron
+
+# Ambas: ejecutar secuencialmente si quieres ambas
+pnpm dev:web &
+pnpm dev:desktop
+```
+
+---
+
+## ✅ Verificar que todo funciona
+
+### Checklist
+
+```bash
+✅ Backend running (http://localhost:8080/healthz)
+✅ PostgreSQL running (docker ps)
+✅ Web available (http://localhost:5173)
+✅ Database has tables (psql -c "\dt")
+
+# Si algo no funciona, ver siguiente sección
+```
+
+### Test rápido
+
+```bash
+# 1. Backend API
+curl http://localhost:8080/healthz
+# {"status":"ok"}
+
+# 2. List repos (modo token para desktop dev)
+curl http://localhost:8080/api/repos \
+  -H "Authorization: Bearer devdeck-local-token"
+
+# 3. Frontend
+open http://localhost:5173
+# Verás la UI
+```
+
+---
+
+## 🐛 Troubleshooting
+
+### "Connection refused on localhost:5432"
+
+```bash
+# PostgreSQL no está corriendo
+docker compose -f deploy/docker-compose.local.yml up -d db migrate api
+
+# Esperar ~5 segundos
+sleep 5
+
+# Verificar
+docker ps | grep postgres
+```
+
+### "database does not exist"
+
+```bash
+# Revisar logs del servicio migrate
+docker compose -f deploy/docker-compose.local.yml logs migrate
+```
+
+### "pnpm: command not found"
+
+```bash
+npm install -g pnpm
+# O en macOS:
+brew install pnpm
+
+# Verificar
+pnpm --version
+```
+
+### Backend: "Address already in use :3000"
+
+```bash
+# Algo ya está usando puerto 3000
+lsof -i :3000
+kill -9 <PID>
+
+# O cambiar puerto en backend/.env
+PORT=3001
+```
+
+### Web: "CORS error" en console
+
+```bash
+# El backend CORS no está configurado correctamente
+# Verificar backend/internal/http/router.go
+
+# Asegurar que VITE_API_URL apunta al backend correcto
+echo $VITE_API_URL
+# Debe ser: http://localhost:8080
+```
+
+### Desktop: "Cannot find electron"
+
+```bash
+# No se instalaron dependencias de desktop
+cd apps/desktop
+pnpm install
+
+# O desde raíz
+pnpm install
+```
+
+---
+
+## 📁 Estructura de carpetas (overview)
+
+```
+dev_deck/
+├── backend/                 # Go API
+│   ├── cmd/api/main.go
+│   ├── internal/
+│   │   ├── domain/         # Business logic
+│   │   ├── http/           # HTTP handlers
+│   │   └── store/          # Database layer
+│   ├── migrations/         # SQL migrations (5 files)
+│   └── .env
+│
+├── apps/
+│   ├── desktop/            # Electron app
+│   │   ├── src/
+│   │   │   ├── main.ts     # Electron main process
+│   │   │   └── App.tsx     # React renderer
+│   │   └── .env
+│   │
+│   └── web/                # Web app
+│       ├── src/
+│       │   ├── main.tsx
+│       │   └── App.tsx
+│       └── .env
+│
+├── packages/
+│   ├── ui/                 # Design system
+│   ├── api-client/         # TanStack Query hooks
+│   └── features/           # Shared pages + components
+│
+├── docs/                   # Documentation
+│   ├── Architecture/
+│   ├── PRD/
+│   ├── Runbooks/
+│   └── adr/
+│
+└── deploy/
+    ├── docker-compose.yml
+    └── Caddyfile (production)
+```
+
+---
+
+## 🧪 Ejecutar tests
+
+```bash
+# Backend tests
+cd backend
+go test ./...
+
+# Frontend tests (Vitest)
+pnpm -F @devdeck/ui test
+pnpm -F @devdeck/api-client test
+pnpm -F @devdeck/features test
+pnpm -F @devdeck/desktop test
+
+# E2E tests (Playwright)
+pnpm -F @devdeck/web e2e
+
+# Todos los tests
+pnpm test
+```
+
+---
+
+## 🔧 Debugging
+
+### Backend (Go)
+
+```bash
+# Con verbose logging
+LOG_LEVEL=debug go run ./cmd/api/main.go
+
+# Con debugger (dlv)
+go install github.com/go-delve/delve/cmd/dlv@latest
+dlv debug ./cmd/api
+(dlv) continue
+(dlv) break main.main
+(dlv) c
+```
+
+### Frontend (Web)
+
+```bash
+# Chrome DevTools abre automáticamente
+pnpm dev:web
+# F12 para abrir DevTools
+
+# Debugger breakpoints
+# En el código: debugger;
+// En src/main.tsx
+debugger;
+```
+
+### Frontend (Desktop)
+
+```bash
+# Electron DevTools
+pnpm dev:desktop
+
+# Presiona: Cmd+Option+I (macOS) o Ctrl+Shift+I (Linux/Windows)
+# Para abrir DevTools
+```
+
+---
+
+## 📚 Documentos relacionados
+
+- **[[Runbooks/Testing]]** — Estrategia de tests completa
+- **[[Runbooks/Deployment]]** — Deployment a producción
+- **[[Backend/Backend MOC]]** — Estructura del backend
+- **[[Frontend/Frontend MOC]]** — Estructura del frontend
+
+---
+
+## 🎯 Próximos pasos
+
+1. **Leer el código:** Empieza en `backend/cmd/api/main.go` o `apps/web/src/App.tsx`
+2. **Crear un item:** Usa CaptureModal para guardar un repo
+3. **Escribir un test:** Agrega un test en `backend/internal/http/handlers/items_test.go`
+4. **Hacer un cambio:** Modifica un handler y verifica que los tests pasen
+
+---
+
+**Last updated:** 2026-04-29  
+**Maintained by:** @dev-team  
+**Status:** Production-ready

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -49,12 +49,12 @@ POSTGRES_PASSWORD=<password-largo-y-random>
 POSTGRES_DB=devdeck
 
 # Backend API
-DATABASE_URL=postgres://devdeck:<password>@db:5432/devdeck?sslmode=disable
 AUTH_MODE=jwt
 JWT_SECRET=<256-bit-random-hex>
 GITHUB_CLIENT_ID=<del paso 1>
 GITHUB_CLIENT_SECRET=<del paso 1>
-OAUTH_REDIRECT_URL=https://api.devdeck.tu-dominio.com/api/auth/github/callback
+GITHUB_OAUTH_CALLBACK_URL=https://api.devdeck.tu-dominio.com/api/auth/github/callback
+APP_OAUTH_REDIRECT_URL=https://app.devdeck.tu-dominio.com/auth/callback
 ALLOWED_GITHUB_LOGINS=tu-usuario,otro-usuario
 
 # Feature flags

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -60,10 +60,8 @@ ALLOWED_GITHUB_LOGINS=tu-usuario,otro-usuario
 # Feature flags
 SEED_CHEATSHEETS=true
 
-# IA (opcional, Ola 6+)
-AI_PROVIDER=disabled        # disabled | openai | ollama
-OPENAI_API_KEY=
-OLLAMA_URL=http://ollama:11434
+# IA local (opcional, Fase 18 MVP actual)
+AI_PROVIDER=heuristic       # heuristic | local | disabled
 ```
 
 Generar `JWT_SECRET`:
@@ -215,13 +213,13 @@ Si querés features de IA sin mandar datos a OpenAI, agregar al `docker-compose.
     # docker compose exec ollama ollama pull nomic-embed-text
 ```
 
-En `.env`:
+En `.env` (futuro, todavía NO implementado en el repo actual):
 ```
 AI_PROVIDER=ollama
 OLLAMA_URL=http://ollama:11434
 ```
 
-Modelos recomendados:
+Modelos recomendados (para la siguiente iteración, no para el estado actual del repo):
 - **Summaries / tags:** `llama3.2:3b` (2 GB, rápido, calidad ok).
 - **Embeddings:** `nomic-embed-text` (270 MB, 768 dims).
 

--- a/docs/TECHNICAL_ROADMAP_AI_OFFLINE.md
+++ b/docs/TECHNICAL_ROADMAP_AI_OFFLINE.md
@@ -18,7 +18,7 @@
 
 ### Estado actual dentro de Ola 5
 - ✅ **Fase 17 completa:** tabla `items` polimórfica, CRUD completo backend + frontend, `ItemsPage` con filtros por tipo, `ItemCard`, `CaptureModal` integrado. Ver `ROADMAP.md §Fase 17`.
-- ⏳ **Fase 18 siguiente:** módulo `internal/ai/` con `Classifier` + `Summarizer`. Ver sección 1.2 abajo.
+- 🚧 **Fase 18 en curso:** ya existe un MVP local/heurístico en `internal/ai/` que genera `ai_summary` + `ai_tags` en background; restan providers LLM reales y endpoints/UI de review. Ver sección 1.2 abajo.
 
 ### Principios técnicos para las nuevas olas
 1. **Offline-first no es opcional.** La app debe ser 100% funcional sin red. La sync es eventual y no bloquea ninguna operación.
@@ -95,37 +95,27 @@ type Item struct {
 ```
 internal/
 └── ai/
-    ├── ai.go              # interfaces: Classifier, Summarizer, Embedder, RAG
-    ├── openai.go          # implementación OpenAI (GPT-4o-mini + text-embedding-3-small)
-    ├── ollama.go          # implementación Ollama (llama3.2 + nomic-embed-text)
-    ├── disabled.go        # implementación noop (cuando AI_PROVIDER=disabled)
-    ├── pipeline.go        # orquestación: enqueue → process → save
-    └── prompts/
-        ├── classify.txt   # prompt para auto-tagging y clasificación de tipo
-        └── summarize.txt  # prompt para auto-summary
+	    ├── service.go         # interfaces + orquestación básica
+	    ├── heuristic.go       # provider local/heurístico (MVP actual)
+	    ├── disabled.go        # implementación noop (cuando AI_PROVIDER=disabled)
+	    ├── openai.go          # futuro: implementación OpenAI
+	    ├── ollama.go          # futuro: implementación Ollama
+	    └── prompts/           # futuro: prompts cuando haya provider LLM
 ```
+
+**Nota de reconciliación (2026-04-30):** el repo NO tiene hoy `openai.go`, `ollama.go` ni prompts LLM. El estado real es `service.go` + `heuristic.go` + `disabled.go`, integrados a `internal/jobs/enrich.go`.
 
 #### Interfaces
 ```go
-// ai/ai.go
+// ai/service.go
 type Classifier interface {
-    // Dado un item, devuelve tipo sugerido, tags sugeridos y categorías
-    Classify(ctx context.Context, item ClassifyInput) (ClassifyResult, error)
+    SuggestTags(ctx context.Context, in Input) ([]string, error)
+    Enabled() bool
 }
 
 type Summarizer interface {
-    // Dado un item, devuelve un resumen corto (≤150 palabras)
-    Summarize(ctx context.Context, item SummarizeInput) (string, error)
-}
-
-type Embedder interface {
-    // Dado un texto, devuelve su vector de embeddings
-    Embed(ctx context.Context, text string) ([]float32, error)
-}
-
-type RAG interface {
-    // Dado una pregunta y contexto (items recuperados), genera respuesta
-    Answer(ctx context.Context, question string, context []Item) (string, error)
+    Summarize(ctx context.Context, in Input) (string, error)
+    Enabled() bool
 }
 ```
 
@@ -133,27 +123,19 @@ type RAG interface {
 ```
 [Save item] → [Write to DB] → [HTTP 201 response] → [Enqueue AI job]
                                                               ↓
-                                               [Worker: Classify + Summarize]
+                               [Worker: fetch metadata opcional + summarize + suggest tags]
                                                               ↓
-                                               [PATCH item: ai_tags + ai_summary]
-                                                              ↓
-                                               [WebSocket / SSE: notify client]
+                                               [UPDATE items.ai_tags + ai_summary]
 ```
 
-**Implementación:** worker pool simple con `goroutine` + canal buffered. No hace falta queue externa para el MVP de IA. Si escala, migrar a PgMQ o similar (ya tienen Postgres).
+**Implementación actual:** la queue existente en `internal/jobs/enrich.go` corre metadata enrichment + AI heurística en el mismo worker. No hay queue externa ni provider LLM todavía; eso vendrá después.
 
 #### Variables de configuración (`config.go`)
 ```go
-AI_PROVIDER        string  // "openai" | "ollama" | "disabled"
-OPENAI_API_KEY     string  // requerido si AI_PROVIDER=openai
-OPENAI_MODEL       string  // default: "gpt-4o-mini"
-OPENAI_EMBED_MODEL string  // default: "text-embedding-3-small"
-OLLAMA_BASE_URL    string  // default: "http://localhost:11434"
-OLLAMA_MODEL       string  // default: "llama3.2"
-OLLAMA_EMBED_MODEL string  // default: "nomic-embed-text"
-AI_MAX_WORKERS     int     // default: 3
-AI_OPT_IN_DEFAULT  bool    // default: false (usuarios deben activar explícitamente)
+AI_PROVIDER string // "heuristic" | "local" | "disabled" (actual)
 ```
+
+**Futuro (todavía no implementado):** `OPENAI_API_KEY`, `OLLAMA_BASE_URL`, modelos y workers configurables cuando entren providers externos.
 
 #### Prompt de clasificación (`prompts/classify.txt`)
 ```
@@ -689,14 +671,15 @@ func SanitizeForAI(item Item) ClassifyInput {
 - Endpoints: `GET /api/items`, `GET /api/items/:id`, `PATCH /api/items/:id`, `DELETE /api/items/:id`, `POST /api/items/:id/seen`. ✅
 - Frontend: `ItemsPage` + `ItemCard` + `CaptureModal` con `why_saved` + type override. ✅
 
-### ⏳ Sprint 2 — Auto-tagging + Auto-summary (Fase 18 — PRÓXIMO)
-- Módulo `internal/ai/` con interfaces `Classifier` + `Summarizer` + `disabled.go` (noop)
-- `internal/ai/openai.go`: GPT-4o-mini
-- `internal/ai/ollama.go`: llama3.2 (Ollama local — default)
-- `internal/ai/pipeline.go`: worker pool + canal buffered; integración con `internal/jobs/`
-- Config: `AI_PROVIDER`, `OPENAI_API_KEY`, `OLLAMA_BASE_URL`, `AI_MAX_WORKERS`, `AI_OPT_IN_DEFAULT`
-- Endpoints: `POST /api/items/:id/ai-enrich`, `PATCH /api/items/:id/ai-tags`
-- Frontend: indicador "analizando…" en `ItemCard` + UI de review de tags sugeridos
+### 🚧 Sprint 2 — Auto-tagging + Auto-summary (Fase 18 — EN CURSO)
+- `internal/ai/` ya existe con interfaces `Classifier` + `Summarizer`, provider `heuristic` y `disabled.go`. ✅
+- Integración con `internal/jobs/`: el worker actual genera `ai_summary` + `ai_tags` sin bloquear el save. ✅
+- Config actual: `AI_PROVIDER=heuristic|local|disabled`. ✅
+- Frontend actual: `ItemCard` muestra "analizando…", prioriza `ai_summary` y cae a `ai_tags` si no hay tags manuales. ✅
+- Pendiente: `internal/ai/openai.go` (GPT-4o-mini). ⏳
+- Pendiente: `internal/ai/ollama.go` (llama3.2 / local). ⏳
+- Pendiente: endpoints `POST /api/items/:id/ai-enrich` y `PATCH /api/items/:id/ai-tags`. ⏳
+- Pendiente: UI de review/aceptación de tags sugeridos. ⏳
 
 ### 🔲 Sprint 3 — Búsqueda semántica (Fase 19)
 - `migrations/0006_embeddings.sql` + pgvector

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -144,8 +144,8 @@ Contra el binario buildeado + backend dockerizado con seeds.
 
 ### Stack
 - **Unit/component:** Vitest + `@testing-library/react` + `@testing-library/user-event`.
-- **E2E (desktop):** Playwright contra Electron build, backend dockerizado.
-- **E2E (web):** pendiente — TODO post-§16.13.
+- **E2E (desktop):** Playwright contra Electron build, backend live + Postgres efímero en CI.
+- **E2E (web):** todavía no existe una suite dedicada; hoy la cobertura del cliente web viene de `@devdeck/features`, `@devdeck/api-client`, `@devdeck/ui` y del build verificado en CI.
 
 ### Cómo correr tests
 
@@ -180,9 +180,9 @@ Cada package con tests tiene su propio `vitest.config.ts` + `vitest.setup.ts` (d
 
 ## Matriz de tests E2E compartidos
 
-| Flow | Electron (Playwright) | Web (TODO) | Backend solo |
-|------|-----------------------|------------|--------------|
-| Login OAuth | ✓ | — | ✓ |
+| Flow | Electron (Playwright) | Web dedicado | Backend solo |
+|------|-----------------------|--------------|--------------|
+| Login OAuth/token | ✓ | — | ✓ |
 | Add repo (URL) | ✓ | — | ✓ |
 | Repo detail + notas | ✓ | — | – |
 | Global search | ✓ | — | ✓ |
@@ -191,7 +191,7 @@ Cada package con tests tiene su propio `vitest.config.ts` + `vitest.setup.ts` (d
 | Cheatsheets | ✓ | — | ✓ |
 | Batch import scripts | ✓ | — | ✓ |
 
-Post-§16.13 los E2E de web son trivales de agregar (mismo Playwright apuntando a `:5173`) — TODO en próximo sprint.
+**Estado real hoy:** no hay suite E2E web separada. Antes de agregarla conviene cerrar el gap del CLI P0 y las próximas features de producto para evitar duplicar mantenimiento de flujos todavía inestables.
 
 ---
 
@@ -203,44 +203,23 @@ name: ci
 on: [push, pull_request]
 jobs:
   backend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with: { go-version: '1.23' }
-      - run: cd backend && go mod download
-      - run: cd backend && go vet ./...
-      - run: cd backend && go test -race -cover ./...
+    # backend/go vet/go test -race ./...
+  cli:
+    # cli/go test ./... + build ./cmd/devdeck + smoke --help
   monorepo:
-    # Desde §16.13 el repo es pnpm workspaces; todo el frontend se instala
-    # y testea desde la raíz con un solo install.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
-        with: { version: 10 }
-      - uses: actions/setup-node@v4
-        with: { node-version: 22, cache: pnpm }
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm typecheck              # pnpm -r typecheck (5 packages)
-      - run: pnpm test                   # pnpm -r test (67 tests en 4 packages)
-      - run: pnpm -F @devdeck/desktop build
-      - run: pnpm -F @devdeck/web build
+    # pnpm install --frozen-lockfile
+    # pnpm typecheck
+    # pnpm test
+    # pnpm build:web
+    # pnpm build:desktop
+  extension:
+    # manifest validation + node --check + npm test
   e2e:
-    runs-on: ubuntu-latest
-    needs: [backend, monorepo]
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env: { POSTGRES_PASSWORD: test, POSTGRES_DB: devdeck_test }
-        ports: ['5432:5432']
-    steps:
-      - uses: actions/checkout@v4
-      # boot backend, run playwright, teardown
+    # postgres service + backend live + Playwright contra apps/desktop
 ```
 
 **Branch protection en `main`:**
-- Requerir status checks: `backend`, `monorepo`, `e2e`.
+- Requerir status checks: `backend`, `cli`, `monorepo`, `extension`, `e2e`.
 - Requerir PR review de al menos 1 maintainer.
 - No permitir force push.
 - No permitir delete.

--- a/extension/README.md
+++ b/extension/README.md
@@ -34,11 +34,17 @@ Spec completa: [`docs/CAPTURE.md §Canal 1`](../docs/CAPTURE.md#canal-1--extensi
 - **Background** (`src/background.js`) — centraliza el fetch a `/api/items/capture`.
   Si el backend está caído (o no hay token), la captura va a una cola offline
   (`chrome.storage.local`) y se reintenta cada minuto via `chrome.alarms`. El
-  badge del toolbar muestra el número de items pendientes en rojo.
+  badge del toolbar muestra el número de items pendientes en rojo. También
+  registra context menus para guardar links o selección de texto.
 - **Options** (`src/options.html` + `options.js`) — editor de `apiUrl` + `token`
-  con un botón "Probar conexión" que hace un GET `/healthz`.
+  con un botón "Probar conexión" que valida reachability + auth contra un
+  endpoint protegido.
 - **Atajo** — declarado en `manifest.json` como `capture-tab` con
   `Cmd/Ctrl+Shift+D`. Capturá sin abrir el popup.
+- **Context menu** — click derecho sobre un link → "Guardar link en DevDeck";
+  click derecho sobre selección → "Guardar selección en DevDeck como snippet".
+  Ambos caminos adjuntan contexto de página (`page_url`, `page_title`, origen de captura)
+  en `meta_hints` para enriquecer mejor el item después.
 
 ## Permisos
 
@@ -47,13 +53,14 @@ Spec completa: [`docs/CAPTURE.md §Canal 1`](../docs/CAPTURE.md#canal-1--extensi
 | `activeTab` | Leer URL/título de la tab actual cuando el usuario invoca el popup o el shortcut. |
 | `storage` | Persistir `apiUrl`, `token` y la cola offline en `chrome.storage.local`. |
 | `alarms` | Reintentos del drain de cola cada minuto. |
+| `contextMenus` | Agregar acciones de click derecho para links y selección. |
 | `host_permissions: <all_urls>` | `fetch` al backend self-hosted (cualquier dominio). Cuando publiquemos al Chrome Web Store esto se restringe al dominio hosted. |
 
 ## Estado
 
 - ✅ P0 — capturar tab activa por shortcut o popup, token storage, offline queue.
+- ✅ Mejoras de captura — context menu para links y selección + verificación real de auth en opciones.
 - ⏳ Firefox — compatible manifest v3, pero falta validar shortcut y MV3 SW.
-- ⏳ Right-click en selección ("Guardar en DevDeck como snippet").
 - ⏳ OAuth flow con `/api/auth/github/login` en lugar de token manual (requiere JWT mode).
 - ⏳ Tags sugeridos vía `GET /api/tags/suggest` (endpoint a crear en Ola 5).
 - ⏳ Chrome Web Store / Firefox Add-ons.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,7 @@
     "page": "src/options.html",
     "open_in_tab": true
   },
-  "permissions": ["activeTab", "storage", "alarms"],
+  "permissions": ["activeTab", "storage", "alarms", "contextMenus"],
   "host_permissions": ["<all_urls>"],
   "commands": {
     "capture-tab": {

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -16,11 +16,18 @@ import { capture } from './lib/api.js'
 import { enqueue, getQueue, getSettings, setQueue } from './lib/storage.js'
 
 const QUEUE_ALARM = 'devdeck-drain-queue'
+const MENU_CAPTURE_LINK = 'devdeck-capture-link'
+const MENU_CAPTURE_SELECTION = 'devdeck-capture-selection'
 
 // ─── Install hook: register the retry alarm ───
 
 chrome.runtime.onInstalled.addListener(async () => {
   await chrome.alarms.create(QUEUE_ALARM, { periodInMinutes: 1 })
+  await ensureContextMenus()
+})
+
+chrome.runtime.onStartup?.addListener(async () => {
+  await ensureContextMenus()
 })
 
 // ─── Keyboard command ───
@@ -33,7 +40,43 @@ chrome.commands.onCommand.addListener(async (command) => {
     url: tab.url,
     title: tab.title || '',
     source: 'browser-extension',
+    metaHints: {
+      capture_context: 'shortcut',
+      page_url: tab.url,
+      page_title: tab.title || '',
+    },
   })
+})
+
+// ─── Context menus ───
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId === MENU_CAPTURE_LINK && info.linkUrl) {
+    await captureTab({
+      url: info.linkUrl,
+      source: 'browser-extension',
+      metaHints: {
+        capture_context: 'context-link',
+        page_url: info.pageUrl || tab?.url || '',
+        page_title: tab?.title || '',
+      },
+    })
+    return
+  }
+
+  if (info.menuItemId === MENU_CAPTURE_SELECTION && info.selectionText) {
+    await captureTab({
+      text: info.selectionText,
+      selection: info.selectionText,
+      typeHint: 'snippet',
+      source: 'browser-extension',
+      metaHints: {
+        capture_context: 'context-selection',
+        page_url: info.pageUrl || tab?.url || '',
+        page_title: tab?.title || '',
+      },
+    })
+  }
 })
 
 // ─── Popup ↔ background messaging ───
@@ -45,6 +88,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       .catch((err) =>
         sendResponse({
           ok: false,
+          queued: Boolean(err.queued),
           error: { status: err.status, code: err.code, message: err.message },
         }),
       )
@@ -66,7 +110,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 
 // ─── Internals ───
 
-async function captureTab({ url, title, source, whySaved, tags }) {
+async function captureTab({ url, text, selection, title, source, whySaved, tags, typeHint, metaHints }) {
   const { apiUrl, token } = await getSettings()
   if (!token) {
     // No token configured → queue the item so it can be flushed after
@@ -74,11 +118,17 @@ async function captureTab({ url, title, source, whySaved, tags }) {
     await enqueue({
       source: source || 'browser-extension',
       url,
+      text,
+      selection,
       title_hint: title,
+      type_hint: typeHint,
       why_saved: whySaved,
       tags,
+      meta_hints: metaHints,
     })
-    throw new Error('no token configured; item queued for later')
+    const err = new Error('No hay credenciales configuradas. La captura quedó en cola para reintentar después de configurar la extensión.')
+    err.queued = true
+    throw err
   }
   try {
     const res = await capture({
@@ -87,9 +137,13 @@ async function captureTab({ url, title, source, whySaved, tags }) {
       input: {
         source: source || 'browser-extension',
         url,
+        text,
+        selection,
         title_hint: title,
+        type_hint: typeHint,
         why_saved: whySaved,
         tags,
+        meta_hints: metaHints,
       },
     })
     await updateBadge()
@@ -100,11 +154,16 @@ async function captureTab({ url, title, source, whySaved, tags }) {
       await enqueue({
         source: source || 'browser-extension',
         url,
+        text,
+        selection,
         title_hint: title,
+        type_hint: typeHint,
         why_saved: whySaved,
         tags,
+        meta_hints: metaHints,
       })
       await updateBadge()
+      err.queued = true
     }
     throw err
   }
@@ -147,4 +206,18 @@ async function updateBadge() {
   } catch {
     /* setBadgeText may fail if the action isn't visible yet */
   }
+}
+
+async function ensureContextMenus() {
+  await chrome.contextMenus.removeAll()
+  chrome.contextMenus.create({
+    id: MENU_CAPTURE_LINK,
+    title: 'Guardar link en DevDeck',
+    contexts: ['link'],
+  })
+  chrome.contextMenus.create({
+    id: MENU_CAPTURE_SELECTION,
+    title: 'Guardar selección en DevDeck como snippet',
+    contexts: ['selection'],
+  })
 }

--- a/extension/src/lib/api.js
+++ b/extension/src/lib/api.js
@@ -50,3 +50,28 @@ export async function health(apiUrl) {
     throw new Error(`healthz ${res.status}`)
   }
 }
+
+/**
+ * verifyAuth hits a protected endpoint so the options page can confirm
+ * both reachability and that the provided token/JWT is actually usable.
+ */
+export async function verifyAuth(apiUrl, token) {
+  const res = await fetch(`${apiUrl.replace(/\/+$/, '')}/api/repos?limit=1`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (!res.ok) {
+    let payload = {}
+    try {
+      payload = await res.json()
+    } catch {
+      /* empty */
+    }
+    const err = new Error(payload?.error?.message || res.statusText)
+    err.status = res.status
+    err.code = payload?.error?.code || 'UNKNOWN'
+    throw err
+  }
+}

--- a/extension/src/options.html
+++ b/extension/src/options.html
@@ -39,7 +39,7 @@
       </label>
 
       <label class="field">
-        <span>API Token</span>
+        <span>API Token / JWT</span>
         <input id="token" type="password" placeholder="sk_live_xxx" autocomplete="off" />
         <span class="field-text">
           Se guarda en <code>chrome.storage.local</code>. Solo vos (y extensiones que

--- a/extension/src/options.js
+++ b/extension/src/options.js
@@ -1,8 +1,8 @@
 // Options page — lets the user set the backend URL + token. We verify
-// the token by hitting /healthz before persisting when the user clicks
-// "Probar conexión" so a fat-fingered paste fails loudly.
+// both backend reachability and auth by hitting a protected endpoint
+// before persisting when the user clicks "Probar conexión".
 
-import { health } from './lib/api.js'
+import { verifyAuth } from './lib/api.js'
 import { getSettings, setSettings } from './lib/storage.js'
 
 const $ = (id) => document.getElementById(id)
@@ -19,13 +19,18 @@ async function init() {
 async function onVerify() {
   clearMessages()
   const apiUrl = $('api-url').value.trim()
+  const token = $('token').value.trim()
   if (!apiUrl) {
     showError('Falta la URL del backend.')
     return
   }
+  if (!token) {
+    showError('Falta el token/JWT.')
+    return
+  }
   try {
-    await health(apiUrl)
-    showSuccess('✓ Backend alcanzable.')
+    await verifyAuth(apiUrl, token)
+    showSuccess('✓ Backend y credenciales válidas.')
   } catch (err) {
     showError(`✗ ${err.message}`)
   }

--- a/extension/src/popup.css
+++ b/extension/src/popup.css
@@ -121,6 +121,22 @@ main {
   font-weight: bold;
 }
 
+.status {
+  border: 3px solid var(--ink);
+  padding: 7px;
+  font-size: 11px;
+  font-weight: bold;
+  background: var(--accent-yellow);
+}
+
+.status-ok {
+  background: var(--accent-lime);
+}
+
+.status-queued {
+  background: var(--accent-yellow);
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -29,6 +29,7 @@
         <input id="tags" type="text" placeholder="opcional" />
       </label>
 
+      <div id="status" class="status" hidden></div>
       <div id="error" class="error" hidden></div>
 
       <footer class="actions">

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -51,6 +51,7 @@ async function init() {
 
 async function onSave(tab) {
   if (!tab) return
+  showStatus(null)
   showError(null)
   const why = $('why').value.trim()
   const tagsRaw = $('tags').value.trim()
@@ -72,15 +73,40 @@ async function onSave(tab) {
       title: tab.title,
       whySaved: why || undefined,
       tags,
+      metaHints: {
+        capture_context: 'popup',
+        page_url: tab.url,
+        page_title: tab.title || '',
+      },
     },
   })
   if (resp?.ok) {
-    window.close()
+    showStatus('✓ Guardado en DevDeck.', 'ok')
+    window.setTimeout(() => window.close(), 500)
+    return
+  }
+  if (resp?.queued) {
+    showStatus('⚠ Guardado en cola. Se reintentará automáticamente.', 'queued')
+    $('save').disabled = false
+    $('save').textContent = 'Guardar'
     return
   }
   showError(resp?.error?.message || 'Error desconocido')
   $('save').disabled = false
   $('save').textContent = 'Guardar'
+}
+
+function showStatus(message, kind) {
+  const el = $('status')
+  if (!message) {
+    el.hidden = true
+    el.textContent = ''
+    el.className = 'status'
+    return
+  }
+  el.hidden = false
+  el.textContent = message
+  el.className = `status status-${kind || 'ok'}`
 }
 
 function showError(message) {

--- a/extension/tests/api.test.js
+++ b/extension/tests/api.test.js
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import http from 'node:http'
 
-import { capture, health } from '../src/lib/api.js'
+import { capture, health, verifyAuth } from '../src/lib/api.js'
 
 // startStub spins up a one-off HTTP server that runs the provided
 // handler, then returns { url, close } so the test can tear it down.
@@ -126,6 +126,45 @@ test('health throws on non-2xx', async () => {
   })
   try {
     await assert.rejects(health(stub.url))
+  } finally {
+    await stub.close()
+  }
+})
+
+test('verifyAuth sends bearer token to protected endpoint', async () => {
+  let seen
+  const stub = await startStub((req, res) => {
+    seen = {
+      path: req.url,
+      auth: req.headers.authorization,
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ total: 0, items: [] }))
+  })
+  try {
+    await verifyAuth(stub.url, 'jwt-or-token')
+    assert.equal(seen.path, '/api/repos?limit=1')
+    assert.equal(seen.auth, 'Bearer jwt-or-token')
+  } finally {
+    await stub.close()
+  }
+})
+
+test('verifyAuth surfaces structured auth errors', async () => {
+  const stub = await startStub((req, res) => {
+    res.writeHead(401, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: { code: 'UNAUTHORIZED', message: 'missing or invalid bearer token' } }))
+  })
+  try {
+    await assert.rejects(
+      verifyAuth(stub.url, 'bad-token'),
+      (err) => {
+        assert.equal(err.status, 401)
+        assert.equal(err.code, 'UNAUTHORIZED')
+        assert.match(err.message, /invalid bearer token/)
+        return true
+      },
+    )
   } finally {
     await stub.close()
   }

--- a/packages/features/src/components/ItemCard.test.tsx
+++ b/packages/features/src/components/ItemCard.test.tsx
@@ -38,6 +38,19 @@ describe('<ItemCard>', () => {
     expect(screen.getByText('A powerful TUI framework')).toBeInTheDocument()
   })
 
+  it('prefers ai_summary over description when present', () => {
+    render(
+      <ItemCard
+        item={makeItem({
+          description: 'Raw upstream description',
+          ai_summary: 'Human-friendly summary from local AI',
+        })}
+      />,
+    )
+    expect(screen.getByText('Human-friendly summary from local AI')).toBeInTheDocument()
+    expect(screen.queryByText('Raw upstream description')).not.toBeInTheDocument()
+  })
+
   it('renders the type ribbon for repos', () => {
     render(<ItemCard item={makeItem({ item_type: 'repo' })} />)
     expect(screen.getByText('REPO')).toBeInTheDocument()
@@ -90,6 +103,17 @@ describe('<ItemCard>', () => {
     expect(screen.getByText('alpha')).toBeInTheDocument()
     expect(screen.getByText('beta')).toBeInTheDocument()
     expect(screen.getByText('gamma')).toBeInTheDocument()
+  })
+
+  it('falls back to ai_tags when manual tags are empty', () => {
+    render(<ItemCard item={makeItem({ tags: [], ai_tags: ['suggested', 'go'] })} />)
+    expect(screen.getByText('suggested')).toBeInTheDocument()
+    expect(screen.getByText('go')).toBeInTheDocument()
+  })
+
+  it('shows queued analysis status', () => {
+    render(<ItemCard item={makeItem({ enrichment_status: 'queued' })} />)
+    expect(screen.getByText(/analizando/i)).toBeInTheDocument()
   })
 
   it('fires onClick when clicked', async () => {

--- a/packages/features/src/components/ItemCard.tsx
+++ b/packages/features/src/components/ItemCard.tsx
@@ -65,6 +65,13 @@ export function ItemCard({ item, onClick }: Props) {
   const language = typeof item.meta?.language === 'string' ? (item.meta.language as string) : null
   const languageColor =
     typeof item.meta?.language_color === 'string' ? (item.meta.language_color as string) : null
+  const heroText = item.ai_summary || item.description
+  const visibleTags = item.tags.length > 0 ? item.tags : item.ai_tags
+  const statusLabel = item.enrichment_status === 'queued'
+    ? 'Analizando…'
+    : item.enrichment_status === 'error'
+      ? 'Análisis pendiente'
+      : null
 
   return (
     <article
@@ -87,8 +94,14 @@ export function ItemCard({ item, onClick }: Props) {
           {item.title || '(sin título)'}
         </h3>
 
-        {item.description && (
-          <p className="text-sm text-ink-soft line-clamp-2 mb-3">{item.description}</p>
+        {heroText && (
+          <p className="text-sm text-ink-soft line-clamp-2 mb-3">{heroText}</p>
+        )}
+
+        {statusLabel && (
+          <p className="text-[11px] font-mono uppercase tracking-wide mb-3 text-ink-soft">
+            ✦ {statusLabel}
+          </p>
         )}
 
         {item.why_saved && (
@@ -122,9 +135,9 @@ export function ItemCard({ item, onClick }: Props) {
           </p>
         )}
 
-        {item.tags.length > 0 && (
+        {visibleTags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {item.tags.slice(0, 5).map((t) => (
+            {visibleTags.slice(0, 5).map((t) => (
               <TagChip key={t} label={t} colorIndex={hashIndex(t)} />
             ))}
           </div>


### PR DESCRIPTION
Closes #28

## Summary
- add a local heuristic AI provider that generates item summaries and suggested tags in the existing async enrichment pipeline
- persist and surface ai_summary/ai_tags in item search and ItemCard UI without blocking capture/save
- reconcile roadmap, capture, and self-hosting docs with the real heuristic MVP state

## Changes
| File | Change |
|------|--------|
| backend/internal/ai/* | Add heuristic + disabled AI providers and service interfaces |
| backend/internal/jobs/enrich.go | Extend the async worker to run item AI enrichment and update status safely |
| backend/internal/store/items.go | Persist ai_summary / ai_tags and include them in item search |
| backend/internal/http/handlers/capture.go | Queue AI-capable item jobs without blocking capture responses |
| backend/internal/config/config.go, backend/cmd/api/main.go | Wire AI_PROVIDER into API startup |
| packages/features/src/components/ItemCard.tsx | Surface AI summary/tags and queued analysis state |
| ROADMAP.md, docs/TECHNICAL_ROADMAP_AI_OFFLINE.md, docs/SELF_HOSTING.md, docs/CAPTURE.md | Reconcile docs with the implemented heuristic MVP |

## Test Plan
- [x] go test ./internal/ai ./internal/jobs ./internal/http/handlers
- [x] pnpm -F @devdeck/features test -- ItemCard.test.tsx
- [x] pnpm -F @devdeck/features typecheck