### PR TITLE
feat(desktop): add circles route parity

### DIFF
--- a/apps/desktop/src/renderer/src/App.routes.test.ts
+++ b/apps/desktop/src/renderer/src/App.routes.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const appSource = readFileSync(resolve(here, 'App.tsx'), 'utf8')
+
+describe('desktop route parity', () => {
+  it('registers Circles routes exported by shared features', () => {
+    expect(appSource).toContain('CirclesPage')
+    expect(appSource).toContain('CircleDetailPage')
+    expect(appSource).toContain('CircleJoinPage')
+    expect(appSource).toContain('path="/circles"')
+    expect(appSource).toContain('path="/circles/:id"')
+    expect(appSource).toContain('path="/circles/join/:inviteCode"')
+  })
+})

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,9 @@ import {
   CheatsheetDetailPage,
   CheatsheetsListPage,
   CaptureModal,
+  CircleDetailPage,
+  CircleJoinPage,
+  CirclesPage,
   DiscoveryPage,
   HomePage,
   ItemDetailPage,
@@ -295,6 +298,24 @@ function AnimatedRoutes() {
             path="/cheatsheets/:id"
             element={
               <AuthGuard>{withTransition(<CheatsheetDetailPage />)}</AuthGuard>
+            }
+          />
+          <Route
+            path="/circles"
+            element={
+              <AuthGuard>{withTransition(<CirclesPage />)}</AuthGuard>
+            }
+          />
+          <Route
+            path="/circles/:id"
+            element={
+              <AuthGuard>{withTransition(<CircleDetailPage />)}</AuthGuard>
+            }
+          />
+          <Route
+            path="/circles/join/:inviteCode"
+            element={
+              <AuthGuard>{withTransition(<CircleJoinPage />)}</AuthGuard>
             }
           />
           <Route path="/deck/:slug" element={withTransition(<PublicDeckPage />)} />


### PR DESCRIPTION
Closes #64

## Type
- [x] New feature

## Summary
- Adds Desktop renderer route parity for Circles pages.
- Covers the route registration with a focused static parity test.

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.json`
- [x] `cd apps/desktop && ./node_modules/.bin/vitest run src/renderer/src/App.routes.test.ts`
