### PR TITLE
feat(circles): share runbooks and cheatsheets

### DIFF
--- a/packages/features/src/pages/CheatsheetDetailPage.test.tsx
+++ b/packages/features/src/pages/CheatsheetDetailPage.test.tsx
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { CheatsheetDetailPage } from './CheatsheetDetailPage'
+
+const mocks = vi.hoisted(() => ({
+  useParams: vi.fn(),
+  useNavigate: vi.fn(),
+  useCheatsheet: vi.fn(),
+  useCreateEntry: vi.fn(),
+  useDeleteCheatsheet: vi.fn(),
+  useDeleteEntry: vi.fn(),
+  useUpdateEntry: vi.fn(),
+  useCapture: vi.fn(),
+  useCircles: vi.fn(),
+  useShareToCircle: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useParams: mocks.useParams,
+  useNavigate: mocks.useNavigate,
+}))
+
+vi.mock('../components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useCheatsheet: mocks.useCheatsheet,
+    useCreateEntry: mocks.useCreateEntry,
+    useDeleteCheatsheet: mocks.useDeleteCheatsheet,
+    useDeleteEntry: mocks.useDeleteEntry,
+    useUpdateEntry: mocks.useUpdateEntry,
+    useCapture: mocks.useCapture,
+    useCircles: mocks.useCircles,
+    useShareToCircle: mocks.useShareToCircle,
+  }
+})
+
+vi.mock('@devdeck/ui', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/ui')>('@devdeck/ui')
+  return {
+    ...actual,
+    showToast: mocks.showToast,
+  }
+})
+
+const cheatsheet = {
+  id: 'cheat-1',
+  slug: 'git-basics',
+  title: 'Git Basics',
+  category: 'vcs',
+  icon: '🌿',
+  color: '#00ff99',
+  description: 'Commands we use every day.',
+  is_seed: false,
+  created_at: '2026-05-23T00:00:00Z',
+  updated_at: '2026-05-23T00:00:00Z',
+  entries: [
+    {
+      id: 'entry-1',
+      cheatsheet_id: 'cheat-1',
+      label: 'Status',
+      command: 'git status --short',
+      description: 'Check concise working tree status.',
+      tags: ['git', 'daily'],
+      position: 0,
+    },
+  ],
+}
+
+describe('<CheatsheetDetailPage>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useParams.mockReturnValue({ id: 'cheat-1' })
+    mocks.useNavigate.mockReturnValue(vi.fn())
+    mocks.useCheatsheet.mockReturnValue({ data: cheatsheet, isLoading: false, error: null })
+    mocks.useCreateEntry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null })
+    mocks.useDeleteCheatsheet.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useDeleteEntry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useUpdateEntry.mockReturnValue({ mutateAsync: vi.fn(), isPending: false, error: null })
+    mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
+  it('shares a cheatsheet to a Circle with required context', async () => {
+    const capture = vi.fn().mockResolvedValue({
+      item: { id: 'item-1' },
+      duplicate_of: null,
+      enrichment_status: 'ok',
+    })
+    const shareToCircle = vi.fn().mockResolvedValue({})
+    mocks.useCapture.mockReturnValue({ mutateAsync: capture, isPending: false })
+    mocks.useCircles.mockReturnValue({
+      data: [{ id: 'circle-1', name: 'Backend Circle' }],
+      isLoading: false,
+    })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+    render(<CheatsheetDetailPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: /share cheatsheet to circle/i }))
+    const saveAndShare = screen.getByRole('button', { name: /save and share cheatsheet/i })
+    expect(saveAndShare).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+    fireEvent.change(screen.getByLabelText('Why this matters'), {
+      target: { value: 'Useful baseline commands for onboarding.' },
+    })
+    fireEvent.click(saveAndShare)
+
+    await waitFor(() => {
+      expect(capture).toHaveBeenCalledWith({
+        source: 'manual',
+        text: expect.stringContaining('git status --short'),
+        title_hint: 'Cheatsheet: Git Basics',
+        type_hint: 'snippet',
+        tags: ['cheatsheet', 'vcs', 'circle-share'],
+        why_saved: 'Useful baseline commands for onboarding.',
+      })
+      expect(shareToCircle).toHaveBeenCalledWith({ circleId: 'circle-1', itemId: 'item-1' })
+    })
+  })
+})

--- a/packages/features/src/pages/CheatsheetDetailPage.tsx
+++ b/packages/features/src/pages/CheatsheetDetailPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Copy, Filter, Plus, Search, Trash2, X } from 'lucide-react'
+import { ArrowLeft, Copy, Filter, Plus, Search, Share2, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button } from '@devdeck/ui'
@@ -9,10 +9,14 @@ import {
   useDeleteCheatsheet,
   useDeleteEntry,
   useUpdateEntry,
+  useCapture,
+  useCircles,
+  useShareToCircle,
 } from '@devdeck/api-client'
-import type { Entry } from '@devdeck/api-client'
+import type { CheatsheetDetail, Entry } from '@devdeck/api-client'
 import { showToast } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
+import { ShareToCirclePanel } from '../components/ShareToCirclePanel'
 
 export function CheatsheetDetailPage() {
   const { t } = useTranslation()
@@ -24,11 +28,15 @@ export function CheatsheetDetailPage() {
   const [searchFilter, setSearchFilter] = useState('')
   const [editingEntry, setEditingEntry] = useState<Entry | null>(null)
   const [addingNew, setAddingNew] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
 
   const createEntry = useCreateEntry(id ?? '')
   const updateEntry = useUpdateEntry(id ?? '')
   const deleteEntry = useDeleteEntry(id ?? '')
   const deleteCheatsheet = useDeleteCheatsheet()
+  const capture = useCapture()
+  const { data: circles = [] } = useCircles()
+  const shareToCircle = useShareToCircle()
 
   async function handleDeleteCheatsheet() {
     if (!id || !detail) return
@@ -128,6 +136,28 @@ export function CheatsheetDetailPage() {
     }
   }
 
+  async function handleShareCheatsheet({ circleId, context }: { circleId: string; context: string }) {
+    if (!detail) return
+    try {
+      const captured = await capture.mutateAsync({
+        source: 'manual',
+        text: formatCheatsheetForSharing(detail),
+        title_hint: `Cheatsheet: ${detail.title}`,
+        type_hint: 'snippet',
+        tags: ['cheatsheet', detail.category, 'circle-share'].filter(Boolean),
+        why_saved: context,
+      })
+      const itemId = captured.item?.id || captured.duplicate_of
+      if (!itemId) throw new Error('Could not capture cheatsheet before sharing.')
+
+      await shareToCircle.mutateAsync({ circleId, itemId })
+      showToast('Cheatsheet shared to Circle', 'success')
+      setShareOpen(false)
+    } catch (err) {
+      showToast((err as Error).message || 'Could not share cheatsheet', 'error')
+    }
+  }
+
   return (
     <AppShell contentClassName="flex-1 overflow-y-auto">
       <div className="min-h-full bg-bg-primary">
@@ -160,6 +190,16 @@ export function CheatsheetDetailPage() {
             {detail.description}
           </p>
         )}
+        <button
+          type="button"
+          onClick={() => setShareOpen((open) => !open)}
+          disabled={circles.length === 0}
+          aria-label="Share cheatsheet to Circle"
+          className="border-3 border-ink p-2 bg-bg-card shadow-hard hover:bg-accent-yellow
+                     disabled:opacity-50 transition-colors ml-auto lg:ml-0"
+        >
+          <Share2 size={18} strokeWidth={3} />
+        </button>
         {!detail.is_seed && (
           <button
             type="button"
@@ -175,6 +215,20 @@ export function CheatsheetDetailPage() {
       </header>
 
       <div className="max-w-5xl mx-auto p-6">
+        {shareOpen && (
+          <div className="mb-6">
+            <ShareToCirclePanel
+              circles={circles}
+              isSharing={capture.isPending || shareToCircle.isPending}
+              title="Share cheatsheet to Circle"
+              description="Add context so the Circle knows when to use this cheatsheet."
+              submitLabel="Save and share cheatsheet"
+              onClose={() => setShareOpen(false)}
+              onShare={handleShareCheatsheet}
+            />
+          </div>
+        )}
+
         {/* Toolbar */}
         <div className="flex flex-wrap items-center gap-3 mb-6">
           {/* Search */}
@@ -259,6 +313,26 @@ export function CheatsheetDetailPage() {
       </div>
     </AppShell>
   )
+}
+
+function formatCheatsheetForSharing(detail: CheatsheetDetail): string {
+  const lines = [`# ${detail.title}`, '', `Category: ${detail.category}`]
+  if (detail.description) {
+    lines.push('', detail.description)
+  }
+  if (detail.entries.length > 0) {
+    lines.push('', '## Entries')
+    detail.entries.forEach((entry) => {
+      lines.push('', `### ${entry.label}`, '', '```bash', entry.command, '```')
+      if (entry.description) {
+        lines.push('', entry.description)
+      }
+      if (entry.tags.length > 0) {
+        lines.push('', `Tags: ${entry.tags.join(', ')}`)
+      }
+    })
+  }
+  return lines.join('\n')
 }
 
 // ─── Entry Card ───

--- a/packages/features/src/pages/ItemDetailPage.tsx
+++ b/packages/features/src/pages/ItemDetailPage.tsx
@@ -10,6 +10,7 @@ import {
 	Library,
 	Plus,
 	Play,
+	Share2,
 	Sparkles,
 	Trash2,
 	Users,
@@ -27,6 +28,9 @@ import {
 	useUpdateRunbookStep,
 	useDeleteRunbook,
 	useUpdateItem,
+	useCapture,
+	useCircles,
+	useShareToCircle,
 	type Item,
 	type Runbook,
 	type RunbookStep,
@@ -35,6 +39,7 @@ import { NotesEditor } from '../components/NotesEditor'
 import { TagsEditor } from '../components/TagsEditor'
 import { TeamReviewCard } from '../components/TeamReviewCard'
 import { AppShell } from '../components/AppShell'
+import { ShareToCirclePanel } from '../components/ShareToCirclePanel'
 import { useTranslation } from '@devdeck/i18n'
 
 export function ItemDetailPage() {
@@ -351,6 +356,10 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 	const { t } = useTranslation()
 	const addStep = useAddRunbookStep()
 	const deleteRunbook = useDeleteRunbook()
+	const capture = useCapture()
+	const { data: circles = [] } = useCircles()
+	const shareToCircle = useShareToCircle()
+	const [shareOpen, setShareOpen] = useState(false)
 
 	async function handleAddStep() {
 		const label = window.prompt(t('item_detail.runbook.step_label_prompt'))
@@ -368,6 +377,28 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 		await deleteRunbook.mutateAsync({ id: runbook.id, itemId: runbook.item_id })
 	}
 
+	async function handleShare({ circleId, context }: { circleId: string; context: string }) {
+		const text = formatRunbookForSharing(runbook)
+		try {
+			const captured = await capture.mutateAsync({
+				source: 'manual',
+				text,
+				title_hint: `Runbook: ${runbook.title}`,
+				type_hint: 'workflow',
+				tags: ['runbook', 'circle-share'],
+				why_saved: context,
+			})
+			const itemId = captured.item?.id || captured.duplicate_of
+			if (!itemId) throw new Error('Could not capture runbook before sharing.')
+
+			await shareToCircle.mutateAsync({ circleId, itemId })
+			showToast('Runbook shared to Circle', 'success')
+			setShareOpen(false)
+		} catch (err) {
+			showToast((err as Error).message || 'Could not share runbook', 'error')
+		}
+	}
+
 	return (
 		<div className="bg-bg-card border-3 border-ink shadow-hard overflow-hidden">
 			<header className="bg-bg-elevated border-b-3 border-ink p-4 flex items-center justify-between">
@@ -375,12 +406,34 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 					<Library size={18} strokeWidth={3} />
 					<h3 className="font-display font-black uppercase text-sm">{runbook.title}</h3>
 				</div>
-				<button onClick={handleDelete} className="p-1 hover:bg-accent-pink transition-colors">
-					<Trash2 size={16} />
-				</button>
+				<div className="flex items-center gap-2">
+					<button
+						onClick={() => setShareOpen((open) => !open)}
+						disabled={circles.length === 0}
+						title="Share runbook to Circle"
+						className="p-1 border-2 border-transparent hover:border-ink hover:bg-accent-yellow transition-colors disabled:opacity-40"
+					>
+						<Share2 size={16} />
+					</button>
+					<button onClick={handleDelete} className="p-1 hover:bg-accent-pink transition-colors">
+						<Trash2 size={16} />
+					</button>
+				</div>
 			</header>
 
 			<div className="p-4 space-y-4">
+				{shareOpen && (
+					<ShareToCirclePanel
+						circles={circles}
+						isSharing={capture.isPending || shareToCircle.isPending}
+						title="Share runbook to Circle"
+						description="Add context so the Circle knows when to use this runbook."
+						submitLabel="Save and share runbook"
+						onClose={() => setShareOpen(false)}
+						onShare={handleShare}
+					/>
+				)}
+
 				{runbook.steps.map((st) => (
 					<RunbookStepItem key={st.id} step={st} />
 				))}
@@ -398,6 +451,26 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 			</div>
 		</div>
 	)
+}
+
+function formatRunbookForSharing(runbook: Runbook): string {
+	const lines = [`# ${runbook.title}`]
+	if (runbook.description) {
+		lines.push('', runbook.description)
+	}
+	if (runbook.steps.length > 0) {
+		lines.push('', '## Steps')
+		runbook.steps.forEach((step, index) => {
+			lines.push('', `${index + 1}. ${step.label}`)
+			if (step.command) {
+				lines.push('', '```bash', step.command, '```')
+			}
+			if (step.description) {
+				lines.push('', step.description)
+			}
+		})
+	}
+	return lines.join('\n')
 }
 
 function RunbookStepItem({ step }: { step: RunbookStep }) {


### PR DESCRIPTION
Closes #67

## Type
- [x] New feature

## Summary
- Adds Circle sharing for runbooks and cheatsheets using the shared panel from #70.
- Formats runbooks and cheatsheets as markdown before capture/share.
- Adds focused Cheatsheet share coverage.

## Stack
- Base: #70 (`feat/issue-65-circle-share-panel`)

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json`
- [x] `cd packages/features && ./node_modules/.bin/vitest run src/pages/ItemDetailPage.test.tsx src/pages/CheatsheetDetailPage.test.tsx`
