### PR TITLE
feat(circles): add reusable share panel

### DIFF
--- a/packages/features/src/components/ItemCard.test.tsx
+++ b/packages/features/src/components/ItemCard.test.tsx
@@ -1,9 +1,29 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ItemCard } from './ItemCard'
 import type { Item } from '@devdeck/api-client'
+
+const mocks = vi.hoisted(() => ({
+  useAIEnrichItem: vi.fn(),
+  useCircles: vi.fn(),
+  useReviewItemAITags: vi.fn(),
+  useShareToCircle: vi.fn(),
+  useUpdateItem: vi.fn(),
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useAIEnrichItem: mocks.useAIEnrichItem,
+    useCircles: mocks.useCircles,
+    useReviewItemAITags: mocks.useReviewItemAITags,
+    useShareToCircle: mocks.useShareToCircle,
+    useUpdateItem: mocks.useUpdateItem,
+  }
+})
 
 function renderItemCard(ui: React.ReactElement) {
   const client = new QueryClient({
@@ -48,6 +68,15 @@ function makeItem(patch: Partial<Item> = {}): Item {
 }
 
 describe('<ItemCard>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useAIEnrichItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
+    mocks.useReviewItemAITags.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useUpdateItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
   it('renders title and description', () => {
     renderItemCard(<ItemCard item={makeItem()} />)
     expect(screen.getByRole('heading')).toHaveTextContent('charmbracelet/bubbletea')
@@ -161,5 +190,35 @@ describe('<ItemCard>', () => {
       />,
     )
     expect(screen.getByText('ripgrep.dev/docs')).toBeInTheDocument()
+  })
+
+  it('requires context before sharing an item to a Circle', async () => {
+    const user = userEvent.setup()
+    const shareToCircle = vi.fn().mockResolvedValue({})
+    mocks.useCircles.mockReturnValue({
+      data: [{ id: 'circle-1', name: 'Frontend Guild' }],
+      isLoading: false,
+    })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+    renderItemCard(<ItemCard item={makeItem()} />)
+
+    await user.click(screen.getByRole('button', { name: /share in circle/i }))
+
+    const shareItem = screen.getByRole('button', { name: /share item/i })
+    expect(shareItem).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+    fireEvent.change(screen.getByLabelText('Why this matters'), {
+      target: { value: 'Reference repo for terminal UI experiments.' },
+    })
+    await user.click(shareItem)
+
+    await waitFor(() => {
+      expect(shareToCircle).toHaveBeenCalledWith({
+        circleId: 'circle-1',
+        itemId: 'a1b2c3-id',
+      })
+    })
   })
 })

--- a/packages/features/src/components/ItemCard.tsx
+++ b/packages/features/src/components/ItemCard.tsx
@@ -18,7 +18,6 @@ import {
   Users,
   Wrench,
   Share2,
-  Loader2,
   type LucideIcon,
 } from 'lucide-react'
 import type { Item, ItemType } from '@devdeck/api-client'
@@ -33,6 +32,7 @@ import {
 } from '@devdeck/api-client'
 import { TagChip, hashIndex, showToast } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
+import { ShareToCirclePanel } from './ShareToCirclePanel'
 
 interface TypeStyle {
   hue: string
@@ -74,8 +74,7 @@ export function ItemCard({ item, onClick }: Props) {
   const { data: circles = [] } = useCircles()
   const shareToCircle = useShareToCircle()
 
-  async function handleShare(e: React.MouseEvent, circleId: string, circleName: string) {
-    e.stopPropagation()
+  async function handleShare({ circleId, circleName }: { circleId: string; circleName: string }) {
     try {
       await shareToCircle.mutateAsync({ circleId, itemId: item.id })
       showToast(t('card.shared_success', { name: circleName }))
@@ -179,38 +178,22 @@ export function ItemCard({ item, onClick }: Props) {
           {shareMenuOpen && (
             <div
               onClick={(e) => e.stopPropagation()}
-              className="absolute right-0 top-6 z-30 w-48 bg-bg-card border-3 border-ink shadow-hard p-2 font-mono text-[11px]"
+              className="absolute right-0 top-6 z-30 w-72 font-mono text-[11px]"
             >
-              <div className="flex items-center justify-between border-b-2 border-ink pb-1.5 mb-1.5">
-                <span className="font-display font-black uppercase text-[9px] tracking-wider">
-                  {t('card.share_in')}
-                </span>
-                <button
-                  onClick={() => setShareMenuOpen(false)}
-                  className="hover:text-accent-pink"
-                >
-                  <X size={10} strokeWidth={3} />
-                </button>
-              </div>
-
               {circles.length === 0 ? (
-                <div className="py-1 text-ink-soft text-center text-[10px]">
+                <div className="bg-bg-card border-3 border-ink shadow-hard p-3 py-2 text-ink-soft text-center text-[10px]">
                   {t('card.no_circles')}
                 </div>
               ) : (
-                <div className="max-h-32 overflow-y-auto space-y-1">
-                  {circles.map((c) => (
-                    <button
-                      key={c.id}
-                      disabled={shareToCircle.isPending}
-                      onClick={(e) => handleShare(e, c.id, c.name)}
-                      className="w-full text-left p-1 hover:bg-accent-pink hover:text-white truncate border border-transparent hover:border-ink transition-colors flex items-center justify-between gap-1"
-                    >
-                      <span className="truncate">{c.name}</span>
-                      {shareToCircle.isPending && <Loader2 size={10} className="animate-spin shrink-0" />}
-                    </button>
-                  ))}
-                </div>
+                <ShareToCirclePanel
+                  circles={circles}
+                  isSharing={shareToCircle.isPending}
+                  title={t('card.share_in')}
+                  description="Add context so the Circle knows why this item is useful."
+                  submitLabel="Share item"
+                  onClose={() => setShareMenuOpen(false)}
+                  onShare={handleShare}
+                />
               )}
             </div>
           )}

--- a/packages/features/src/components/ShareToCirclePanel.tsx
+++ b/packages/features/src/components/ShareToCirclePanel.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { Share2, X } from 'lucide-react'
+import { Button } from '@devdeck/ui'
+import type { Circle } from '@devdeck/api-client'
+
+interface ShareToCirclePanelProps {
+  circles: Circle[]
+  isSharing?: boolean
+  title?: string
+  description?: string
+  submitLabel?: string
+  requireContext?: boolean
+  onClose: () => void
+  onShare: (input: { circleId: string; circleName: string; context: string }) => Promise<void> | void
+}
+
+export function ShareToCirclePanel({
+  circles,
+  isSharing = false,
+  title = 'Share to Circle',
+  description = 'Add context so the group knows why this is useful.',
+  submitLabel = 'Share',
+  requireContext = true,
+  onClose,
+  onShare,
+}: ShareToCirclePanelProps) {
+  const [circleId, setCircleId] = useState('')
+  const [context, setContext] = useState('')
+
+  const selectedCircle = circles.find((circle) => circle.id === circleId)
+  const canSubmit = !!selectedCircle && (!requireContext || context.trim().length > 0) && !isSharing
+
+  async function submit() {
+    if (!selectedCircle || !canSubmit) return
+    await onShare({
+      circleId: selectedCircle.id,
+      circleName: selectedCircle.name,
+      context: context.trim(),
+    })
+  }
+
+  return (
+    <div className="grid gap-3 border-3 border-ink bg-bg-elevated p-4 shadow-hard-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-display text-sm font-black uppercase">{title}</h3>
+          <p className="mt-1 font-mono text-xs text-ink-soft">{description}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="border-2 border-ink bg-bg-card p-1 hover:bg-accent-pink"
+          aria-label="Close Circle share"
+        >
+          <X size={14} strokeWidth={3} />
+        </button>
+      </div>
+
+      <label className="grid gap-2">
+        <span className="font-display text-xs font-black uppercase tracking-widest">Circle</span>
+        <select
+          value={circleId}
+          onChange={(event) => setCircleId(event.target.value)}
+          className="border-3 border-ink bg-bg-primary p-2 font-mono text-sm outline-none focus:bg-accent-yellow/10"
+        >
+          <option value="">Choose a Circle</option>
+          {circles.map((circle) => (
+            <option key={circle.id} value={circle.id}>
+              {circle.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="grid gap-2">
+        <span className="font-display text-xs font-black uppercase tracking-widest">Why this matters</span>
+        <textarea
+          value={context}
+          onChange={(event) => setContext(event.target.value)}
+          placeholder="Example: useful for debugging JWT auth in our API workshop."
+          className="min-h-32 w-full resize-y border-3 border-ink bg-bg-primary p-3 font-mono text-sm outline-none focus:bg-accent-yellow/10"
+        />
+      </label>
+
+      <Button type="button" size="sm" onClick={submit} disabled={!canSubmit}>
+        <span className="flex items-center gap-2">
+          <Share2 size={15} strokeWidth={3} />
+          {submitLabel}
+        </span>
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #65

## Type
- [x] New feature

## Summary
- Adds reusable `ShareToCirclePanel` for context-rich Circle sharing.
- Migrates ItemCard sharing to the shared panel.
- Adds focused ItemCard coverage for context-required sharing.

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json`
- [x] `cd packages/features && ./node_modules/.bin/vitest run src/components/ItemCard.test.tsx`
