### PR TITLE
feat(circles): show shared item attribution

### DIFF
--- a/backend/internal/http/handlers/circles_test.go
+++ b/backend/internal/http/handlers/circles_test.go
@@ -83,6 +83,9 @@ func TestCircles_CRUDAndFlows(t *testing.T) {
 	if got := circleItems[0].Meta["circle_share_context"]; got != "Useful when teaching fast Git status checks." {
 		t.Fatalf("expected share context metadata, got: %v", got)
 	}
+	if got := circleItems[0].Meta["circle_shared_by_name"]; got == "" {
+		t.Fatalf("expected share attribution name metadata, got: %v", got)
+	}
 
 	// 6. List Members
 	membersRec := ts.do(t, http.MethodGet, "/api/circles/"+created.ID.String()+"/members", nil)

--- a/backend/internal/store/circles.go
+++ b/backend/internal/store/circles.go
@@ -205,9 +205,16 @@ func (s *Store) ListCircleItems(ctx context.Context, circleID uuid.UUID) ([]*ite
 	}
 	if len(itemIDs) > 0 {
 		metaRows, err := s.Reader().Query(ctx, `
-			SELECT item_id, share_context, shared_by::text, shared_at::text
-			FROM circle_items
-			WHERE circle_id = $1 AND item_id = ANY($2)
+			SELECT
+				ci.item_id,
+				ci.share_context,
+				ci.shared_by::text,
+				COALESCE(NULLIF(u.display_name, ''), u.username, u.login, ci.shared_by::text) AS shared_by_name,
+				COALESCE(u.username, u.login, '') AS shared_by_username,
+				ci.shared_at::text
+			FROM circle_items ci
+			LEFT JOIN users u ON u.id = ci.shared_by
+			WHERE ci.circle_id = $1 AND ci.item_id = ANY($2)
 		`, circleID, itemIDs)
 		if err != nil {
 			return nil, err
@@ -215,15 +222,24 @@ func (s *Store) ListCircleItems(ctx context.Context, circleID uuid.UUID) ([]*ite
 		defer metaRows.Close()
 
 		type shareMeta struct {
-			context  string
-			sharedBy string
-			sharedAt string
+			context          string
+			sharedBy         string
+			sharedByName     string
+			sharedByUsername string
+			sharedAt         string
 		}
 		byItemID := map[uuid.UUID]shareMeta{}
 		for metaRows.Next() {
 			var itemID uuid.UUID
 			var meta shareMeta
-			if err := metaRows.Scan(&itemID, &meta.context, &meta.sharedBy, &meta.sharedAt); err != nil {
+			if err := metaRows.Scan(
+				&itemID,
+				&meta.context,
+				&meta.sharedBy,
+				&meta.sharedByName,
+				&meta.sharedByUsername,
+				&meta.sharedAt,
+			); err != nil {
 				return nil, err
 			}
 			byItemID[itemID] = meta
@@ -238,6 +254,8 @@ func (s *Store) ListCircleItems(ctx context.Context, circleID uuid.UUID) ([]*ite
 			}
 			it.Meta["circle_share_context"] = meta.context
 			it.Meta["circle_shared_by"] = meta.sharedBy
+			it.Meta["circle_shared_by_name"] = meta.sharedByName
+			it.Meta["circle_shared_by_username"] = meta.sharedByUsername
 			it.Meta["circle_shared_at"] = meta.sharedAt
 		}
 	}

--- a/backend/internal/store/circles_test.go
+++ b/backend/internal/store/circles_test.go
@@ -114,6 +114,12 @@ func TestStore_Circles(t *testing.T) {
 	if got := circleItems[0].Meta["circle_share_context"]; got != "Useful when onboarding a new shell workflow." {
 		t.Errorf("expected circle share context metadata, got %v", got)
 	}
+	if got := circleItems[0].Meta["circle_shared_by_name"]; got != "User One" {
+		t.Errorf("expected circle share attribution name, got %v", got)
+	}
+	if got := circleItems[0].Meta["circle_shared_by_username"]; got != "user1" {
+		t.Errorf("expected circle share attribution username, got %v", got)
+	}
 
 	// 5. Leave Circle
 	err = st.LeaveCircle(ctx, c1.ID, u2.ID)

--- a/packages/features/src/pages/CircleDetailPage.test.tsx
+++ b/packages/features/src/pages/CircleDetailPage.test.tsx
@@ -52,6 +52,9 @@ const sharedItem = {
   source_channel: 'manual',
   meta: {
     circle_share_context: 'Use this when explaining JWT refresh token rotation.',
+    circle_shared_by_name: 'Ada Lovelace',
+    circle_shared_by_username: 'ada',
+    circle_shared_at: '2026-05-23T21:00:00Z',
   },
   ai_summary: '',
   ai_tags: [],
@@ -87,6 +90,7 @@ describe('<CircleDetailPage>', () => {
 
     expect(screen.getByText('Why this was shared')).toBeInTheDocument()
     expect(screen.getByText('Use this when explaining JWT refresh token rotation.')).toBeInTheDocument()
+    expect(screen.getByText(/Shared by Ada Lovelace/i)).toBeInTheDocument()
     expect(screen.getByText('Useful Auth Repo')).toBeInTheDocument()
   })
 })

--- a/packages/features/src/pages/CircleDetailPage.tsx
+++ b/packages/features/src/pages/CircleDetailPage.tsx
@@ -142,17 +142,41 @@ export function CircleDetailPage() {
                 const shareContext = typeof item.meta?.circle_share_context === 'string'
                   ? item.meta.circle_share_context
                   : ''
+                const sharedByName = typeof item.meta?.circle_shared_by_name === 'string'
+                  ? item.meta.circle_shared_by_name
+                  : ''
+                const sharedByUsername = typeof item.meta?.circle_shared_by_username === 'string'
+                  ? item.meta.circle_shared_by_username
+                  : ''
+                const sharedAt = typeof item.meta?.circle_shared_at === 'string'
+                  ? item.meta.circle_shared_at
+                  : ''
+                const attribution = sharedByName || sharedByUsername
+                const sharedDate = sharedAt ? new Date(sharedAt) : null
+                const sharedDateLabel = sharedDate && !Number.isNaN(sharedDate.getTime())
+                  ? sharedDate.toLocaleDateString()
+                  : ''
 
                 return (
                   <div key={item.id} className="grid gap-3">
-                    {shareContext ? (
+                    {shareContext || attribution ? (
                       <div className="border-3 border-ink bg-accent-yellow/30 p-4 shadow-hard-sm">
-                        <p className="font-display text-xs font-black uppercase tracking-widest">
-                          {t('circles.why_shared')}
-                        </p>
-                        <p className="mt-2 font-mono text-sm text-ink">
-                          {shareContext}
-                        </p>
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-display text-xs font-black uppercase tracking-widest">
+                            {t('circles.why_shared')}
+                          </p>
+                          {attribution ? (
+                            <p className="font-mono text-xs text-ink-soft">
+                              {t('circles.shared_by', { name: attribution })}
+                              {sharedDateLabel ? ` · ${sharedDateLabel}` : ''}
+                            </p>
+                          ) : null}
+                        </div>
+                        {shareContext ? (
+                          <p className="mt-2 font-mono text-sm text-ink">
+                            {shareContext}
+                          </p>
+                        ) : null}
                       </div>
                     ) : null}
                     <ItemGrid

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -704,6 +704,7 @@
     "all_circles": "All Circles",
     "shared_vault": "Shared Vault",
     "why_shared": "Why this was shared",
+    "shared_by": "Shared by {{name}}",
     "shared_items_count": "{{count}} item shared",
     "shared_items_count_plural": "{{count}} items shared",
     "empty_shared_vault_title": "Empty Vault",


### PR DESCRIPTION
Closes #75

## PR Type
- [x] New feature

## Summary
- Adds Circle shared-item attribution metadata from the backend.
- Displays who shared an item and when in Circle detail.
- Extends backend/frontend tests for attribution rendering.

## Changes
| File | Change |
|------|--------|
| `backend/internal/store/circles.go` | Joins share metadata with user attribution. |
| `backend/internal/store/circles_test.go` | Verifies share attribution metadata. |
| `backend/internal/http/handlers/circles_test.go` | Verifies attribution is exposed by the API. |
| `packages/features/src/pages/CircleDetailPage.tsx` | Shows contributor attribution near the share context. |
| `packages/features/src/pages/CircleDetailPage.test.tsx` | Covers attribution rendering. |
| `packages/i18n/src/locales/en.json` | Adds the attribution label. |

## Test Plan
- [x] `./node_modules/.bin/tsc --noEmit -p packages/features/tsconfig.json`
- [x] `cd packages/features && ./node_modules/.bin/vitest run src/pages/CircleDetailPage.test.tsx`
- [x] `cd backend && GOCACHE=/private/tmp/devdeck-go-build-cache go test ./internal/store ./internal/http/handlers`

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
