### PR TITLE
feat(circles): add community sharing flows

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,21 @@ See [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) for the current product propo
 - [x] **Wave 11:** Mobile Bridge (PWA Share Target, Progressive Sync).
 - [x] **Wave 12:** Social Gamification and Reputation System.
 
+### Wave 12 — Social Collaboration and Public Curation
+
+#### Phase 41 — Collaborative Circles and Following
+
+- **Collaborative Circles:** Share repositories, useful bash commands, cheatsheets, Workbench tools, and other developer findings inside closed/private groups.
+- **Social graph:** Follow public curator profiles to keep high-signal developer discoveries visible after they leave chat, Slack, Discord, or community threads.
+- **Feed:** Combine recent saves from followed curators with activity from the user's Circles.
+- **Notifications:** Alert users when a followed curator publishes a new Deck or when useful activity happens in their Circles.
+
+#### Phase 42 — Community Discovery and Rankings
+
+- **Discovery:** Global feed with the most-saved developer findings of the week.
+- **Gamification:** Contribution points and expertise badges based on high-signal contributions, not raw posting volume.
+- **Leaderboard:** Rank useful curators and starred Decks so communities can find trustworthy references faster.
+
 ## Waves 13–16: Enterprise & Agents
 
 - [x] **Wave 13:** Global Scalability (Read Replicas, Multi-region Sync).

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -280,6 +280,7 @@ function createWindow(): void {
       nodeIntegration: false,
       sandbox: true,
       preload: preloadPath,
+      webSecurity: !process.env.ELECTRON_RENDERER_URL,
     },
   })
   mainWindow = win

--- a/apps/desktop/src/renderer/src/App.routes.test.ts
+++ b/apps/desktop/src/renderer/src/App.routes.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appSource = readFileSync(resolve(here, 'App.tsx'), 'utf8')
+
+describe('desktop route parity', () => {
+  it('registers Circles routes exported by shared features', () => {
+    expect(appSource).toContain('CirclesPage')
+    expect(appSource).toContain('CircleDetailPage')
+    expect(appSource).toContain('CircleJoinPage')
+    expect(appSource).toContain('path="/circles"')
+    expect(appSource).toContain('path="/circles/:id"')
+    expect(appSource).toContain('path="/circles/join/:inviteCode"')
+  })
+})

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,9 @@ import {
   CheatsheetDetailPage,
   CheatsheetsListPage,
   CaptureModal,
+  CircleDetailPage,
+  CircleJoinPage,
+  CirclesPage,
   DiscoveryPage,
   HomePage,
   ItemDetailPage,
@@ -295,6 +298,24 @@ function AnimatedRoutes() {
             path="/cheatsheets/:id"
             element={
               <AuthGuard>{withTransition(<CheatsheetDetailPage />)}</AuthGuard>
+            }
+          />
+          <Route
+            path="/circles"
+            element={
+              <AuthGuard>{withTransition(<CirclesPage />)}</AuthGuard>
+            }
+          />
+          <Route
+            path="/circles/:id"
+            element={
+              <AuthGuard>{withTransition(<CircleDetailPage />)}</AuthGuard>
+            }
+          />
+          <Route
+            path="/circles/join/:inviteCode"
+            element={
+              <AuthGuard>{withTransition(<CircleJoinPage />)}</AuthGuard>
             }
           />
           <Route path="/deck/:slug" element={withTransition(<PublicDeckPage />)} />

--- a/docs/APP_AUDIT_REVIEW_2026_05.md
+++ b/docs/APP_AUDIT_REVIEW_2026_05.md
@@ -1,0 +1,187 @@
+# DevDeck — App Audit Review & Community Plan (May 2026)
+
+> Date: 2026-05-23  
+> Source audit: `docs/APP_AUDIT_2026_05.md`  
+> Goal: verify that claimed P0/P1 work is not only present, but product-quality, then turn the social/community surface into a daily-use growth loop for developer communities.
+
+## Executive Verdict
+
+P0/P1 are mostly implemented, but they are not all equally “done done”. The core fixes compile and targeted tests pass, but the product strategy needs one correction: Circles should not be treated as a ghost feature anymore. It should become the community contribution loop, with progressive disclosure protecting solo users from noise.
+
+## Verification Evidence
+
+### P0.1 — Hide dead AI surfaces when provider is unavailable
+
+**Verdict:** Done, acceptable.
+
+Evidence:
+- `packages/features/src/components/UnifiedCommandPalette.tsx` hides Ask AI when `ai_provider` is `disabled`, `heuristic`, or `local`.
+- `packages/features/src/components/GlobalSearchModal.tsx` hides semantic/hybrid modes under the same condition and forces text search.
+- Tests cover disabled, heuristic, and local provider states in:
+  - `packages/features/src/components/UnifiedCommandPalette.test.tsx`
+  - `packages/features/src/components/GlobalSearchModal.test.tsx`
+
+Risk:
+- The provider check is duplicated in two components. Extracting a shared `isInteractiveAiEnabled` helper would prevent drift.
+
+### P0.2 — SyncStatusIndicator must not lie
+
+**Verdict:** Done, product-honest for current backend state.
+
+Evidence:
+- `backend/internal/http/router.go` constructs `SystemConfigHandler` with `syncEnabled=false`.
+- `packages/features/src/components/SyncStatusIndicator.tsx` renders “Cloud Mode” and does not poll local pending sync when sync is disabled.
+- `packages/features/src/components/SyncStatusIndicator.test.tsx` verifies disabled sync ignores pending/offline states.
+
+Risk:
+- This is honest, but it also means offline-first remains disabled globally. The next step is not to show “Synced”; it is to graduate sync behind a real capability flag once local persistence is production-ready.
+
+### P0.3 — Hide team/org features when user has no org
+
+**Verdict:** Partially done.
+
+Evidence:
+- `packages/features/src/components/NavSidebar.tsx` hides the Team section unless `activeOrgId` exists.
+- `packages/features/src/pages/TeamFeedPage.tsx` and `packages/features/src/pages/TeamReviewPage.tsx` guard direct route access with an org-required empty state.
+- `packages/features/src/pages/SettingsPage.tsx` hides SAML, SCIM, and Org Insights unless `prefs.activeOrgId` exists.
+
+Gap:
+- Routes still exist for direct access, which is fine, but the empty states are generic. They should explain how to create/join an org when that becomes a real user path.
+
+### P0.UX — Navigation and information architecture overhaul
+
+**Verdict:** Implemented, but the OpenSpec task file is stale.
+
+Evidence:
+- `packages/features/src/components/AppShell.tsx` now uses a two-column shell with `NavSidebar` and simplified `Topbar`.
+- `packages/features/src/components/NavSidebar.tsx` includes grouped Vault, Tools, Social, Team, and System navigation.
+- `packages/features/src/components/Topbar.tsx` is simplified to search, capture, sync status, notifications, profile, and mobile menu.
+- Targeted tests pass for `NavSidebar`, `Topbar`-adjacent surfaces, and key P0 components.
+
+Gap:
+- `openspec/changes/navigation-ux-overhaul/tasks.md` still has all tasks unchecked. This creates false evidence. Update it or archive the change.
+- Desktop routes did not include Circles pages while Web routes did. This review added Desktop route parity in `apps/desktop/src/renderer/src/App.tsx`.
+- P2 navigation entries are still incomplete: Runbooks, Explore/Trending, and Deck workflows are not first-class enough.
+
+### P1.4 — Improve heuristic AI tagger
+
+**Verdict:** Done, acceptable for current scope.
+
+Evidence:
+- `backend/internal/ai/heuristic.go` uses URL ecosystem tags, technology keyword mapping, metadata topics/language, `why_saved`, and item type fallbacks.
+- `backend/internal/ai/heuristic_test.go` covers crates, Vitest/testing, GitHub metadata, CLI command extraction, shortcuts, and summaries.
+- `go test ./internal/ai/...` passes.
+
+Risk:
+- Keyword matching uses substring checks, so short tokens like `ai`, `ts`, or `go` can over-match inside unrelated words. This is acceptable for MVP but should move to token-aware matching.
+
+### P1.5 — Decide on Circles
+
+**Verdict:** Documented, but under-leveraged.
+
+Evidence:
+- `ROADMAP.es.md` has “Ola 12 — Colaboración Social y Curación Pública” with Circles, Following, feed, notifications, discovery, ranking, and gamification.
+- `ROADMAP.md` top-level checklist mentions collaborative Circles.
+- Backend, API client, migrations, and frontend pages exist for Circles.
+
+Gap:
+- English roadmap lacks the same detailed Circles section visible in Spanish.
+- Desktop route parity for Circles was added during this review.
+- Circles currently look like a feature, not a habit loop. The product needs contribution prompts, group digest, and “share finding to Circle” as a primary flow.
+
+### P1.6 — Refactor WorkbenchPage
+
+**Verdict:** Done, good.
+
+Evidence:
+- `packages/features/src/pages/WorkbenchPage.tsx` is down to ~143 lines.
+- Tools live in `packages/features/src/components/Workbench/`.
+- `packages/features/src/pages/WorkbenchPage.test.tsx` passes.
+
+Next improvement:
+- Add “Share output to Circle” and “Save as community finding” for tools where output is useful to a group.
+
+### P1.7 — Refactor ProfilePage
+
+**Verdict:** Mostly done, but not fully simplified.
+
+Evidence:
+- `packages/features/src/pages/ProfilePage.tsx` is down to ~340 lines.
+- Extracted components exist under `packages/features/src/components/Profile/`.
+
+Gap:
+- Profile still owns achievements/reputation calculation and several presentation concerns. Good enough for maintainability, but not yet a clean domain/presenter split.
+- `CropModal.tsx` exists but is nested under `EditProfileModal`; that is fine, but tests should cover avatar/crop flow if profile becomes community-facing.
+
+## Community Strategy: Make Circles the Daily Developer Loop
+
+The product should position Circles as “private collective memory for dev communities”. The killer loop is:
+
+1. A developer finds a repo, command, article, plugin, workflow, or Workbench result.
+2. They capture it into their vault with `why_saved`.
+3. DevDeck suggests a concise summary and tags.
+4. They share it to a Circle with context.
+5. The Circle receives a digest/feed of useful findings.
+6. Other members save, fork, star, comment, or convert it into a runbook/deck.
+7. High-signal findings become public/community showcase material.
+
+This turns DevDeck from “my bookmark vault” into “our community’s reusable engineering memory”.
+
+## Development Plan
+
+### Phase 0 — Evidence cleanup and parity
+
+- Update `openspec/changes/navigation-ux-overhaul/tasks.md` to match completed work or archive the change. **Done in this review; full workspace test + manual mobile drawer audit still remain.**
+- Add Circles routes to `apps/desktop/src/renderer/src/App.tsx` for parity with Web. **Done in this review.**
+- Align English roadmap with Spanish detailed Circles/social roadmap. **Started in this review by adding Wave 12 details to `ROADMAP.md`.**
+- Add a short product note in docs explaining Circles as the community contribution model.
+
+### Phase 1 — Make community sharing useful, not noisy
+
+- Add direct “Share to Circle” affordances to Workbench outputs, runbooks, commands, cheatsheets, repos, and captured items.
+- Require/encourage a short “why this matters” note when sharing to a Circle.
+- Show shared context in Circle detail: who shared, why, tags, source, and save/fork actions.
+- Keep Social nav visible as a strategic entry point, but add empty states that guide the user to create/join a Circle instead of showing dead lists.
+
+### Phase 2 — Circle feed and digest
+
+- Create a Circle activity feed combining shared items, comments/reactions, decks, and runbooks.
+- Add weekly Circle digest notifications once notification generation is reliable.
+- Add filters by tag, item type, and contributor.
+- Make “best finds this week” easy to export/share externally.
+
+### Phase 3 — Contribution and reputation with signal
+
+- Score contributions by saves/forks/usefulness, not raw posting volume.
+- Add lightweight reactions: useful, tried, needs-review.
+- Add member expertise badges based on accepted/high-signal contributions.
+- Surface trusted contributors in public profiles and launch/community pages.
+
+### Phase 4 — Public visibility loop
+
+- Let Circles publish selected findings/decks publicly.
+- Add SEO-friendly public pages for curated community collections.
+- Build launch assets around real community use: “what this Circle found this week”.
+- Keep enterprise/org features separate from community Circles; do not confuse team compliance with community discovery.
+
+## Immediate Next PR Recommendation
+
+Start with a small, reviewable PR:
+
+1. Add the Circles/community product note in English and Spanish docs.
+2. Add/adjust tests for Desktop route parity and NavSidebar social behavior.
+3. Complete manual responsive drawer audit.
+4. Decide whether Runbooks, Explore/Trending, and Decks need first-class sidebar entries or contextual entry points.
+
+This is the right foundation before adding more social behavior. Architecture first, velocity second.
+
+## Verified Commands
+
+- `go test ./internal/ai/...` — passed after running outside sandbox because Go build cache was blocked.
+- `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json` — passed.
+- `./node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json` — passed after adding Desktop Circles routes.
+- `./node_modules/.bin/vitest run src/components/NavSidebar.test.tsx src/components/SyncStatusIndicator.test.tsx src/components/UnifiedCommandPalette.test.tsx src/components/GlobalSearchModal.test.tsx src/pages/WorkbenchPage.test.tsx` — 5 files / 30 tests passed.
+
+## Current Working Tree Note
+
+There was already an unstaged change in `apps/desktop/src/main/index.ts` adding `webSecurity: !process.env.ELECTRON_RENDERER_URL`. This review did not modify that line.

--- a/docs/CIRCLES_COMMUNITY.es.md
+++ b/docs/CIRCLES_COMMUNITY.es.md
@@ -1,0 +1,40 @@
+# Circles — Modelo de contribución comunitaria
+
+Circles es la memoria colectiva privada de DevDeck para comunidades de developers.
+
+La idea es simple: cuando alguien encuentra un repo, comando, artículo, plugin, workflow, runbook o salida del Workbench que sirve, eso no debería perderse en Slack, Discord, Telegram o el historial del chat. Tiene que transformarse en conocimiento reutilizable para el grupo.
+
+## Loop de producto
+
+1. Un developer captura un hallazgo en su vault personal.
+2. DevDeck lo enriquece con tags, resumen, fuente y contexto de `why_saved`.
+3. El developer lo comparte a un Circle con una nota corta explicando por qué importa.
+4. Los miembros pueden guardar, forkear, starrear, probar o convertirlo en runbook/deck.
+5. Los hallazgos de mayor señal pueden convertirse en digest semanal, colección pública o showcase de la comunidad.
+
+## Qué pertenece a un Circle
+
+- Repos que vale la pena probar.
+- Comandos CLI y snippets de setup.
+- Cheatsheets y workflows reutilizables.
+- Salidas del Workbench que conviene preservar.
+- Notas de debugging y runbooks operativos.
+- Artículos o docs con una explicación clara de “cuándo esto ayuda”.
+
+## Principios de producto
+
+- **Señal sobre volumen:** importa más la calidad de la contribución que postear mucho.
+- **Contexto obligatorio:** cada hallazgo compartido debería explicar por qué importa.
+- **Privado primero:** Circles es para grupos de confianza antes que descubrimiento público.
+- **Personal + colectivo:** cada usuario mantiene su vault y decide qué ayuda al grupo.
+- **Divulgación progresiva:** un usuario solo no debe sentirse abrumado, pero una comunidad sí debe ver Circles como flujo principal.
+
+## Estrategia de crecimiento
+
+Circles es el puente entre utilidad individual y visibilidad comunitaria:
+
+- El usuario individual obtiene valor diario con capture, search, workbench, repos, commands y cheatsheets.
+- Los grupos obtienen valor con hallazgos compartidos, digests, runbooks y decks reutilizables.
+- Las páginas públicas pueden mostrar colecciones seleccionadas de alta señal sin exponer contenido privado del Circle.
+
+Esto convierte a DevDeck en algo más que un bookmark manager: pasa a ser la memoria de ingeniería reutilizable de una comunidad.

--- a/docs/CIRCLES_COMMUNITY.md
+++ b/docs/CIRCLES_COMMUNITY.md
@@ -1,0 +1,40 @@
+# Circles — Community Contribution Model
+
+Circles are DevDeck's private collective memory for developer communities.
+
+The goal is simple: when someone finds a useful repo, command, article, plugin, workflow, runbook, or Workbench output, it should not disappear in Slack, Discord, Telegram, or chat history. It should become reusable knowledge for the group.
+
+## Product loop
+
+1. A developer captures a finding into their personal vault.
+2. DevDeck enriches it with tags, summary, source, and `why_saved` context.
+3. The developer shares it to a Circle with a short note explaining why it matters.
+4. Circle members can save, fork, star, try, or turn it into a runbook/deck.
+5. High-signal findings become weekly digests, public collections, or community showcases.
+
+## What belongs in a Circle
+
+- Repositories worth trying.
+- CLI commands and setup snippets.
+- Cheatsheets and reusable workflows.
+- Workbench outputs worth preserving.
+- Debugging notes and operational runbooks.
+- Articles or docs with a clear “when this helps” explanation.
+
+## Product principles
+
+- **Signal over volume:** contribution quality matters more than posting frequency.
+- **Context is required:** every shared finding should explain why it matters.
+- **Private first:** Circles are for trusted groups before public discovery.
+- **Personal + collective:** users keep their own vault, then choose what helps the group.
+- **Progressive disclosure:** solo users should not be overwhelmed, but communities should see Circles as a first-class workflow.
+
+## Growth strategy
+
+Circles are the bridge from individual utility to community visibility:
+
+- Individual users get daily value from capture, search, workbench, repos, commands, and cheatsheets.
+- Groups get value from shared findings, digests, runbooks, and reusable decks.
+- Public pages can showcase selected high-signal collections without exposing private Circle content.
+
+This makes DevDeck more than a bookmark manager: it becomes the reusable engineering memory of a community.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -11,6 +11,7 @@
 | [PRD.md](PRD.md) | **Product Requirements Document.** Visión, tipos de items, funcionalidades por ola (1–7), user stories, métricas, constraints, decisiones y riesgos. Punto de entrada principal para entender el producto. |
 | [VISION.md](VISION.md) | **Visión y posicionamiento.** Qué es DevDeck (y qué no es), diferenciadores genuinos, taglines por audiencia, roadmap de posicionamiento y preguntas frecuentes de posicionamiento. |
 | [DEV_WORKBENCH.md](DEV_WORKBENCH.md) · [DEV_WORKBENCH.es.md](DEV_WORKBENCH.es.md) | **Developer Workbench.** Evolución de memoria a acción contextual: utilities locales, paleta, requests reutilizables, límites de producto y roadmap recomendado. |
+| [CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md) · [CIRCLES_COMMUNITY.es.md](CIRCLES_COMMUNITY.es.md) | **Circles y contribución comunitaria.** Modelo de producto para convertir hallazgos individuales en memoria reutilizable para grupos/comunidades de developers. |
 | [COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md) | **Análisis competitivo.** Comparación detallada con GitHub Stars, Raindrop, Pocket, Notion, Obsidian, Raycast y Pieces.app. Incluye tablas de pros/contras y posicionamiento relativo. |
 
 ---
@@ -56,8 +57,9 @@ Si llegás sin contexto, el orden recomendado es:
 2. **[VISION.md](VISION.md)** — por qué existe y para quién
 3. **[PRD.md](PRD.md)** — qué hace, cómo crece, qué se decidió
 4. **[DEV_WORKBENCH.md](DEV_WORKBENCH.md)** — hacia dónde evoluciona memoria + acción
-5. **[ARCHITECTURE.md](ARCHITECTURE.md)** — cómo está construido
-6. **[ROADMAP.md](../ROADMAP.md)** — qué está hecho y qué viene
+5. **[CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md)** — cómo DevDeck convierte hallazgos en memoria comunitaria
+6. **[ARCHITECTURE.md](ARCHITECTURE.md)** — cómo está construido
+7. **[ROADMAP.md](../ROADMAP.md)** — qué está hecho y qué viene
 
 Para contribuir o extender el producto:
 - Agregá items al PRD antes de implementar

--- a/openspec/changes/navigation-ux-overhaul/tasks.md
+++ b/openspec/changes/navigation-ux-overhaul/tasks.md
@@ -1,18 +1,18 @@
 # Tasks: Navigation & Information Architecture Overhaul (P0.UX)
 
 ## Phase 1: Global Shell & Component Infrastructure
-- [ ] **Task 1.1:** Create new `NavSidebar.tsx` in `packages/features/src/components/` with complete link list, icons, active tab styling, and progressive disclosure (hiding social/team options by default).
-- [ ] **Task 1.2:** Refactor `AppShell.tsx` in `packages/features/src/components/` to implement two-column layout using Tailwind flex/grid, and integrate `NavSidebar` (with mobile drawer state).
-- [ ] **Task 1.3:** Simplify `Topbar.tsx` in `packages/features/src/components/` to remove the redundant primary/secondary nav links and include the mobile menu toggle callback.
+- [x] **Task 1.1:** Create new `NavSidebar.tsx` in `packages/features/src/components/` with complete link list, icons, active tab styling, and progressive disclosure (Team hidden without an active organization; Social intentionally remains visible as the Circles/community entry point).
+- [x] **Task 1.2:** Refactor `AppShell.tsx` in `packages/features/src/components/` to implement two-column layout using Tailwind flex/grid, and integrate `NavSidebar` (with mobile drawer state).
+- [x] **Task 1.3:** Simplify `Topbar.tsx` in `packages/features/src/components/` to remove the redundant primary/secondary nav links and include the mobile menu toggle callback.
 
 ## Phase 2: Page Integrations & Layout Unification
-- [ ] **Task 2.1:** Refactor `HomePage.tsx` (Repos list) to remove its manual `Topbar`/`Sidebar` mounts and wrap the entire screen inside the new `<AppShell>`.
-- [ ] **Task 2.2:** Update `ItemsPage.tsx` to ensure layout structure sits perfectly inside the new two-column `AppShell`.
-- [ ] **Task 2.3:** Refactor `CheatsheetsListPage.tsx` and `CheatsheetDetailPage.tsx` to wrap inside `<AppShell>`.
-- [ ] **Task 2.4:** Refactor `DiscoveryPage.tsx` to integrate inside `<AppShell>` (removing its manual header container).
-- [ ] **Task 2.5:** Wrap other authenticated pages (`SettingsPage.tsx`, `ProfilePage.tsx`, `AdminDashboardPage.tsx`) cleanly under `<AppShell>`.
+- [x] **Task 2.1:** Refactor `HomePage.tsx` (Repos list) to remove its manual `Topbar`/`Sidebar` mounts and wrap the entire screen inside the new `<AppShell>`.
+- [x] **Task 2.2:** Update `ItemsPage.tsx` to ensure layout structure sits perfectly inside the new two-column `AppShell`.
+- [x] **Task 2.3:** Refactor `CheatsheetsListPage.tsx` and `CheatsheetDetailPage.tsx` to wrap inside `<AppShell>`.
+- [x] **Task 2.4:** Refactor `DiscoveryPage.tsx` to integrate inside `<AppShell>` (removing its manual header container).
+- [x] **Task 2.5:** Wrap other authenticated pages (`SettingsPage.tsx`, `ProfilePage.tsx`, `AdminDashboardPage.tsx`) cleanly under `<AppShell>`.
 
 ## Phase 3: Testing & Quality Assurance
-- [ ] **Task 3.1:** Run typescript type checking: `pnpm typecheck` to guarantee all layout/page props are valid.
-- [ ] **Task 3.2:** Execute test suites: `pnpm test` and fix any broken component rendering or shell mock configurations.
+- [x] **Task 3.1:** Run typescript type checking: `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json` passed on 2026-05-23.
+- [/] **Task 3.2:** Execute test suites: targeted feature tests passed on 2026-05-23 (`NavSidebar`, `SyncStatusIndicator`, `UnifiedCommandPalette`, `GlobalSearchModal`, `WorkbenchPage`). Full workspace `pnpm test` still needs a clean pnpm/corepack run.
 - [ ] **Task 3.3:** Manually audit responsive drawer sliding on mobile viewports.

--- a/packages/features/src/components/ItemCard.test.tsx
+++ b/packages/features/src/components/ItemCard.test.tsx
@@ -1,9 +1,29 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ItemCard } from './ItemCard'
 import type { Item } from '@devdeck/api-client'
+
+const mocks = vi.hoisted(() => ({
+  useAIEnrichItem: vi.fn(),
+  useCircles: vi.fn(),
+  useReviewItemAITags: vi.fn(),
+  useShareToCircle: vi.fn(),
+  useUpdateItem: vi.fn(),
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useAIEnrichItem: mocks.useAIEnrichItem,
+    useCircles: mocks.useCircles,
+    useReviewItemAITags: mocks.useReviewItemAITags,
+    useShareToCircle: mocks.useShareToCircle,
+    useUpdateItem: mocks.useUpdateItem,
+  }
+})
 
 function renderItemCard(ui: React.ReactElement) {
   const client = new QueryClient({
@@ -48,6 +68,15 @@ function makeItem(patch: Partial<Item> = {}): Item {
 }
 
 describe('<ItemCard>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useAIEnrichItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
+    mocks.useReviewItemAITags.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useUpdateItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
   it('renders title and description', () => {
     renderItemCard(<ItemCard item={makeItem()} />)
     expect(screen.getByRole('heading')).toHaveTextContent('charmbracelet/bubbletea')
@@ -161,5 +190,35 @@ describe('<ItemCard>', () => {
       />,
     )
     expect(screen.getByText('ripgrep.dev/docs')).toBeInTheDocument()
+  })
+
+  it('requires context before sharing an item to a Circle', async () => {
+    const user = userEvent.setup()
+    const shareToCircle = vi.fn().mockResolvedValue({})
+    mocks.useCircles.mockReturnValue({
+      data: [{ id: 'circle-1', name: 'Frontend Guild' }],
+      isLoading: false,
+    })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+    renderItemCard(<ItemCard item={makeItem()} />)
+
+    await user.click(screen.getByRole('button', { name: /share in circle/i }))
+
+    const shareItem = screen.getByRole('button', { name: /share item/i })
+    expect(shareItem).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+    fireEvent.change(screen.getByLabelText('Why this matters'), {
+      target: { value: 'Reference repo for terminal UI experiments.' },
+    })
+    await user.click(shareItem)
+
+    await waitFor(() => {
+      expect(shareToCircle).toHaveBeenCalledWith({
+        circleId: 'circle-1',
+        itemId: 'a1b2c3-id',
+      })
+    })
   })
 })

--- a/packages/features/src/components/ItemCard.tsx
+++ b/packages/features/src/components/ItemCard.tsx
@@ -18,7 +18,6 @@ import {
   Users,
   Wrench,
   Share2,
-  Loader2,
   type LucideIcon,
 } from 'lucide-react'
 import type { Item, ItemType } from '@devdeck/api-client'
@@ -33,6 +32,7 @@ import {
 } from '@devdeck/api-client'
 import { TagChip, hashIndex, showToast } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
+import { ShareToCirclePanel } from './ShareToCirclePanel'
 
 interface TypeStyle {
   hue: string
@@ -74,8 +74,7 @@ export function ItemCard({ item, onClick }: Props) {
   const { data: circles = [] } = useCircles()
   const shareToCircle = useShareToCircle()
 
-  async function handleShare(e: React.MouseEvent, circleId: string, circleName: string) {
-    e.stopPropagation()
+  async function handleShare({ circleId, circleName }: { circleId: string; circleName: string }) {
     try {
       await shareToCircle.mutateAsync({ circleId, itemId: item.id })
       showToast(t('card.shared_success', { name: circleName }))
@@ -179,38 +178,22 @@ export function ItemCard({ item, onClick }: Props) {
           {shareMenuOpen && (
             <div
               onClick={(e) => e.stopPropagation()}
-              className="absolute right-0 top-6 z-30 w-48 bg-bg-card border-3 border-ink shadow-hard p-2 font-mono text-[11px]"
+              className="absolute right-0 top-6 z-30 w-72 font-mono text-[11px]"
             >
-              <div className="flex items-center justify-between border-b-2 border-ink pb-1.5 mb-1.5">
-                <span className="font-display font-black uppercase text-[9px] tracking-wider">
-                  {t('card.share_in')}
-                </span>
-                <button
-                  onClick={() => setShareMenuOpen(false)}
-                  className="hover:text-accent-pink"
-                >
-                  <X size={10} strokeWidth={3} />
-                </button>
-              </div>
-
               {circles.length === 0 ? (
-                <div className="py-1 text-ink-soft text-center text-[10px]">
+                <div className="bg-bg-card border-3 border-ink shadow-hard p-3 py-2 text-ink-soft text-center text-[10px]">
                   {t('card.no_circles')}
                 </div>
               ) : (
-                <div className="max-h-32 overflow-y-auto space-y-1">
-                  {circles.map((c) => (
-                    <button
-                      key={c.id}
-                      disabled={shareToCircle.isPending}
-                      onClick={(e) => handleShare(e, c.id, c.name)}
-                      className="w-full text-left p-1 hover:bg-accent-pink hover:text-white truncate border border-transparent hover:border-ink transition-colors flex items-center justify-between gap-1"
-                    >
-                      <span className="truncate">{c.name}</span>
-                      {shareToCircle.isPending && <Loader2 size={10} className="animate-spin shrink-0" />}
-                    </button>
-                  ))}
-                </div>
+                <ShareToCirclePanel
+                  circles={circles}
+                  isSharing={shareToCircle.isPending}
+                  title={t('card.share_in')}
+                  description="Add context so the Circle knows why this item is useful."
+                  submitLabel="Share item"
+                  onClose={() => setShareMenuOpen(false)}
+                  onShare={handleShare}
+                />
               )}
             </div>
           )}

--- a/packages/features/src/components/ShareToCirclePanel.tsx
+++ b/packages/features/src/components/ShareToCirclePanel.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { Share2, X } from 'lucide-react'
+import { Button } from '@devdeck/ui'
+import type { Circle } from '@devdeck/api-client'
+
+interface ShareToCirclePanelProps {
+  circles: Circle[]
+  isSharing?: boolean
+  title?: string
+  description?: string
+  submitLabel?: string
+  requireContext?: boolean
+  onClose: () => void
+  onShare: (input: { circleId: string; circleName: string; context: string }) => Promise<void> | void
+}
+
+export function ShareToCirclePanel({
+  circles,
+  isSharing = false,
+  title = 'Share to Circle',
+  description = 'Add context so the group knows why this is useful.',
+  submitLabel = 'Share',
+  requireContext = true,
+  onClose,
+  onShare,
+}: ShareToCirclePanelProps) {
+  const [circleId, setCircleId] = useState('')
+  const [context, setContext] = useState('')
+
+  const selectedCircle = circles.find((circle) => circle.id === circleId)
+  const canSubmit = !!selectedCircle && (!requireContext || context.trim().length > 0) && !isSharing
+
+  async function submit() {
+    if (!selectedCircle || !canSubmit) return
+    await onShare({
+      circleId: selectedCircle.id,
+      circleName: selectedCircle.name,
+      context: context.trim(),
+    })
+  }
+
+  return (
+    <div className="grid gap-3 border-3 border-ink bg-bg-elevated p-4 shadow-hard-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-display text-sm font-black uppercase">{title}</h3>
+          <p className="mt-1 font-mono text-xs text-ink-soft">{description}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="border-2 border-ink bg-bg-card p-1 hover:bg-accent-pink"
+          aria-label="Close Circle share"
+        >
+          <X size={14} strokeWidth={3} />
+        </button>
+      </div>
+
+      <label className="grid gap-2">
+        <span className="font-display text-xs font-black uppercase tracking-widest">Circle</span>
+        <select
+          value={circleId}
+          onChange={(event) => setCircleId(event.target.value)}
+          className="border-3 border-ink bg-bg-primary p-2 font-mono text-sm outline-none focus:bg-accent-yellow/10"
+        >
+          <option value="">Choose a Circle</option>
+          {circles.map((circle) => (
+            <option key={circle.id} value={circle.id}>
+              {circle.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="grid gap-2">
+        <span className="font-display text-xs font-black uppercase tracking-widest">Why this matters</span>
+        <textarea
+          value={context}
+          onChange={(event) => setContext(event.target.value)}
+          placeholder="Example: useful for debugging JWT auth in our API workshop."
+          className="min-h-32 w-full resize-y border-3 border-ink bg-bg-primary p-3 font-mono text-sm outline-none focus:bg-accent-yellow/10"
+        />
+      </label>
+
+      <Button type="button" size="sm" onClick={submit} disabled={!canSubmit}>
+        <span className="flex items-center gap-2">
+          <Share2 size={15} strokeWidth={3} />
+          {submitLabel}
+        </span>
+      </Button>
+    </div>
+  )
+}

--- a/packages/features/src/components/Workbench/shared.tsx
+++ b/packages/features/src/components/Workbench/shared.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { Clipboard, Save } from 'lucide-react'
+import { Clipboard, Save, Share2 } from 'lucide-react'
 import { Button, showToast } from '@devdeck/ui'
-import { useCapture } from '@devdeck/api-client'
+import { useCapture, useCircles, useShareToCircle } from '@devdeck/api-client'
+import { ShareToCirclePanel } from '../ShareToCirclePanel'
 
 export function ToolFrame({
   title,
@@ -58,6 +59,9 @@ export function ResultActions({
   itemType?: 'snippet' | 'note'
 }) {
   const capture = useCapture()
+  const { data: circles = [] } = useCircles()
+  const shareToCircle = useShareToCircle()
+  const [shareOpen, setShareOpen] = React.useState(false)
 
   async function copy() {
     if (!output) return
@@ -82,20 +86,67 @@ export function ResultActions({
     }
   }
 
+  async function share({ circleId, context }: { circleId: string; context: string }) {
+    if (!output.trim()) return
+    try {
+      const captured = await capture.mutateAsync({
+        source: 'manual',
+        text: output,
+        title_hint: title,
+        type_hint: itemType,
+        tags: ['workbench', 'circle-share'],
+        why_saved: context,
+      })
+      const itemId = captured.item?.id || captured.duplicate_of
+      if (!itemId) throw new Error('Could not capture output before sharing.')
+
+      await shareToCircle.mutateAsync({ circleId, itemId })
+      showToast('Shared to Circle', 'success')
+      setShareOpen(false)
+    } catch (err) {
+      showToast((err as Error).message || 'Could not share output', 'error')
+    }
+  }
+
   return (
-    <div className="flex flex-wrap gap-3">
-      <Button type="button" size="sm" variant="secondary" onClick={copy} disabled={!output}>
-        <span className="flex items-center gap-2">
-          <Clipboard size={15} strokeWidth={3} />
-          Copy
-        </span>
-      </Button>
-      <Button type="button" size="sm" onClick={save} disabled={!output || capture.isPending}>
-        <span className="flex items-center gap-2">
-          <Save size={15} strokeWidth={3} />
-          Save output
-        </span>
-      </Button>
+    <div className="grid gap-3">
+      <div className="flex flex-wrap gap-3">
+        <Button type="button" size="sm" variant="secondary" onClick={copy} disabled={!output}>
+          <span className="flex items-center gap-2">
+            <Clipboard size={15} strokeWidth={3} />
+            Copy
+          </span>
+        </Button>
+        <Button type="button" size="sm" onClick={save} disabled={!output || capture.isPending}>
+          <span className="flex items-center gap-2">
+            <Save size={15} strokeWidth={3} />
+            Save output
+          </span>
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={() => setShareOpen((open) => !open)}
+          disabled={!output || circles.length === 0}
+        >
+          <span className="flex items-center gap-2">
+            <Share2 size={15} strokeWidth={3} />
+            Share to Circle
+          </span>
+        </Button>
+      </div>
+
+      {shareOpen && (
+        <ShareToCirclePanel
+          circles={circles}
+          isSharing={capture.isPending || shareToCircle.isPending}
+          title="Share output to Circle"
+          submitLabel="Save and share"
+          onClose={() => setShareOpen(false)}
+          onShare={share}
+        />
+      )}
     </div>
   )
 }

--- a/packages/features/src/pages/CheatsheetDetailPage.test.tsx
+++ b/packages/features/src/pages/CheatsheetDetailPage.test.tsx
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { CheatsheetDetailPage } from './CheatsheetDetailPage'
+
+const mocks = vi.hoisted(() => ({
+  useParams: vi.fn(),
+  useNavigate: vi.fn(),
+  useCheatsheet: vi.fn(),
+  useCreateEntry: vi.fn(),
+  useDeleteCheatsheet: vi.fn(),
+  useDeleteEntry: vi.fn(),
+  useUpdateEntry: vi.fn(),
+  useCapture: vi.fn(),
+  useCircles: vi.fn(),
+  useShareToCircle: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useParams: mocks.useParams,
+  useNavigate: mocks.useNavigate,
+}))
+
+vi.mock('../components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useCheatsheet: mocks.useCheatsheet,
+    useCreateEntry: mocks.useCreateEntry,
+    useDeleteCheatsheet: mocks.useDeleteCheatsheet,
+    useDeleteEntry: mocks.useDeleteEntry,
+    useUpdateEntry: mocks.useUpdateEntry,
+    useCapture: mocks.useCapture,
+    useCircles: mocks.useCircles,
+    useShareToCircle: mocks.useShareToCircle,
+  }
+})
+
+vi.mock('@devdeck/ui', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/ui')>('@devdeck/ui')
+  return {
+    ...actual,
+    showToast: mocks.showToast,
+  }
+})
+
+const cheatsheet = {
+  id: 'cheat-1',
+  slug: 'git-basics',
+  title: 'Git Basics',
+  category: 'vcs',
+  icon: '🌿',
+  color: '#00ff99',
+  description: 'Commands we use every day.',
+  is_seed: false,
+  created_at: '2026-05-23T00:00:00Z',
+  updated_at: '2026-05-23T00:00:00Z',
+  entries: [
+    {
+      id: 'entry-1',
+      cheatsheet_id: 'cheat-1',
+      label: 'Status',
+      command: 'git status --short',
+      description: 'Check concise working tree status.',
+      tags: ['git', 'daily'],
+      position: 0,
+    },
+  ],
+}
+
+describe('<CheatsheetDetailPage>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useParams.mockReturnValue({ id: 'cheat-1' })
+    mocks.useNavigate.mockReturnValue(vi.fn())
+    mocks.useCheatsheet.mockReturnValue({ data: cheatsheet, isLoading: false, error: null })
+    mocks.useCreateEntry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null })
+    mocks.useDeleteCheatsheet.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useDeleteEntry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useUpdateEntry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null })
+    mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
+  it('shares a cheatsheet to a Circle with required context', async () => {
+    const capture = vi.fn().mockResolvedValue({
+      item: { id: 'item-1' },
+      duplicate_of: null,
+      enrichment_status: 'ok',
+    })
+    const shareToCircle = vi.fn().mockResolvedValue({})
+    mocks.useCapture.mockReturnValue({ mutateAsync: capture, isPending: false })
+    mocks.useCircles.mockReturnValue({
+      data: [{ id: 'circle-1', name: 'Backend Circle' }],
+      isLoading: false,
+    })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+    render(<CheatsheetDetailPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /share cheatsheet to circle/i }))
+    const saveAndShare = screen.getByRole('button', { name: /save and share cheatsheet/i })
+    expect(saveAndShare).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+    fireEvent.change(screen.getByLabelText('Why this matters'), {
+      target: { value: 'Useful baseline commands for onboarding.' },
+    })
+    fireEvent.click(saveAndShare)
+
+    await waitFor(() => {
+      expect(capture).toHaveBeenCalledWith({
+        source: 'manual',
+        text: expect.stringContaining('git status --short'),
+        title_hint: 'Cheatsheet: Git Basics',
+        type_hint: 'snippet',
+        tags: ['cheatsheet', 'vcs', 'circle-share'],
+        why_saved: 'Useful baseline commands for onboarding.',
+      })
+      expect(shareToCircle).toHaveBeenCalledWith({ circleId: 'circle-1', itemId: 'item-1' })
+    })
+  })
+})

--- a/packages/features/src/pages/CheatsheetDetailPage.tsx
+++ b/packages/features/src/pages/CheatsheetDetailPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Copy, Filter, Plus, Search, Trash2, X } from 'lucide-react'
+import { ArrowLeft, Copy, Filter, Plus, Search, Share2, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button } from '@devdeck/ui'
@@ -9,10 +9,14 @@ import {
   useDeleteCheatsheet,
   useDeleteEntry,
   useUpdateEntry,
+  useCapture,
+  useCircles,
+  useShareToCircle,
 } from '@devdeck/api-client'
-import type { Entry } from '@devdeck/api-client'
+import type { CheatsheetDetail, Entry } from '@devdeck/api-client'
 import { showToast } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
+import { ShareToCirclePanel } from '../components/ShareToCirclePanel'
 
 export function CheatsheetDetailPage() {
   const { t } = useTranslation()
@@ -24,11 +28,15 @@ export function CheatsheetDetailPage() {
   const [searchFilter, setSearchFilter] = useState('')
   const [editingEntry, setEditingEntry] = useState<Entry | null>(null)
   const [addingNew, setAddingNew] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
 
   const createEntry = useCreateEntry(id ?? '')
   const updateEntry = useUpdateEntry(id ?? '')
   const deleteEntry = useDeleteEntry(id ?? '')
   const deleteCheatsheet = useDeleteCheatsheet()
+  const capture = useCapture()
+  const { data: circles = [] } = useCircles()
+  const shareToCircle = useShareToCircle()
 
   async function handleDeleteCheatsheet() {
     if (!id || !detail) return
@@ -128,6 +136,28 @@ export function CheatsheetDetailPage() {
     }
   }
 
+  async function handleShareCheatsheet({ circleId, context }: { circleId: string; context: string }) {
+    if (!detail) return
+    try {
+      const captured = await capture.mutateAsync({
+        source: 'manual',
+        text: formatCheatsheetForSharing(detail),
+        title_hint: `Cheatsheet: ${detail.title}`,
+        type_hint: 'snippet',
+        tags: ['cheatsheet', detail.category, 'circle-share'].filter(Boolean),
+        why_saved: context,
+      })
+      const itemId = captured.item?.id || captured.duplicate_of
+      if (!itemId) throw new Error('Could not capture cheatsheet before sharing.')
+
+      await shareToCircle.mutateAsync({ circleId, itemId })
+      showToast('Cheatsheet shared to Circle', 'success')
+      setShareOpen(false)
+    } catch (err) {
+      showToast((err as Error).message || 'Could not share cheatsheet', 'error')
+    }
+  }
+
   return (
     <AppShell contentClassName="flex-1 overflow-y-auto">
       <div className="min-h-full bg-bg-primary">
@@ -160,6 +190,16 @@ export function CheatsheetDetailPage() {
             {detail.description}
           </p>
         )}
+        <button
+          type="button"
+          onClick={() => setShareOpen((open) => !open)}
+          disabled={circles.length === 0}
+          aria-label="Share cheatsheet to Circle"
+          className="border-3 border-ink p-2 bg-bg-card shadow-hard hover:bg-accent-yellow
+                     disabled:opacity-50 transition-colors ml-auto lg:ml-0"
+        >
+          <Share2 size={18} strokeWidth={3} />
+        </button>
         {!detail.is_seed && (
           <button
             type="button"
@@ -175,6 +215,20 @@ export function CheatsheetDetailPage() {
       </header>
 
       <div className="max-w-5xl mx-auto p-6">
+        {shareOpen && (
+          <div className="mb-6">
+            <ShareToCirclePanel
+              circles={circles}
+              isSharing={capture.isPending || shareToCircle.isPending}
+              title="Share cheatsheet to Circle"
+              description="Add context so the Circle knows when to use this cheatsheet."
+              submitLabel="Save and share cheatsheet"
+              onClose={() => setShareOpen(false)}
+              onShare={handleShareCheatsheet}
+            />
+          </div>
+        )}
+
         {/* Toolbar */}
         <div className="flex flex-wrap items-center gap-3 mb-6">
           {/* Search */}
@@ -259,6 +313,26 @@ export function CheatsheetDetailPage() {
       </div>
     </AppShell>
   )
+}
+
+function formatCheatsheetForSharing(detail: CheatsheetDetail): string {
+  const lines = [`# ${detail.title}`, '', `Category: ${detail.category}`]
+  if (detail.description) {
+    lines.push('', detail.description)
+  }
+  if (detail.entries.length > 0) {
+    lines.push('', '## Entries')
+    detail.entries.forEach((entry) => {
+      lines.push('', `### ${entry.label}`, '', '```bash', entry.command, '```')
+      if (entry.description) {
+        lines.push('', entry.description)
+      }
+      if (entry.tags.length > 0) {
+        lines.push('', `Tags: ${entry.tags.join(', ')}`)
+      }
+    })
+  }
+  return lines.join('\n')
 }
 
 // ─── Entry Card ───

--- a/packages/features/src/pages/ItemDetailPage.tsx
+++ b/packages/features/src/pages/ItemDetailPage.tsx
@@ -10,6 +10,7 @@ import {
 	Library,
 	Plus,
 	Play,
+	Share2,
 	Sparkles,
 	Trash2,
 	Users,
@@ -27,6 +28,9 @@ import {
 	useUpdateRunbookStep,
 	useDeleteRunbook,
 	useUpdateItem,
+	useCapture,
+	useCircles,
+	useShareToCircle,
 	type Item,
 	type Runbook,
 	type RunbookStep,
@@ -35,6 +39,7 @@ import { NotesEditor } from '../components/NotesEditor'
 import { TagsEditor } from '../components/TagsEditor'
 import { TeamReviewCard } from '../components/TeamReviewCard'
 import { AppShell } from '../components/AppShell'
+import { ShareToCirclePanel } from '../components/ShareToCirclePanel'
 import { useTranslation } from '@devdeck/i18n'
 
 export function ItemDetailPage() {
@@ -351,6 +356,10 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 	const { t } = useTranslation()
 	const addStep = useAddRunbookStep()
 	const deleteRunbook = useDeleteRunbook()
+	const capture = useCapture()
+	const { data: circles = [] } = useCircles()
+	const shareToCircle = useShareToCircle()
+	const [shareOpen, setShareOpen] = useState(false)
 
 	async function handleAddStep() {
 		const label = window.prompt(t('item_detail.runbook.step_label_prompt'))
@@ -368,6 +377,28 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 		await deleteRunbook.mutateAsync({ id: runbook.id, itemId: runbook.item_id })
 	}
 
+	async function handleShare({ circleId, context }: { circleId: string; context: string }) {
+		const text = formatRunbookForSharing(runbook)
+		try {
+			const captured = await capture.mutateAsync({
+				source: 'manual',
+				text,
+				title_hint: `Runbook: ${runbook.title}`,
+				type_hint: 'workflow',
+				tags: ['runbook', 'circle-share'],
+				why_saved: context,
+			})
+			const itemId = captured.item?.id || captured.duplicate_of
+			if (!itemId) throw new Error('Could not capture runbook before sharing.')
+
+			await shareToCircle.mutateAsync({ circleId, itemId })
+			showToast('Runbook shared to Circle', 'success')
+			setShareOpen(false)
+		} catch (err) {
+			showToast((err as Error).message || 'Could not share runbook', 'error')
+		}
+	}
+
 	return (
 		<div className="bg-bg-card border-3 border-ink shadow-hard overflow-hidden">
 			<header className="bg-bg-elevated border-b-3 border-ink p-4 flex items-center justify-between">
@@ -375,12 +406,34 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 					<Library size={18} strokeWidth={3} />
 					<h3 className="font-display font-black uppercase text-sm">{runbook.title}</h3>
 				</div>
-				<button onClick={handleDelete} className="p-1 hover:bg-accent-pink transition-colors">
-					<Trash2 size={16} />
-				</button>
+				<div className="flex items-center gap-2">
+					<button
+						onClick={() => setShareOpen((open) => !open)}
+						disabled={circles.length === 0}
+						title="Share runbook to Circle"
+						className="p-1 border-2 border-transparent hover:border-ink hover:bg-accent-yellow transition-colors disabled:opacity-40"
+					>
+						<Share2 size={16} />
+					</button>
+					<button onClick={handleDelete} className="p-1 hover:bg-accent-pink transition-colors">
+						<Trash2 size={16} />
+					</button>
+				</div>
 			</header>
 
 			<div className="p-4 space-y-4">
+				{shareOpen && (
+					<ShareToCirclePanel
+						circles={circles}
+						isSharing={capture.isPending || shareToCircle.isPending}
+						title="Share runbook to Circle"
+						description="Add context so the Circle knows when to use this runbook."
+						submitLabel="Save and share runbook"
+						onClose={() => setShareOpen(false)}
+						onShare={handleShare}
+					/>
+				)}
+
 				{runbook.steps.map((st) => (
 					<RunbookStepItem key={st.id} step={st} />
 				))}
@@ -398,6 +451,26 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 			</div>
 		</div>
 	)
+}
+
+function formatRunbookForSharing(runbook: Runbook): string {
+	const lines = [`# ${runbook.title}`]
+	if (runbook.description) {
+		lines.push('', runbook.description)
+	}
+	if (runbook.steps.length > 0) {
+		lines.push('', '## Steps')
+		runbook.steps.forEach((step, index) => {
+			lines.push('', `${index + 1}. ${step.label}`)
+			if (step.command) {
+				lines.push('', '```bash', step.command, '```')
+			}
+			if (step.description) {
+				lines.push('', step.description)
+			}
+		})
+	}
+	return lines.join('\n')
 }
 
 function RunbookStepItem({ step }: { step: RunbookStep }) {

--- a/packages/features/src/pages/WorkbenchPage.test.tsx
+++ b/packages/features/src/pages/WorkbenchPage.test.tsx
@@ -6,8 +6,10 @@ import { WorkbenchPage } from './WorkbenchPage'
 
 const mocks = vi.hoisted(() => ({
   useCapture: vi.fn(),
+  useCircles: vi.fn(),
   useGlobalSearch: vi.fn(),
   useItem: vi.fn(),
+  useShareToCircle: vi.fn(),
   useUpdateItem: vi.fn(),
 }))
 
@@ -16,8 +18,10 @@ vi.mock('@devdeck/api-client', async () => {
   return {
     ...actual,
     useCapture: mocks.useCapture,
+    useCircles: mocks.useCircles,
     useGlobalSearch: mocks.useGlobalSearch,
     useItem: mocks.useItem,
+    useShareToCircle: mocks.useShareToCircle,
     useUpdateItem: mocks.useUpdateItem,
   }
 })
@@ -39,8 +43,10 @@ describe('<WorkbenchPage>', () => {
     vi.clearAllMocks()
     vi.unstubAllGlobals()
     mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
     mocks.useGlobalSearch.mockReturnValue({ data: [], isLoading: false })
     mocks.useItem.mockReturnValue({ data: undefined, isLoading: false })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     mocks.useUpdateItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     Object.assign(navigator, {
       clipboard: {
@@ -158,5 +164,46 @@ describe('<WorkbenchPage>', () => {
 
     expect(screen.getByLabelText('Expansion preview')).toHaveValue('docker run --rm -it IMAGE sh')
     expect(screen.getByLabelText('Expanded text')).toHaveValue('Deploy with docker run --rm -it IMAGE sh')
+  })
+
+  it('requires context before sharing Workbench output to a Circle', async () => {
+    const captureOutput = vi.fn().mockResolvedValue({
+      item: { id: 'item-1' },
+      duplicate_of: null,
+      enrichment_status: 'ok',
+    })
+    const shareToCircle = vi.fn().mockResolvedValue({})
+    mocks.useCapture.mockReturnValue({ mutateAsync: captureOutput, isPending: false })
+    mocks.useCircles.mockReturnValue({
+      data: [{ id: 'circle-1', name: 'Frontend Guild' }],
+      isLoading: false,
+    })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+    renderWorkbench()
+
+    fireEvent.change(screen.getByLabelText('Input'), { target: { value: '{"name":"DevDeck"}' } })
+    fireEvent.click(screen.getByRole('button', { name: /share to circle/i }))
+
+    const saveAndShare = screen.getByRole('button', { name: /save and share/i })
+    expect(saveAndShare).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+    fireEvent.change(screen.getByLabelText('Why this matters'), {
+      target: { value: 'Useful payload shape for our API examples.' },
+    })
+    fireEvent.click(saveAndShare)
+
+    await waitFor(() => {
+      expect(captureOutput).toHaveBeenCalledWith({
+        source: 'manual',
+        text: '{\n  "name": "DevDeck"\n}',
+        title_hint: 'Formatted JSON',
+        type_hint: 'snippet',
+        tags: ['workbench', 'circle-share'],
+        why_saved: 'Useful payload shape for our API examples.',
+      })
+      expect(shareToCircle).toHaveBeenCalledWith({ circleId: 'circle-1', itemId: 'item-1' })
+    })
   })
 })


### PR DESCRIPTION
Closes #61

## Type
- [x] New feature

## Summary
- Adds a reusable context-required Circle sharing panel.
- Connects Workbench outputs, existing items, runbooks, and cheatsheets into the Circle contribution loop.
- Adds Desktop Circles route parity and documents Circles as DevDeck's community contribution model.

## Changes
| File | Change |
|------|--------|
| `packages/features/src/components/ShareToCirclePanel.tsx` | Adds reusable Circle share UI with required context. |
| `packages/features/src/components/Workbench/shared.tsx` | Captures Workbench output and shares it to a Circle. |
| `packages/features/src/components/ItemCard.tsx` | Reuses the shared Circle panel for existing item sharing. |
| `packages/features/src/pages/ItemDetailPage.tsx` | Formats runbooks as markdown, captures them, and shares them to Circles. |
| `packages/features/src/pages/CheatsheetDetailPage.tsx` | Formats cheatsheets as markdown, captures them, and shares them to Circles. |
| `apps/desktop/src/renderer/src/App.tsx` | Adds Desktop Circles route parity. |
| `docs/CIRCLES_COMMUNITY*.md` | Documents the Circles community contribution model. |
| `docs/APP_AUDIT_REVIEW_2026_05.md` | Records the audit verification and community plan. |
| `openspec/changes/navigation-ux-overhaul/tasks.md` | Corrects stale P0.UX task evidence. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json`
- [x] `./node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json`
- [x] `./node_modules/.bin/vitest run src/components/NavSidebar.test.tsx src/components/SyncStatusIndicator.test.tsx src/components/UnifiedCommandPalette.test.tsx src/components/GlobalSearchModal.test.tsx src/components/ItemCard.test.tsx src/pages/ItemDetailPage.test.tsx src/pages/CheatsheetDetailPage.test.tsx src/pages/WorkbenchPage.test.tsx`
- [x] `./node_modules/.bin/vitest run src/renderer/src/App.routes.test.ts`

## Notes
This PR intentionally uses the existing capture-then-share backend contract: content is captured as an item with `why_saved` context, then shared to the selected Circle. That avoids a backend migration while preserving useful contribution context.

The diff is above the usual small-review target because it includes docs, route parity, shared UI extraction, and tests across multiple sharing surfaces. It is still one cohesive product slice: context-rich Circle community sharing.
