### PR TITLE
feat(capture): implement quick capture optimized

### DIFF
--- a/backend/internal/http/handlers/preview.go
+++ b/backend/internal/http/handlers/preview.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"devdeck/internal/domain/items"
+	"devdeck/internal/enricher"
+)
+
+// PreviewHandler handles POST /api/items/preview. Returns metadata for a
+// URL without persisting anything — used for instant preview while
+// the user types.
+type PreviewHandler struct {
+	enricher *enricher.Service
+}
+
+type PreviewInput struct {
+	URL      string `json:"url"`
+	TypeHint string `json:"type_hint,omitempty"`
+}
+
+type PreviewResponse struct {
+	URL         string  `json:"url,omitempty"`
+	Title       string  `json:"title,omitempty"`
+	Description string  `json:"description,omitempty"`
+	Image       string  `json:"image,omitempty"`
+	Type        string  `json:"type"`
+}
+
+func NewPreviewHandler(en *enricher.Service) *PreviewHandler {
+	return &PreviewHandler{enricher: en}
+}
+
+// Preview handles POST /api/items/preview.
+func (h *PreviewHandler) Preview(w http.ResponseWriter, r *http.Request) {
+	var in PreviewInput
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid json body")
+		return
+	}
+	if in.URL == "" {
+		writeError(w, http.StatusBadRequest, "MISSING_URL", "url is required")
+		return
+	}
+
+	// Detect type from URL (the same logic capture uses)
+	det := items.DetectType(items.CaptureInput{
+		URL:      in.URL,
+		TypeHint: in.TypeHint,
+	})
+
+	resp := PreviewResponse{
+		URL:   in.URL,
+		Type:  string(det.Type),
+		Title: det.Title,
+	}
+
+	// Try to fetch OG metadata for title/description/image
+	// This is best-effort — failure to fetch shouldn't block preview
+	if md, err := h.enricher.Enrich(r.Context(), in.URL); err == nil && md != nil {
+		if md.Description != nil && *md.Description != "" {
+			resp.Description = *md.Description
+		}
+		if md.OGImageURL != nil && *md.OGImageURL != "" {
+			resp.Image = *md.OGImageURL
+		}
+		// If we got OG title, prefer it over detected title
+		if resp.Title == "" && md.Description != nil {
+			resp.Title = *md.Description
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -80,6 +80,7 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 	suggestionsH := handlers.NewSuggestionsHandler(st)
 	captureH := handlers.NewCaptureHandler(st, deps.EnrichQueue)
 	itemsH := handlers.NewItemsHandler(st, deps.EnrichQueue)
+	previewH := handlers.NewPreviewHandler(deps.Enricher)
 
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/suggestions/commands", suggestionsH.Commands)
@@ -157,6 +158,7 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 
 			r.Route("/items", func(ir chi.Router) {
 				ir.Post("/capture", captureH.Capture)
+				ir.Post("/preview", previewH.Preview)
 				ir.Get("/", itemsH.List)
 				ir.Get("/{id}", itemsH.Get)
 				ir.Patch("/{id}", itemsH.Update)

--- a/packages/api-client/src/features/capture/preview.ts
+++ b/packages/api-client/src/features/capture/preview.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import { api } from '../../api-client'
+
+export interface PreviewInput {
+  url: string
+  type_hint?: string
+}
+
+export interface PreviewResponse {
+  url: string
+  title: string
+  description: string
+  image: string
+  type: string
+}
+
+/**
+ * usePreview fetches instant metadata for a URL without persisting.
+ * Used to show preview while the user types in the capture modal.
+ */
+export function usePreview() {
+  return useMutation({
+    mutationFn: (input: PreviewInput) =>
+      api.post<PreviewResponse>('/api/items/preview', input),
+  })
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -130,6 +130,8 @@ export type { Stats, MascotMood } from './features/stats/types'
 
 // Feature hooks — capture
 export { useCapture } from './features/capture/api'
+export { usePreview } from './features/capture/preview'
+export type { PreviewInput, PreviewResponse } from './features/capture/preview'
 export {
   detectType,
   quickDetectFromClipboard,

--- a/packages/features/src/components/CaptureModal.tsx
+++ b/packages/features/src/components/CaptureModal.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@devdeck/ui'
-import { useCapture } from '@devdeck/api-client'
+import { useCapture, usePreview, type PreviewResponse } from '@devdeck/api-client'
 import { detectType } from '@devdeck/api-client'
 import { ALL_ITEM_TYPES, type CaptureInput, type ItemType } from '@devdeck/api-client'
 import { showToast } from '@devdeck/ui'
@@ -30,7 +30,10 @@ export function CaptureModal({ open, onClose, prefill, source = 'manual' }: Prop
   const [typeHint, setTypeHint] = useState<ItemType | ''>('')
   const [whySaved, setWhySaved] = useState('')
   const [tagsRaw, setTagsRaw] = useState('')
+  const [preview, setPreview] = useState<PreviewResponse | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
   const capture = useCapture()
+  const previewFetch = usePreview()
 
   // Reset + seed from prefill each time the modal opens.
   useEffect(() => {
@@ -53,12 +56,42 @@ export function CaptureModal({ open, onClose, prefill, source = 'manual' }: Prop
       }
     }
     function onKey(e: KeyboardEvent) {
+      // Don't trap Enter in inputs - native form submission handles it
       if (e.key === 'Escape') onClose()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, prefill])
+
+  // Fetch preview when URL changes (debounced)
+  const [lastPreviewUrl, setLastPreviewUrl] = useState('')
+  useEffect(() => {
+    const urlTrimmed = url.trim()
+    if (!urlTrimmed || !looksLikeURL(urlTrimmed)) {
+      setPreview(null)
+      setLastPreviewUrl('')
+      return
+    }
+    // Debounce: only fetch if URL changed significantly
+    if (urlTrimmed === lastPreviewUrl) return
+    setLastPreviewUrl(urlTrimmed)
+
+    const timer = setTimeout(async () => {
+      try {
+        const res = await previewFetch.mutateAsync({
+          url: urlTrimmed,
+          type_hint: typeHint || undefined,
+        })
+        setPreview(res)
+      } catch {
+        // Best-effort: failure to fetch shouldn't block capture
+        setPreview(null)
+      }
+    }, 300) // 300ms debounce
+
+    return () => clearTimeout(timer)
+  }, [url, typeHint])
 
   const detected = useMemo(() => {
     if (!url.trim() && !text.trim()) return null
@@ -109,8 +142,8 @@ export function CaptureModal({ open, onClose, prefill, source = 'manual' }: Prop
       <form
         onSubmit={onSubmit}
         onClick={(e) => e.stopPropagation()}
-        className="bg-bg-card border-5 border-ink shadow-hard-xl p-8 w-full max-w-2xl
-                   max-h-[90vh] overflow-y-auto"
+        className="bg-bg-card border-5 border-ink shadow-hard-xl p-5 w-full max-w-lg
+                   max-h-[85vh] overflow-y-auto"
       >
         <header className="flex items-center justify-between mb-5">
           <h2 className="font-display font-black text-3xl uppercase">
@@ -126,7 +159,22 @@ export function CaptureModal({ open, onClose, prefill, source = 'manual' }: Prop
           </button>
         </header>
 
-        <label className="block mb-3">
+        <label
+          className={`block mb-3 ${isDragging ? 'bg-accent-yellow/30' : ''}`}
+          onDragOver={(e) => {
+            e.preventDefault()
+            setIsDragging(true)
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={(e) => {
+            e.preventDefault()
+            setIsDragging(false)
+            const text = e.dataTransfer.getData('text/plain')
+            if (text && looksLikeURL(text)) {
+              setUrl(text)
+            }
+          }}
+        >
           <span className="block text-xs font-mono font-bold uppercase mb-1">URL</span>
           <input
             autoFocus={!text}
@@ -162,6 +210,29 @@ export function CaptureModal({ open, onClose, prefill, source = 'manual' }: Prop
                 <span className="opacity-60"> · </span>
                 <span>{detected.title}</span>
               </>
+            )}
+          </div>
+        )}
+
+        {preview && (
+          <div className="mb-4 p-3 bg-accent-cyan/20 border-3 border-ink">
+            {preview.image && (
+              <img
+                src={preview.image}
+                alt=""
+                className="w-full h-32 object-cover mb-2 border-2 border-ink"
+              />
+            )}
+            {preview.title && (
+              <div className="font-bold text-sm truncate">{preview.title}</div>
+            )}
+            {preview.description && (
+              <div className="text-xs opacity-70 truncate mt-1">
+                {preview.description}
+              </div>
+            )}
+            {previewFetch.isPending && (
+              <div className="text-xs opacity-50 mt-1">Cargando preview…</div>
             )}
           </div>
         )}

--- a/packages/features/src/pages/ItemsPage.tsx
+++ b/packages/features/src/pages/ItemsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Box, Plus } from 'lucide-react'
 import { CaptureModal } from '../components/CaptureModal'
@@ -46,6 +46,24 @@ export function ItemsPage() {
     }
     return out
   }, [items])
+
+  // Keyboard shortcuts: Cmd/Ctrl+K → open capture modal
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null
+      const isTyping =
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.isContentEditable
+
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setCaptureOpen(true)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
 
   return (
     <div className="h-screen flex flex-col bg-bg-primary">


### PR DESCRIPTION
## Summary

- Compact modal UI (max-w-lg, reduced padding from p-8 to p-5)
- Keyboard shortcuts: cmd+K open, esc close, enter submit
- Add /api/items/preview endpoint for instant OG metadata fetch
- Integrate preview with 300ms debounce in CaptureModal
- Add drag-and-drop support for URLs

## Changes

| File | Change |
|------|--------|
|  | Compact size, preview UI, drag-drop |
|  | cmd+K shortcut |
|  | New preview handler |
|  | Register /api/items/preview route |
|  | New usePreview hook |
|  | Export usePreview |

## Test Plan

- [x] TypeScript compiles: pnpm -r typecheck
- [x] Go compiles: go build ./...
- [x] Manually tested cmd+K opens modal

Closes #13