### PR TITLE
feat(circles): persist share context notes

### DIFF
--- a/backend/internal/http/handlers/circles.go
+++ b/backend/internal/http/handlers/circles.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"devdeck/internal/authctx"
 	"devdeck/internal/store"
@@ -135,7 +136,8 @@ func (h *CirclesHandler) Join(w http.ResponseWriter, r *http.Request) {
 }
 
 type ShareItemInput struct {
-	ItemID uuid.UUID `json:"item_id"`
+	ItemID       uuid.UUID `json:"item_id"`
+	ShareContext string    `json:"share_context"`
 }
 
 func (h *CirclesHandler) ShareItem(w http.ResponseWriter, r *http.Request) {
@@ -179,7 +181,7 @@ func (h *CirclesHandler) ShareItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.store.ShareItemToCircle(r.Context(), circleID, in.ItemID, userID)
+	err = h.store.ShareItemToCircle(r.Context(), circleID, in.ItemID, userID, strings.TrimSpace(in.ShareContext))
 	if err != nil {
 		writeInternal(w, err)
 		return

--- a/backend/internal/http/handlers/circles_test.go
+++ b/backend/internal/http/handlers/circles_test.go
@@ -64,7 +64,8 @@ func TestCircles_CRUDAndFlows(t *testing.T) {
 	})
 
 	shareRec := ts.do(t, http.MethodPost, "/api/circles/"+created.ID.String()+"/share", map[string]any{
-		"item_id": item.ID.String(),
+		"item_id":       item.ID.String(),
+		"share_context": "Useful when teaching fast Git status checks.",
 	})
 	if shareRec.Code != http.StatusNoContent {
 		t.Fatalf("share item: expected 204, got %d, body: %s", shareRec.Code, shareRec.Body.String())
@@ -78,6 +79,9 @@ func TestCircles_CRUDAndFlows(t *testing.T) {
 	circleItems := decodeJSON[[]itemResp](t, circleItemsRec)
 	if len(circleItems) != 1 || circleItems[0].ID != item.ID {
 		t.Fatalf("expected 1 circle item matching seed, got: %+v", circleItems)
+	}
+	if got := circleItems[0].Meta["circle_share_context"]; got != "Useful when teaching fast Git status checks." {
+		t.Fatalf("expected share context metadata, got: %v", got)
 	}
 
 	// 6. List Members

--- a/backend/internal/http/handlers/items_test.go
+++ b/backend/internal/http/handlers/items_test.go
@@ -13,17 +13,18 @@ import (
 // only what the test needs so the fixture stays stable if we add
 // fields to the Item struct.
 type itemResp struct {
-	ID               uuid.UUID `json:"id"`
-	Type             string    `json:"item_type"`
-	Title            string    `json:"title"`
-	Tags             []string  `json:"tags"`
-	Notes            string    `json:"notes"`
-	Archived         bool      `json:"archived"`
-	WhySaved         string    `json:"why_saved"`
-	WhenToUse        string    `json:"when_to_use"`
-	AISummary        string    `json:"ai_summary"`
-	AITags           []string  `json:"ai_tags"`
-	EnrichmentStatus string    `json:"enrichment_status"`
+	ID               uuid.UUID      `json:"id"`
+	Type             string         `json:"item_type"`
+	Title            string         `json:"title"`
+	Tags             []string       `json:"tags"`
+	Notes            string         `json:"notes"`
+	Archived         bool           `json:"archived"`
+	WhySaved         string         `json:"why_saved"`
+	WhenToUse        string         `json:"when_to_use"`
+	AISummary        string         `json:"ai_summary"`
+	AITags           []string       `json:"ai_tags"`
+	Meta             map[string]any `json:"meta"`
+	EnrichmentStatus string         `json:"enrichment_status"`
 }
 
 type itemListResp struct {

--- a/backend/internal/store/circles.go
+++ b/backend/internal/store/circles.go
@@ -165,12 +165,15 @@ func (s *Store) IsCircleMember(ctx context.Context, userID, circleID uuid.UUID) 
 	return role, true
 }
 
-func (s *Store) ShareItemToCircle(ctx context.Context, circleID, itemID, userID uuid.UUID) error {
+func (s *Store) ShareItemToCircle(ctx context.Context, circleID, itemID, userID uuid.UUID, shareContext string) error {
 	_, err := s.Writer().Exec(ctx, `
-		INSERT INTO circle_items (circle_id, item_id, shared_by)
-		VALUES ($1, $2, $3)
-		ON CONFLICT (circle_id, item_id) DO NOTHING
-	`, circleID, itemID, userID)
+		INSERT INTO circle_items (circle_id, item_id, shared_by, share_context)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (circle_id, item_id) DO UPDATE SET
+			shared_by = EXCLUDED.shared_by,
+			shared_at = now(),
+			share_context = EXCLUDED.share_context
+	`, circleID, itemID, userID, shareContext)
 	return err
 }
 
@@ -188,17 +191,60 @@ func (s *Store) ListCircleItems(ctx context.Context, circleID uuid.UUID) ([]*ite
 	defer rows.Close()
 
 	var list []*items.Item
+	var itemIDs []uuid.UUID
 	for rows.Next() {
 		it, err := scanItem(rows)
 		if err != nil {
 			return nil, err
 		}
 		list = append(list, it)
+		itemIDs = append(itemIDs, it.ID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(itemIDs) > 0 {
+		metaRows, err := s.Reader().Query(ctx, `
+			SELECT item_id, share_context, shared_by::text, shared_at::text
+			FROM circle_items
+			WHERE circle_id = $1 AND item_id = ANY($2)
+		`, circleID, itemIDs)
+		if err != nil {
+			return nil, err
+		}
+		defer metaRows.Close()
+
+		type shareMeta struct {
+			context  string
+			sharedBy string
+			sharedAt string
+		}
+		byItemID := map[uuid.UUID]shareMeta{}
+		for metaRows.Next() {
+			var itemID uuid.UUID
+			var meta shareMeta
+			if err := metaRows.Scan(&itemID, &meta.context, &meta.sharedBy, &meta.sharedAt); err != nil {
+				return nil, err
+			}
+			byItemID[itemID] = meta
+		}
+		if err := metaRows.Err(); err != nil {
+			return nil, err
+		}
+		for _, it := range list {
+			meta, ok := byItemID[it.ID]
+			if !ok {
+				continue
+			}
+			it.Meta["circle_share_context"] = meta.context
+			it.Meta["circle_shared_by"] = meta.sharedBy
+			it.Meta["circle_shared_at"] = meta.sharedAt
+		}
 	}
 	if list == nil {
 		list = []*items.Item{}
 	}
-	return list, rows.Err()
+	return list, nil
 }
 
 func (s *Store) ListCircleMembers(ctx context.Context, circleID uuid.UUID) ([]circles.CircleMemberDetail, error) {

--- a/backend/internal/store/circles_test.go
+++ b/backend/internal/store/circles_test.go
@@ -98,7 +98,7 @@ func TestStore_Circles(t *testing.T) {
 		t.Fatalf("CreateItem failed: %v", err)
 	}
 
-	err = st.ShareItemToCircle(ctx, c1.ID, it.ID, u1.ID)
+	err = st.ShareItemToCircle(ctx, c1.ID, it.ID, u1.ID, "Useful when onboarding a new shell workflow.")
 	if err != nil {
 		t.Fatalf("ShareItemToCircle failed: %v", err)
 	}
@@ -110,6 +110,9 @@ func TestStore_Circles(t *testing.T) {
 	}
 	if len(circleItems) != 1 || circleItems[0].ID != it.ID || circleItems[0].Title != "Cool Tip" {
 		t.Errorf("unexpected circle items: %+v", circleItems)
+	}
+	if got := circleItems[0].Meta["circle_share_context"]; got != "Useful when onboarding a new shell workflow." {
+		t.Errorf("expected circle share context metadata, got %v", got)
 	}
 
 	// 5. Leave Circle

--- a/backend/migrations/0042_circle_share_context.sql
+++ b/backend/migrations/0042_circle_share_context.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Persist the human context behind a Circle share.
+
+ALTER TABLE circle_items
+    ADD COLUMN IF NOT EXISTS share_context TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE circle_items
+    DROP COLUMN IF EXISTS share_context;

--- a/packages/api-client/src/features/circles/api.ts
+++ b/packages/api-client/src/features/circles/api.ts
@@ -32,6 +32,7 @@ export interface JoinCircleInput {
 export interface ShareToCircleInput {
   circleId: string
   itemId: string
+  shareContext?: string
 }
 
 const CIRCLES_KEY = ['circles']
@@ -102,8 +103,11 @@ export function useJoinCircle() {
 export function useShareToCircle() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ circleId, itemId }: ShareToCircleInput) => {
-      return api.post<void>(`/api/circles/${circleId}/share`, { item_id: itemId })
+    mutationFn: async ({ circleId, itemId, shareContext }: ShareToCircleInput) => {
+      return api.post<void>(`/api/circles/${circleId}/share`, {
+        item_id: itemId,
+        share_context: shareContext ?? '',
+      })
     },
     onSuccess: (_, { circleId }) => {
       queryClient.invalidateQueries({ queryKey: [...CIRCLES_KEY, 'items', circleId] })

--- a/packages/features/src/components/ItemCard.test.tsx
+++ b/packages/features/src/components/ItemCard.test.tsx
@@ -218,6 +218,7 @@ describe('<ItemCard>', () => {
       expect(shareToCircle).toHaveBeenCalledWith({
         circleId: 'circle-1',
         itemId: 'a1b2c3-id',
+        shareContext: 'Reference repo for terminal UI experiments.',
       })
     })
   })

--- a/packages/features/src/components/ItemCard.tsx
+++ b/packages/features/src/components/ItemCard.tsx
@@ -74,9 +74,9 @@ export function ItemCard({ item, onClick }: Props) {
   const { data: circles = [] } = useCircles()
   const shareToCircle = useShareToCircle()
 
-  async function handleShare({ circleId, circleName }: { circleId: string; circleName: string }) {
+  async function handleShare({ circleId, circleName, context }: { circleId: string; circleName: string; context: string }) {
     try {
-      await shareToCircle.mutateAsync({ circleId, itemId: item.id })
+      await shareToCircle.mutateAsync({ circleId, itemId: item.id, shareContext: context })
       showToast(t('card.shared_success', { name: circleName }))
       setShareMenuOpen(false)
     } catch (err) {

--- a/packages/features/src/pages/CircleDetailPage.test.tsx
+++ b/packages/features/src/pages/CircleDetailPage.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { CircleDetailPage } from './CircleDetailPage'
+
+const mocks = vi.hoisted(() => ({
+  useParams: vi.fn(),
+  useNavigate: vi.fn(),
+  useCircleDetail: vi.fn(),
+  useCircleItems: vi.fn(),
+  useCircleMembers: vi.fn(),
+  useLeaveCircle: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useParams: mocks.useParams,
+  useNavigate: mocks.useNavigate,
+}))
+
+vi.mock('../components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useCircleDetail: mocks.useCircleDetail,
+    useCircleItems: mocks.useCircleItems,
+    useCircleMembers: mocks.useCircleMembers,
+    useLeaveCircle: mocks.useLeaveCircle,
+    useUpdateItem: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+    useAIEnrichItem: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+    useReviewItemAITags: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+    useCircles: vi.fn(() => ({ data: [], isLoading: false })),
+    useShareToCircle: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  }
+})
+
+const sharedItem = {
+  id: 'item-1',
+  user_id: 'user-1',
+  item_type: 'repo',
+  title: 'Useful Auth Repo',
+  url: 'https://github.com/example/auth',
+  url_normalized: 'https://github.com/example/auth',
+  description: 'Reference implementation',
+  notes: '',
+  tags: ['auth'],
+  why_saved: '',
+  when_to_use: '',
+  source_channel: 'manual',
+  meta: {
+    circle_share_context: 'Use this when explaining JWT refresh token rotation.',
+  },
+  ai_summary: '',
+  ai_tags: [],
+  enrichment_status: 'ok',
+  archived: false,
+  is_favorite: false,
+  created_at: '2026-05-23T00:00:00Z',
+  updated_at: '2026-05-23T00:00:00Z',
+  last_seen_at: null,
+}
+
+describe('<CircleDetailPage>', () => {
+  beforeEach(() => {
+    mocks.useParams.mockReturnValue({ id: 'circle-1' })
+    mocks.useNavigate.mockReturnValue(vi.fn())
+    mocks.useCircleDetail.mockReturnValue({
+      data: {
+        id: 'circle-1',
+        name: 'Frontend Guild',
+        description: 'Shared frontend memory',
+        invite_code: 'ABC123',
+      },
+      isLoading: false,
+      error: null,
+    })
+    mocks.useCircleItems.mockReturnValue({ data: [sharedItem], isLoading: false })
+    mocks.useCircleMembers.mockReturnValue({ data: [], isLoading: false })
+    mocks.useLeaveCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
+  it('shows the context note stored with a shared Circle item', () => {
+    render(<CircleDetailPage />)
+
+    expect(screen.getByText('Why this was shared')).toBeInTheDocument()
+    expect(screen.getByText('Use this when explaining JWT refresh token rotation.')).toBeInTheDocument()
+    expect(screen.getByText('Useful Auth Repo')).toBeInTheDocument()
+  })
+})

--- a/packages/features/src/pages/CircleDetailPage.tsx
+++ b/packages/features/src/pages/CircleDetailPage.tsx
@@ -137,10 +137,32 @@ export function CircleDetailPage() {
               </Button>
             </div>
           ) : (
-            <ItemGrid
-              items={items}
-              onSelect={(it) => navigate(detailPathForItem(it))}
-            />
+            <div className="grid gap-5">
+              {items.map((item) => {
+                const shareContext = typeof item.meta?.circle_share_context === 'string'
+                  ? item.meta.circle_share_context
+                  : ''
+
+                return (
+                  <div key={item.id} className="grid gap-3">
+                    {shareContext ? (
+                      <div className="border-3 border-ink bg-accent-yellow/30 p-4 shadow-hard-sm">
+                        <p className="font-display text-xs font-black uppercase tracking-widest">
+                          {t('circles.why_shared')}
+                        </p>
+                        <p className="mt-2 font-mono text-sm text-ink">
+                          {shareContext}
+                        </p>
+                      </div>
+                    ) : null}
+                    <ItemGrid
+                      items={[item]}
+                      onSelect={(it) => navigate(detailPathForItem(it))}
+                    />
+                  </div>
+                )
+              })}
+            </div>
           )}
         </section>
       </div>

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -703,6 +703,7 @@
     "leave_button": "Leave",
     "all_circles": "All Circles",
     "shared_vault": "Shared Vault",
+    "why_shared": "Why this was shared",
     "shared_items_count": "{{count}} item shared",
     "shared_items_count_plural": "{{count}} items shared",
     "empty_shared_vault_title": "Empty Vault",


### PR DESCRIPTION
Closes #73

## PR Type
- [x] New feature

## Summary
- Persists the Circle share context note in `circle_items.share_context`.
- Sends the context from existing item share flows through the API client/backend.
- Shows the saved “why this was shared” note on Circle detail shared vault items.

## Changes
| File | Change |
|------|--------|
| `backend/migrations/0042_circle_share_context.sql` | Adds `share_context` to Circle item shares. |
| `backend/internal/http/handlers/circles.go` | Accepts and trims `share_context` in Circle share requests. |
| `backend/internal/store/circles.go` | Stores share context and returns it in item metadata. |
| `packages/api-client/src/features/circles/api.ts` | Sends `share_context` from client mutations. |
| `packages/features/src/components/ItemCard.tsx` | Passes the user-entered context note when sharing. |
| `packages/features/src/pages/CircleDetailPage.tsx` | Displays saved share context above shared items. |
| Tests | Adds/updates backend and frontend coverage for persisted context. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json`
- [x] `cd packages/features && ./node_modules/.bin/vitest run src/components/ItemCard.test.tsx src/pages/CircleDetailPage.test.tsx`
- [x] `cd backend && GOCACHE=/private/tmp/devdeck-go-build-cache go test ./internal/store ./internal/http/handlers`

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
