### PR TITLE
feat(items): add stack filter UI with multi-select pills

### DIFF
--- a/packages/api-client/src/features/items/api.ts
+++ b/packages/api-client/src/features/items/api.ts
@@ -11,6 +11,7 @@ export const ITEMS_KEY = ['items'] as const
 export interface ListItemsParams {
   type?: ItemType
   tag?: string
+  stack?: string    // Filter by tech stack (single or comma-separated)
   q?: string
   archived?: boolean
   sort?: 'added_desc' | 'added_asc' | 'updated_desc' | 'title_asc'
@@ -42,6 +43,7 @@ function buildQuery(p: ListItemsParams): string {
   const qs = new URLSearchParams()
   if (p.type) qs.set('type', p.type)
   if (p.tag) qs.set('tag', p.tag)
+  if (p.stack) qs.set('stack', p.stack)
   if (p.q) qs.set('q', p.q)
   if (p.sort) qs.set('sort', p.sort)
   if (p.archived !== undefined) qs.set('archived', String(p.archived))

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -144,3 +144,4 @@ export type {
   CaptureSource,
 } from './features/capture/types'
 export { ALL_ITEM_TYPES, EnrichmentStatus } from './features/capture/types'
+

--- a/packages/features/src/pages/ItemsPage.tsx
+++ b/packages/features/src/pages/ItemsPage.tsx
@@ -16,6 +16,10 @@ import { ALL_ITEM_TYPES, type ItemType } from '@devdeck/api-client'
 
 type TypeFilter = 'all' | ItemType
 
+const STACKS = ['go', 'node', 'python', 'rust', 'typescript', 'react', 'vue', 'ai', 'cli', 'db'] as const
+
+type StackFilter = typeof STACKS[number]
+
 const TYPE_FILTERS: Array<{ key: TypeFilter; label: string }> = [
   { key: 'all', label: 'All' },
   ...ALL_ITEM_TYPES.map((t) => ({ key: t as TypeFilter, label: t })),
@@ -24,17 +28,36 @@ const TYPE_FILTERS: Array<{ key: TypeFilter; label: string }> = [
 export function ItemsPage() {
   const navigate = useNavigate()
   const [type, setType] = useState<TypeFilter>('all')
+  const [stack, setStack] = useState<StackFilter[]>([])
   const [query, setQuery] = useState('')
   const [captureOpen, setCaptureOpen] = useState(false)
 
+  // Build stack query param — comma-separated for OR logic
+  const stackParam = stack.length > 0 ? stack.join(',') : undefined
+
   const { data, isLoading, error } = useItems({
     type: type === 'all' ? undefined : type,
+    stack: stackParam,
     q: query || undefined,
     limit: 200,
     sort: 'added_desc',
   })
 
   const items = data?.items ?? []
+
+  // Handler: toggle a stack in the filter
+  function toggleStack(s: StackFilter) {
+    setStack((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]))
+  }
+
+  // Handler: clear all filters
+  function clearFilters() {
+    setType('all')
+    setStack([])
+    setQuery('')
+  }
+
+  const hasFilters = type !== 'all' || stack.length > 0 || query.length > 0
 
   // Count by type for the chip badges. The UI doesn't paginate between
   // types so this is a single pass over the current page, not a
@@ -109,6 +132,43 @@ export function ItemsPage() {
             )
           })}
         </div>
+
+        {/* Stack filters — inline pills */}
+        <div className="flex gap-2 mt-3 pt-3 border-t border-ink/30">
+          <span className="text-xs font-mono text-ink-soft uppercase tracking-wide py-1">
+            Stack:
+          </span>
+          {STACKS.map((s) => {
+            const active = stack.includes(s as StackFilter)
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => toggleStack(s as StackFilter)}
+                className={`border-3 border-ink px-2 py-0.5 text-xs font-mono
+                            lowercase transition-colors whitespace-nowrap
+                            ${
+                              active
+                                ? 'bg-accent-orange text-white shadow-hard-sm'
+                                : 'bg-bg-card hover:bg-accent-yellow/40'
+                            }`}
+              >
+                {s}
+              </button>
+            )
+          })}
+
+          {hasFilters && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="ml-2 px-2 py-0.5 text-xs font-mono text-ink-soft
+                         hover:text-danger transition-colors"
+            >
+              [clear]
+            </button>
+          )}
+        </div>
       </nav>
 
       <main className="flex-1 overflow-y-auto p-6">
@@ -145,6 +205,7 @@ export function ItemsPage() {
             <p className="font-mono text-xs text-ink-soft mb-4">
               {data?.total} items
               {type !== 'all' && ` · tipo: ${type}`}
+              {stack.length > 0 && ` · stack: ${stack.join(', ')}`}
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
               {items.map((it) => (
@@ -152,7 +213,7 @@ export function ItemsPage() {
                   key={it.id}
                   item={it}
                   onClick={() => {
-					navigate(`/items/${it.id}`)
+                    navigate(`/items/${it.id}`)
                   }}
                 />
               ))}


### PR DESCRIPTION
## Summary

Add stack filter to ItemsPage with multi-select pills for filtering items by tech stack.

## Changes

### Backend
- Add `stack` param to `ListItemsParams` and `buildQuery`

### API Client
- Add `stack` param to `useItems` hook

### ItemsPage
- Add STACKS constant with proper typing (`as const`)
- Add stack filter state with `toggleStack()` handler
- Add inline pills UI for stack selection
- Add [clear] button to reset all filters
- Show active stack filters in items summary

## Test Plan
- [x] TypeScript compiles
- [x] Manually tested filters UI

Closes #18