### PR TITLE
feat(workbench): share outputs to circles

### DIFF
--- a/packages/features/src/components/Workbench/shared.tsx
+++ b/packages/features/src/components/Workbench/shared.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { Clipboard, Save } from 'lucide-react'
+import { Clipboard, Save, Share2 } from 'lucide-react'
 import { Button, showToast } from '@devdeck/ui'
-import { useCapture } from '@devdeck/api-client'
+import { useCapture, useCircles, useShareToCircle } from '@devdeck/api-client'
+import { ShareToCirclePanel } from '../ShareToCirclePanel'
 
 export function ToolFrame({
   title,
@@ -58,6 +59,9 @@ export function ResultActions({
   itemType?: 'snippet' | 'note'
 }) {
   const capture = useCapture()
+  const { data: circles = [] } = useCircles()
+  const shareToCircle = useShareToCircle()
+  const [shareOpen, setShareOpen] = React.useState(false)
 
   async function copy() {
     if (!output) return
@@ -82,20 +86,67 @@ export function ResultActions({
     }
   }
 
+  async function share({ circleId, context }: { circleId: string; context: string }) {
+    if (!output.trim()) return
+    try {
+      const captured = await capture.mutateAsync({
+        source: 'manual',
+        text: output,
+        title_hint: title,
+        type_hint: itemType,
+        tags: ['workbench', 'circle-share'],
+        why_saved: context,
+      })
+      const itemId = captured.item?.id || captured.duplicate_of
+      if (!itemId) throw new Error('Could not capture output before sharing.')
+
+      await shareToCircle.mutateAsync({ circleId, itemId })
+      showToast('Shared to Circle', 'success')
+      setShareOpen(false)
+    } catch (err) {
+      showToast((err as Error).message || 'Could not share output', 'error')
+    }
+  }
+
   return (
-    <div className="flex flex-wrap gap-3">
-      <Button type="button" size="sm" variant="secondary" onClick={copy} disabled={!output}>
-        <span className="flex items-center gap-2">
-          <Clipboard size={15} strokeWidth={3} />
-          Copy
-        </span>
-      </Button>
-      <Button type="button" size="sm" onClick={save} disabled={!output || capture.isPending}>
-        <span className="flex items-center gap-2">
-          <Save size={15} strokeWidth={3} />
-          Save output
-        </span>
-      </Button>
+    <div className="grid gap-3">
+      <div className="flex flex-wrap gap-3">
+        <Button type="button" size="sm" variant="secondary" onClick={copy} disabled={!output}>
+          <span className="flex items-center gap-2">
+            <Clipboard size={15} strokeWidth={3} />
+            Copy
+          </span>
+        </Button>
+        <Button type="button" size="sm" onClick={save} disabled={!output || capture.isPending}>
+          <span className="flex items-center gap-2">
+            <Save size={15} strokeWidth={3} />
+            Save output
+          </span>
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={() => setShareOpen((open) => !open)}
+          disabled={!output || circles.length === 0}
+        >
+          <span className="flex items-center gap-2">
+            <Share2 size={15} strokeWidth={3} />
+            Share to Circle
+          </span>
+        </Button>
+      </div>
+
+      {shareOpen && (
+        <ShareToCirclePanel
+          circles={circles}
+          isSharing={capture.isPending || shareToCircle.isPending}
+          title="Share output to Circle"
+          submitLabel="Save and share"
+          onClose={() => setShareOpen(false)}
+          onShare={share}
+        />
+      )}
     </div>
   )
 }

--- a/packages/features/src/pages/WorkbenchPage.test.tsx
+++ b/packages/features/src/pages/WorkbenchPage.test.tsx
@@ -6,8 +6,10 @@ import { WorkbenchPage } from './WorkbenchPage'
 
 const mocks = vi.hoisted(() => ({
   useCapture: vi.fn(),
+  useCircles: vi.fn(),
   useGlobalSearch: vi.fn(),
   useItem: vi.fn(),
+  useShareToCircle: vi.fn(),
   useUpdateItem: vi.fn(),
 }))
 
@@ -16,8 +18,10 @@ vi.mock('@devdeck/api-client', async () => {
   return {
     ...actual,
     useCapture: mocks.useCapture,
+    useCircles: mocks.useCircles,
     useGlobalSearch: mocks.useGlobalSearch,
     useItem: mocks.useItem,
+    useShareToCircle: mocks.useShareToCircle,
     useUpdateItem: mocks.useUpdateItem,
   }
 })
@@ -39,8 +43,10 @@ describe('<WorkbenchPage>', () => {
     vi.clearAllMocks()
     vi.unstubAllGlobals()
     mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
     mocks.useGlobalSearch.mockReturnValue({ data: [], isLoading: false })
     mocks.useItem.mockReturnValue({ data: undefined, isLoading: false })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     mocks.useUpdateItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
     Object.assign(navigator, {
       clipboard: {
@@ -158,5 +164,46 @@ describe('<WorkbenchPage>', () => {
 
     expect(screen.getByLabelText('Expansion preview')).toHaveValue('docker run --rm -it IMAGE sh')
     expect(screen.getByLabelText('Expanded text')).toHaveValue('Deploy with docker run --rm -it IMAGE sh')
+  })
+
+  it('requires context before sharing Workbench output to a Circle', async () => {
+    const captureOutput = vi.fn().mockResolvedValue({
+      item: { id: 'item-1' },
+      duplicate_of: null,
+      enrichment_status: 'ok',
+    })
+    const shareToCircle = vi.fn().mockResolvedValue({})
+    mocks.useCapture.mockReturnValue({ mutateAsync: captureOutput, isPending: false })
+    mocks.useCircles.mockReturnValue({
+      data: [{ id: 'circle-1', name: 'Frontend Guild' }],
+      isLoading: false,
+    })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+    renderWorkbench()
+
+    fireEvent.change(screen.getByLabelText('Input'), { target: { value: '{"name":"DevDeck"}' } })
+    fireEvent.click(screen.getByRole('button', { name: /share to circle/i }))
+
+    const saveAndShare = screen.getByRole('button', { name: /save and share/i })
+    expect(saveAndShare).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+    fireEvent.change(screen.getByLabelText('Why this matters'), {
+      target: { value: 'Useful payload shape for our API examples.' },
+    })
+    fireEvent.click(saveAndShare)
+
+    await waitFor(() => {
+      expect(captureOutput).toHaveBeenCalledWith({
+        source: 'manual',
+        text: '{\n  "name": "DevDeck"\n}',
+        title_hint: 'Formatted JSON',
+        type_hint: 'snippet',
+        tags: ['workbench', 'circle-share'],
+        why_saved: 'Useful payload shape for our API examples.',
+      })
+      expect(shareToCircle).toHaveBeenCalledWith({ circleId: 'circle-1', itemId: 'item-1' })
+    })
   })
 })


### PR DESCRIPTION
Closes #66

## Type
- [x] New feature

## Summary
- Adds Workbench output sharing to Circles using the shared panel from #70.
- Captures output with `why_saved` context before sharing the resulting item.
- Adds focused Workbench coverage for the capture-then-share flow.

## Stack
- Base: #70 (`feat/issue-65-circle-share-panel`)

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json`
- [x] `cd packages/features && ./node_modules/.bin/vitest run src/pages/WorkbenchPage.test.tsx`
