### PR TITLE
docs(launch): clarify public beta positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,39 +23,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.0] - 2026-05-17
+## [0.5.0] - 2026-06-04
 
 ### Added
 
-- **Autonomous AI Agents**: Multi-step orchestration with tool-calling capabilities. Agents can search the vault, create items, and propose shell commands (Fases 49-50).
-- **Hybrid Execution**: Secure "Human-in-the-loop" model for executing terminal commands locally from the Desktop App.
-- **Collective Intelligence**: Team insights, adoption analytics, and trending tags detection for organizations (Fases 47-48).
-- **Enterprise Identity**: Full support for SAML 2.0 (SSO) and SCIM 2.0 (Automatic Provisioning) via Okta/Azure AD (Fases 45-46).
-- **Global Scalability**: Multi-region active-active synchronization with read replicas and atomic conflict resolution (Fases 43-44).
-- **Real-time Collaboration**: Conflict-free concurrent editing using Yjs and CRDTs over WebSockets (Fase 35).
-- **Teams & RBAC**: Organization-level multi-tenancy with granular Role-Based Access Control (Owner, Admin, Editor, Viewer).
-- **Plugin SDK**: Language-agnostic extensibility via HTTP-based custom enrichers and outbound webhooks (Fases 36-38).
-- **Onboarding Wizard**: Guided product tour with "Starter Kits" to eliminate the empty vault problem (Fase 51).
-- **Advanced Discovery**: Social feed for followers, team-wide search, and personalized tool recommendations.
+- **Public beta positioning**: DevDeck is now presented honestly as a functional open-source public beta, not a stable 1.0 product.
+- **Developer memory loop**: Public docs now explain the capture → context → retrieval → Workbench → Circles workflow.
+- **Circles community flow**: Circle sharing now includes context notes, attribution, source metadata, tags, and empty-state contribution guidance.
+- **Developer Workbench direction**: Docs describe the Workbench as a daily-use surface for reusable developer utilities, requests, snippets, runbooks, and project context.
+- **Contributor path**: README and contributing docs now call out launch-readiness contribution areas and small-PR expectations.
+- **Community launch kit**: Added honest Reddit/forum/social copy, support messaging, and launch-readiness checklist.
 
 ### Changed
 
-- **V1.0 Final Release**: Transitioned from a bookmark manager to a comprehensive **Knowledge OS for Developers**.
-- **Brutalist Redesign**: Final polish of the neo-brutalist design system across all platforms.
-- **Unified Search**: Refactored global search to prioritize team-validated knowledge.
-- **Documentation**: Complete technical architecture guide and self-hosting documentation.
+- **Version reset for honesty**: Workspace packages and extension version moved from premature `1.0.0` to `0.5.0`.
+- **Launch copy**: Removed over-promising stable/enterprise/autonomous-agent claims from public launch materials.
+- **README**: Reworked the public README around the rediscovery problem, product loop, current capabilities, setup, contribution, and support.
 
 ### Fixed
 
-- **Stability**: Fixed memory management in Electron renderer and pointer handling in Go backend.
-- **Security**: Hardened SSRF protection for OG scraping and refined PAT auditing.
-- **Performance**: Aggregated analytics queries now run exclusively on read replicas.
-
-### Security
-
-- HMAC SHA-256 signatures for outbound webhooks.
-- Dial-time IP validation for enrichment scraping.
-- Encrypted credential storage in Desktop using OS-native safe storage.
+- **Public trust risk**: Corrected misleading `v1.0.0 Stable` language in versioning and launch docs.
 
 ---
 
@@ -103,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/tiagofur/dev_deck/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/tiagofur/dev_deck/releases/tag/v1.0.0
+[Unreleased]: https://github.com/tiagofur/dev_deck/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/tiagofur/dev_deck/compare/v0.1.0...v0.5.0
 [0.1.0]: https://github.com/tiagofur/dev_deck/compare/v0.0.5...v0.1.0
 [0.0.5]: https://github.com/tiagofur/dev_deck/releases/tag/v0.0.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,19 @@ Thank you for your interest in contributing to DevDeck! This is an indie project
 2.  **Discussion first**: For new features, please open a **Discussion Issue** first. Do not send large PRs without prior acknowledgment.
 3.  **Reporting bugs**: Open an issue with clear reproduction steps, version, OS, and stack traces if applicable.
 
+## Best First Contributions
+
+DevDeck is currently preparing for a community launch. The most useful contributions are small, visible improvements that make the app easier to try, understand, and trust:
+
+- Polish one empty/loading/error state.
+- Improve one onboarding or README section.
+- Add one focused test for an existing feature.
+- Fix one Desktop/Web parity gap.
+- Improve one Circle sharing or community-memory flow.
+- Make local setup or self-hosting easier to follow.
+
+If you are new here, look for issues labeled `good first issue` or ask for a small launch-readiness task.
+
 ---
 
 ## Local Setup
@@ -95,6 +108,7 @@ We follow **Conventional Commits**: `feat:`, `fix:`, `docs:`, `test:`, `refactor
 - One PR = One concern.
 - Ensure the CI is green before requesting a review.
 - A minimum of one maintainer approval is required for merging.
+- Keep PRs small. Large PRs are harder to review, harder to debug, and more likely to be split.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,102 +1,192 @@
 # DevDeck.ai
 
-[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/tiagofur)
+[![Buy Me a Coffee](https://img.shields.io/badge/Support-Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)](https://www.buymeacoffee.com/tiagofur)
 
-> **Your AI-assisted external memory for development work.**
+> **The developer memory layer for everything useful you discover, build, and share.**
 
-[Leer en español](README.es.md)
+[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
 
-An **offline-first, multi-user, and multi-platform** app to save, organize, and rediscover everything useful a developer finds: repos, CLIs, plugins, cheatsheets, shortcuts, snippets, agents, prompts, and workflows. Powered by AI that classifies, summarizes, and retrieves by intent — not just exact tags.
+DevDeck is an open-source desktop/web app for developers who keep losing useful repos, CLIs, snippets, prompts, shortcuts, cheatsheets, and workflow notes across chats, bookmarks, browser tabs, and GitHub stars.
+
+It turns scattered discoveries into a searchable engineering memory: capture useful artifacts, enrich them with context, retrieve them by intent, use them inside a developer workbench, and share high-signal findings with trusted Circles.
 
 Domain: **[devdeck.ai](https://devdeck.ai)**
 
+Current version: **0.5.0 Public Beta** — functional, useful, and actively being polished before a stable 1.0 release.
+
 ---
 
-## Why DevDeck?
+## Why this exists
 
-The real problem isn't "saving repos." It's being unable to find what you already discovered: a useful CLI shared in a chat, an IDE plugin whose name you forgot, a macOS shortcut that took hours to learn, or a repo that solved exactly your current problem.
+Developers do not have a saving problem. We have a **rediscovery problem**.
 
-DevDeck is your **curated collection of dev knowledge** — with AI that makes everything you save findable weeks later, even if you don't remember what you called it.
+You saw the perfect CLI in a Discord thread. A repo solved an auth problem. A prompt helped with a code review. A shortcut saved you five minutes. Three weeks later, you remember the shape of the solution — but not the name, link, flags, or context.
+
+DevDeck is built for that moment.
+
+It is not another bookmark graveyard. It is a practical, AI-assisted memory system for daily development work.
+
+---
+
+## The daily loop
+
+1. **Capture** a repo, CLI, snippet, shortcut, prompt, article, runbook, or note.
+2. **Add context**: why it matters, when to use it, tags, source, and gotchas.
+3. **Retrieve by intent** using fuzzy and semantic search instead of exact names only.
+4. **Use it in Workbench** for reusable developer workflows, snippets, requests, and project context.
+5. **Share to Circles** so a group or community can build private collective memory instead of losing signal in chat.
+
+This is the product direction: from “my saved links” to **our reusable engineering memory**.
+
+---
+
+## What is already in the app
+
+- **Vault:** save and organize developer artifacts such as repos, CLIs, prompts, snippets, shortcuts, articles, tools, notes, and how-tos.
+- **AI enrichment:** classify, summarize, and tag saved items with OpenAI or local Ollama-backed flows.
+- **Search:** fuzzy and semantic retrieval powered by Postgres extensions such as `pg_trgm` and `pgvector`.
+- **Developer Workbench:** reusable local utilities, command palette, saved requests, snippets, runbooks, and project context tools.
+- **Circles:** private shared spaces where developers can contribute findings with context, attribution, source metadata, and tags.
+- **Multi-surface app:** shared React feature package for Web and Desktop, plus a browser extension and Go CLI.
+- **Offline-first direction:** local-first desktop/web architecture with sync-oriented docs and implementation work in progress.
+
+DevDeck is still evolving. If something is rough, that is exactly where contributors can have a visible impact.
+
+---
+
+## Screenshots and demo
+
+> Public screenshots and demo assets are being prepared for the community launch.
+
+For now, the best demo path is:
+
+1. Open the app.
+2. Capture a few real tools you use weekly.
+3. Add “why this matters” context.
+4. Try Workbench actions.
+5. Create a Circle and share one useful finding with context.
+
+That is the core experience we are polishing for public adoption.
 
 ---
 
 ## Stack
 
 - **Desktop:** Electron + React 18 + TypeScript + Tailwind + Framer Motion
-- **Web:** React 18 + Vite + React Router + TanStack Query (shares 100% of pages and components with Desktop)
-- **Backend:** Go + Chi + pgx + pgvector
-- **DB:** Postgres 16 (with `pg_trgm` + `pgvector` for fuzzy and semantic search)
-- **AI:** OpenAI API / Ollama (local)
-- **Offline:** Local SQLite (Electron) + sql.js/OPFS (Web)
-- **Deploy:** Self-hosted VPS · Docker Compose · Caddy (Automatic TLS)
-- **Domain:** [devdeck.ai](https://devdeck.ai) · `app.devdeck.ai` · `api.devdeck.ai`
+- **Web:** React 18 + Vite + React Router + TanStack Query
+- **Backend:** Go + Chi + pgx + Postgres 16
+- **Search:** `pg_trgm` + `pgvector`
+- **AI:** OpenAI API and local Ollama-oriented flows
+- **CLI:** Go
+- **Extension:** Manifest V3 + Vite
+- **Deploy:** Docker Compose + Caddy for self-hosted VPS deployments
 
-### Repo Layout (pnpm workspaces monorepo)
+### Monorepo layout
 
-```
+```txt
 dev_deck/
 ├── apps/
-│   ├── desktop/          # Electron app (React renderer)
-│   └── web/              # Web app (React + BrowserRouter)
+│   ├── desktop/          # Electron app
+│   ├── extension/        # Browser extension
+│   └── web/              # Web app
 ├── packages/
-│   ├── ui/               # Design system: Button, TagChip, Toaster, tailwind-preset
-│   ├── api-client/       # Fetch wrapper + TanStack Query hooks + auth adapters
-│   └── features/         # Pages + domain components (shared between apps)
+│   ├── ui/               # Design system
+│   ├── api-client/       # Fetch wrapper + TanStack Query hooks
+│   ├── features/         # Shared pages and domain components
+│   ├── i18n/             # Locale resources
+│   └── realtime-client/  # Realtime collaboration client
 ├── backend/              # Go API
-├── cli/                  # `devdeck` CLI (Go)
-├── extension/            # Browser extension (Manifest v3)
+├── cli/                  # devdeck CLI
 ├── deploy/               # Docker Compose + Caddy
-└── docs/                 # Documentation
+└── docs/                 # Product, architecture, launch, and ops docs
 ```
 
-Both apps import pages and components from the `@devdeck/features` package — they only differ in the shell (HashRouter + PasteInterceptor on desktop, BrowserRouter + AuthGuard on web). See [docs/adr/0003-monorepo-pnpm-workspaces.md](docs/adr/0003-monorepo-pnpm-workspaces.md).
+---
+
+## Quick start for contributors
+
+```bash
+pnpm install
+pnpm typecheck
+pnpm test
+```
+
+Run the desktop app:
+
+```bash
+pnpm dev:desktop
+```
+
+Run the web app:
+
+```bash
+pnpm dev:web
+```
+
+Run the backend locally:
+
+```bash
+cd backend
+cp .env.example .env
+docker compose -f ../deploy/docker-compose.local.yml up -d db
+go run ./cmd/api
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full setup and PR flow.
 
 ---
 
-## Screenshots
+## How to contribute
+
+The project is especially looking for help with:
+
+- UI/UX polish and responsive layout improvements.
+- Desktop/Web parity fixes.
+- Better onboarding and demo data.
+- Circle/community collaboration flows.
+- Search and AI enrichment quality.
+- CLI, extension, and capture integrations.
+- Tests, docs, and self-hosting reliability.
+
+Before opening a PR:
+
+1. Search existing issues.
+2. Open or use an approved issue.
+3. Keep the PR small and focused.
+4. Include tests or a clear verification note.
+
+Small, high-quality PRs are more valuable than giant feature drops.
+
 ---
 
-> 📸 **Explore screenshots and live demos on [DevDeck.ai](https://devdeck.ai)**
+## Support the project
+
+DevDeck is an indie open-source project. If it helps you, or if you want to support the push toward a polished public launch:
+
+- Sponsor/support: [Buy Me a Coffee](https://www.buymeacoffee.com/tiagofur)
+- Share the repo with developers who collect tools, repos, commands, and workflows.
+- Open issues with sharp feedback.
+- Contribute small PRs that improve launch readiness.
+
+Possible future sustainability paths include hosted community Circles, paid setup/support, curated workflow packs, and sponsorships — without compromising the open-source core.
 
 ---
 
 ## Documentation
 
-### Product & Vision
 | Doc | Content |
-|-----|-----------|
-| [docs/VISION.md](docs/VISION.md) | Vision, positioning, differentiators |
-| [docs/PRD.md](docs/PRD.md) | Product, features, user stories, scope by waves |
-| [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) | Developer Workbench: local utilities, palette, reusable actions |
-| [docs/COMPETITIVE_ANALYSIS.md](docs/COMPETITIVE_ANALYSIS.md) | Detailed competitive analysis |
-| [docs/LANDING.md](docs/LANDING.md) · [docs/LANDING_COPY.md](docs/LANDING_COPY.md) | Landing copy (ES / EN) |
-
-### Architecture & Decisions
-| Doc | Content |
-|-----|-----------|
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Diagram, stack, DB schema |
-| [docs/API.md](docs/API.md) | OpenAPI spec |
-| [docs/DESIGN_SYSTEM.md](docs/DESIGN_SYSTEM.md) | Tokens, palette, typography |
-| [docs/TECHNICAL_ROADMAP_AI_OFFLINE.md](docs/TECHNICAL_ROADMAP_AI_OFFLINE.md) | Technical roadmap: offline, sync, AI |
-| [docs/adr/0001-items-polymorphism.md](docs/adr/0001-items-polymorphism.md) | ADR: polymorphic items model |
-| [docs/adr/0002-sync-strategy.md](docs/adr/0002-sync-strategy.md) | ADR: offline-first sync strategy |
-| [docs/adr/0003-monorepo-pnpm-workspaces.md](docs/adr/0003-monorepo-pnpm-workspaces.md) | ADR: pnpm workspaces monorepo + React on web |
-
-### Operation & Contribution
-| Doc | Content |
-|-----|-----------|
-| [cli/README.md](cli/README.md) | Real installation and usage of the `devdeck` CLI (P0) |
-| [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Step-by-step self-hosting guide |
-| [docs/CAPTURE.md](docs/CAPTURE.md) | Capture channels spec (extension, CLI, paste, share) |
-| [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Test plan and CI |
-| [docs/REVIEW_2026_04.md](docs/REVIEW_2026_04.md) | **April 2026 Technical Review** — motivates Wave 4.5 |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |
-| [SECURITY.md](SECURITY.md) | Security policy |
+|-----|---------|
+| [docs/CIRCLES_COMMUNITY.md](docs/CIRCLES_COMMUNITY.md) | Circles as private collective memory for developer communities |
+| [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) | Developer Workbench direction and workflows |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture and technical design |
+| [docs/API.md](docs/API.md) | API documentation |
+| [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Self-hosting guide |
+| [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Testing and CI strategy |
+| [docs/LAUNCH_KIT.md](docs/LAUNCH_KIT.md) | Community launch copy and checklist |
+| [ROADMAP.md](ROADMAP.md) | Product roadmap |
 
 ---
 
-## Status
+## License
 
-DevDeck is an evolving open-source product. The current direction is to strengthen the core vault, capture flows, semantic retrieval, and the new **Developer Workbench**: local utilities, command palette, reusable requests, snippets, and runbooks connected to your saved context.
-
-See [ROADMAP.md](ROADMAP.md) and [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) for the product direction.
+Apache-2.0. See [LICENSE](LICENSE).

--- a/ROADMAP.es.md
+++ b/ROADMAP.es.md
@@ -15,8 +15,8 @@ Ver [docs/DEV_WORKBENCH.es.md](docs/DEV_WORKBENCH.es.md) para la propuesta de pr
 ### Ola 4.5 a 17 — Cerradas
 - ✅ §16.5 Higiene de repo (ADRs, docs, licensing)
 - ✅ §16.9 `POST /api/items/capture` con detección, dedupe y enrich async
-- ✅ §16.10 CLI `devdeck` (v1.0.0 Stable)
-- ✅ §16.11 Extensión de browser (v1.0.0 Stable)
+- ✅ §16.10 CLI `devdeck` (v0.5.0 Beta Pública)
+- ✅ §16.11 Extensión de browser (v0.5.0 Beta Pública)
 - ✅ Wave 5-12: Features avanzadas, sync y social
 - ✅ Wave 13-16: Enterprise identity y Agentes autónomos
 - ✅ Wave 17: Lanzamiento y Onboarding
@@ -67,13 +67,13 @@ Fortalecer la captura, recuperación y reutilización diaria del conocimiento gu
 - Response incluye `duplicate_of` cuando aplica y `enrichment_status`. ✅
 - Tests end-to-end con los 9 tipos de input + dedupe intra-tabla + dedupe cross-table contra `repos` legacy. ✅
 
-### Fase 16.10 — CLI `devdeck` (v1.0.0 Stable) ✅
+### Fase 16.10 — CLI `devdeck` (v0.5.0 Beta Pública) ✅
 - Localizado en `cli/` (Go con Cobra).
 - Soporte para `login`, `logout`, `add`, `search`, `list`, `open`, `status`, `import`.
 - Nuevo comando interactivo: `devdeck agent` para chatear con el vault.
 - Almacenamiento seguro de tokens en el Keychain del sistema.
 
-### Fase 16.11 — Extensión de browser (v1.0.0 Stable) ✅
+### Fase 16.11 — Extensión de browser (v0.5.0 Beta Pública) ✅
 - Localizada en `apps/extension/` (React + manifest v3).
 - Atajo `Cmd/Ctrl+Shift+D` para captura inmediata.
 - Menús contextuales para guardar links y fragmentos de texto como notas.
@@ -117,8 +117,8 @@ Fortalecer la captura, recuperación y reutilización diaria del conocimiento gu
 - [x] ≥ 5 flows E2E pasando en Electron (Playwright skeleton con los 5 flows).
 - [x] Endpoint `/api/items/capture` en producción con tests.
 - [x] Web client migrado a React y compartiendo código con desktop (§16.13).
-- [x] CLI `devdeck` en release v1.0.0 Stable con distribución global.
-- [x] Extensión Chrome en Chrome Web Store (v1.0.0 Stable). ✅
+- [x] CLI `devdeck` en release v0.5.0 Beta Pública con distribución global.
+- [x] Extensión Chrome en Chrome Web Store (v0.5.0 Beta Pública). ✅
 - [x] README con screenshots (enlace a [devdeck.ai](https://devdeck.ai)). ✅
 - [x] `api.exe` fuera del repo.
 - [x] ADRs 0001, 0002 y 0003 con decisión final ("Aceptadas").
@@ -605,16 +605,16 @@ Fortalecer la captura, recuperación y reutilización diaria del conocimiento gu
 - Docs: Documentación técnica completa para desarrolladores y administradores
 - Marketing: Preparación de assets para lanzamiento en Product Hunt / GitHub Trending
 
-### Fase 53 — Hardening de Producción, Team Alerts y v1.0 Release (FINAL)
+### Fase 53 — Hardening de Producción, Team Alerts y v0.5 Public Beta (FINAL)
 
 - Monitoring: Implementación de observabilidad global con Prometheus para Agentes e IA
 - Security: Mitigación de SSRF en enriquecedores y auditoría final de flujos de identidad
 - Alerts: Sistema de Team Alerts proactivo vía webhooks para Hot Topics internos. ✅
-- Launch: Publicación de la v1.0 estable y finalización del Roadmap de 17 Olas
+- Launch: Publicación de la v0.5 beta pública y finalización del Roadmap de 17 Olas
 
 ---
 
-## Stack actualizado (v1.0)
+## Stack actualizado (v0.5 beta)
 
 | Capa | Tecnología |
 |------|-----------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,90 +1,109 @@
 # DevDeck.ai Roadmap
 
-This document outlines the vision and development stages for **DevDeck.ai**. We worked in "Waves" (Olas) to progressively build the core infrastructure, the capture network, and the collective AI intelligence.
+This roadmap reflects the current public position of DevDeck: **0.5.0 Public Beta**.
 
 [Leer en español](ROADMAP.es.md)
 
 ---
 
-## Product Direction
+## Current product direction
 
-DevDeck is moving from external memory toward a **Developer Workbench**: saved developer knowledge that can be retrieved by intent and reused as commands, snippets, requests, runbooks, and local utility workflows.
+DevDeck is becoming a developer memory layer: capture useful developer artifacts, add context, retrieve them by intent, use them inside a Workbench, and share high-signal findings with trusted Circles.
 
-See [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) for the current product proposal.
+The priority before a stable `1.0.0` is not more hype. It is trust:
 
----
-
-## ✅ Waves 1–4: Core Foundation
-
-- [x] **Wave 1:** Core Go API, Auth (GitHub), and basic Items CRUD.
-- [x] **Wave 2:** Enrichment engine (Open Graph metadata, screenshot capture).
-- [x] **Wave 3:** Frontend redesign (Neo-brutalist / Dark mode).
-- [x] **Wave 4:** Monorepo transition (pnpm workspaces) and shared components.
-
-## ✅ Wave 5: General Items + Real AI
-
-- [x] **Phase 18:** Polymorphic Items (CLIs, Snippets, Prompts, Workflows).
-- [x] **Phase 19:** AI Semantic Brain (Embeddings, Semantic Search, RAG).
-
-## ✅ Wave 6: Offline-first + Sync
-
-- [x] **Phase 20:** Offline-first Architecture (Local SQLite, OPFS, Atomic Sync).
-- [x] **Phase 21:** Public Decks & Community sharing.
-
-## Waves 7–12: Advanced Features
-
-- [x] **Wave 7:** Versioning and Multi-device management.
-- [x] **Wave 8:** Smart Notifications, Social Following, and collaborative Circles (share repos, tools, bash, etc. with friends).
-- [x] **Wave 9:** Real-time Collaboration (Yjs, WebSockets, CRDTs).
-- [x] **Wave 10:** Plugin SDK and Outbound Webhooks (HMAC signatures).
-- [x] **Wave 11:** Mobile Bridge (PWA Share Target, Progressive Sync).
-- [x] **Wave 12:** Social Gamification and Reputation System.
-
-### Wave 12 — Social Collaboration and Public Curation
-
-#### Phase 41 — Collaborative Circles and Following
-
-- **Collaborative Circles:** Share repositories, useful bash commands, cheatsheets, Workbench tools, and other developer findings inside closed/private groups.
-- **Social graph:** Follow public curator profiles to keep high-signal developer discoveries visible after they leave chat, Slack, Discord, or community threads.
-- **Feed:** Combine recent saves from followed curators with activity from the user's Circles.
-- **Notifications:** Alert users when a followed curator publishes a new Deck or when useful activity happens in their Circles.
-
-#### Phase 42 — Community Discovery and Rankings
-
-- **Discovery:** Global feed with the most-saved developer findings of the week.
-- **Gamification:** Contribution points and expertise badges based on high-signal contributions, not raw posting volume.
-- **Leaderboard:** Rank useful curators and starred Decks so communities can find trustworthy references faster.
-
-## Waves 13–16: Enterprise & Agents
-
-- [x] **Wave 13:** Global Scalability (Read Replicas, Multi-region Sync).
-- [x] **Wave 14:** Enterprise Core (SAML 2.0 SSO, SCIM 2.0 Provisioning).
-- [x] **Wave 15:** Collective Intelligence (Team Insights, Trending Tags).
-- [x] **Wave 16:** AI Agents (Autonomous Tool Calling, Hybrid Local Execution).
-
-## Wave 17: Public Launch
-
-- [x] **Phase 51:** Onboarding Wizard and Starter Kits.
-- [x] **Phase 52:** v1.0 Landing Page and Documentation.
-- [x] **Phase 53:** Production Hardening, Team Alerts (Webhooks), and Stable v1.0 Release.
+- clear onboarding,
+- reliable setup,
+- polished UI states,
+- honest documentation,
+- useful demo data,
+- stable capture/search/workbench/Circles flows,
+- and a contributor path that makes small PRs easy.
 
 ---
 
-## Tech Stack (v1.0)
+## 0.5.x — Public beta / launch readiness
 
-| Layer | Technology |
-|------|-----------|
-| **Monorepo** | pnpm workspaces (100% shared domain logic) |
-| **Desktop** | Electron 32 + Native Shell support + safeStorage |
-| **Web** | Vite + React 18 + PWA (Workbox) + OPFS |
-| **Backend** | Go 1.22+ with Multi-Pool architecture (Reader/Writer) |
-| **Database** | Postgres 16 + pgvector + Regional Replicas |
-| **AI** | Autonomous Agents (SSE + Tool Calling) + OpenAI/Ollama |
-| **Identity** | SAML 2.0 (SSO) + SCIM 2.0 + RBAC |
-| **Sync** | Bidirectional Atomic Sync with LWW + CRDTs |
-| **Styling** | Tailwind CSS (Neo-Brutalist design system) |
-| **Real-time** | Yjs + WebSockets |
+### Product polish
+
+- [x] Clarify public README and launch story.
+- [x] Position DevDeck honestly as `0.5.0 Public Beta`.
+- [ ] Add screenshots and/or a short demo GIF.
+- [ ] Add realistic demo/seed data for a first-run experience.
+- [ ] Document known limitations clearly.
+- [ ] Verify local setup on a clean machine.
+
+### Core developer memory loop
+
+- [x] Capture developer artifacts into the vault.
+- [x] Add context such as notes, tags, source, and why it matters.
+- [x] Support fuzzy/semantic retrieval direction with Postgres search extensions.
+- [x] Share useful findings into Circles with context and attribution.
+- [ ] Tighten empty/loading/error states across core flows.
+- [ ] Improve first-run onboarding around capture → retrieve → share.
+
+### Workbench
+
+- [x] Establish Developer Workbench as a daily-use surface.
+- [x] Support reusable utilities, snippets, runbooks, requests, and project context direction.
+- [ ] Improve Workbench onboarding and examples.
+- [ ] Add more tests around save/share flows.
+
+### Circles / community memory
+
+- [x] Treat Circles as a strategic community contribution loop.
+- [x] Add context-required sharing from useful surfaces.
+- [x] Display share context, attribution, source metadata, and tags.
+- [x] Add empty-state guidance for starting a shared vault.
+- [ ] Add lightweight activity feed design.
+- [ ] Add save/fork/usefulness interactions for shared findings.
+- [ ] Prepare public/community showcase strategy without exposing private Circle content.
+
+### Contributor readiness
+
+- [x] Add contributor call-to-action in README.
+- [x] Add best-first-contribution guidance.
+- [ ] Create at least 5 `good first issue` tasks.
+- [ ] Add a short architecture map for new contributors.
+- [ ] Keep PRs small, issue-backed, and CI-verified.
 
 ---
 
-*Last updated: May 2026*
+## 0.6.x — Stronger beta
+
+- [ ] Ship demo data and guided first-run path.
+- [ ] Improve responsive UI polish for public screenshots.
+- [ ] Harden extension and CLI capture flows.
+- [ ] Improve self-hosting docs and deploy verification.
+- [ ] Add more integration/E2E coverage for critical user loops.
+- [ ] Refine AI enrichment quality and local/Ollama setup guidance.
+
+---
+
+## 0.7.x — Community collaboration beta
+
+- [ ] Circle activity feed.
+- [ ] Reactions/comments or usefulness signals.
+- [ ] Weekly digest prototype.
+- [ ] Public curated collection prototype.
+- [ ] Contributor/curator profile improvements.
+
+---
+
+## 1.0.0 criteria
+
+DevDeck should only be called `1.0.0 Stable` when:
+
+- A new developer can understand the value from the README in under 30 seconds.
+- Screenshots/GIF/demo assets exist.
+- Clean setup works from documented instructions.
+- Capture, search, Workbench, and Circles flows are reliable.
+- Known limitations are explicit.
+- CI and critical E2E checks are stable.
+- Contributor workflow is proven through small external-friendly issues/PRs.
+
+Until then, DevDeck stays honest: useful public beta, improving in the open.
+
+---
+
+*Last updated: June 2026 — 0.5.0 Public Beta*

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@devdeck/desktop",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
-  "description": "DevDeck — your personal dev multi-tool. Desktop app.",
+  "description": "DevDeck \u2014 your personal dev multi-tool. Desktop app.",
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -1,4 +1,4 @@
-# DevDeck — Browser Extension (v1.0.0 Stable)
+# DevDeck — Browser Extension (v0.5.0 Public Beta)
 
 > The browser companion for your Knowledge OS. Capture repositories, documentation, and technical notes with a single click or keyboard shortcut.
 
@@ -31,4 +31,4 @@ Located in `apps/extension/` within the DevDeck monorepo.
 Default: `Cmd/Ctrl+Shift+D`. You can customize this in `chrome://extensions/shortcuts`.
 
 ---
-*Part of the DevDeck v1.0.0 Stable release.*
+*Part of the DevDeck v0.5.0 Public Beta release.*

--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -1,15 +1,19 @@
 {
   "manifest_version": 3,
-  "name": "DevDeck — Browser Extension",
+  "name": "DevDeck \u2014 Browser Extension",
   "description": "Capture repositories, documentation, and technical notes with a single click. The browser companion for your Knowledge OS.",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "action": {
     "default_popup": "src/popup/index.html"
   },
   "content_scripts": [
     {
-      "js": ["src/content/index.tsx"],
-      "matches": ["<all_urls>"]
+      "js": [
+        "src/content/index.tsx"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ],
   "background": {
@@ -20,8 +24,15 @@
     "page": "src/options/index.html",
     "open_in_tab": true
   },
-  "permissions": ["activeTab", "storage", "alarms", "contextMenus"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "activeTab",
+    "storage",
+    "alarms",
+    "contextMenus"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "commands": {
     "capture-tab": {
       "suggested_key": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@devdeck/extension",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
-  "description": "DevDeck — browser extension (React/Vite).",
+  "description": "DevDeck \u2014 browser extension (React/Vite).",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "package": "npm run build && zip -r ../../dist/devdeck-extension-v1.0.0.zip dist/",
+    "package": "npm run build && zip -r ../../dist/devdeck-extension-v0.5.0.zip dist/",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@devdeck/web",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
-  "description": "DevDeck — web client (React).",
+  "description": "DevDeck \u2014 web client (React).",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,7 +60,7 @@ ALLOWED_GITHUB_LOGINS=tu-usuario,otro-colega
 JWT_SECRET=<hex-32-chars>
 REFRESH_SECRET=<hex-32-chars>
 
-# IA (Opcional, pero recomendado para v1.0)
+# IA (Opcional, pero recomendado para v0.5 beta)
 AI_PROVIDER=openai
 OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-4o
@@ -93,9 +93,9 @@ docker compose logs -f api
 docker compose logs -f web
 ```
 
-## 5. Aplicar migraciones (v1.0.0)
+## 5. Aplicar migraciones (0.5.0 beta)
 
-DevDeck v1.0.0 requiere aplicar todas las migraciones del core:
+DevDeck 0.5.0 beta requiere aplicar las migraciones del core disponibles:
 
 ```bash
 for f in ../backend/migrations/*.sql; do
@@ -107,7 +107,7 @@ done
 ## 6. Probar que está vivo
 
 ```bash
-# Health (público - incluye DB ping en v1.0)
+# Health (público - incluye DB ping en v0.5 beta)
 curl https://devdeck.ai/healthz
 
 # Métricas (Prometheus)
@@ -116,7 +116,7 @@ curl https://devdeck.ai/metrics
 
 Si todo está bien, vas a ver `{"status":"ok"}` y una lista de métricas que incluyen `devdeck_agent_tool_calls_total`.
 
-## 7. Observabilidad (v1.0.0)
+## 7. Observabilidad (0.5.0 beta)
 
 DevDeck incluye un stack de monitoreo integrado:
 

--- a/docs/API.es.md
+++ b/docs/API.es.md
@@ -1,4 +1,4 @@
-# Especificación de la API de DevDeck.ai (v1.0)
+# Especificación de la API de DevDeck.ai (v0.5 beta)
 
 Este documento describe la API REST de **DevDeck.ai**.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,4 @@
-# DevDeck.ai API Specification (v1.0)
+# DevDeck.ai API Specification (0.5.0 Public Beta)
 
 This document describes the REST API for **DevDeck.ai**.
 
@@ -11,8 +11,6 @@ The API uses **JWT (JSON Web Tokens)** for most operations and **API Keys** for 
 
 - **JWT Header:** `Authorization: Bearer <access_token>`
 - **API Key Header:** `X-API-Key: devdeck_<token>`
-- **SAML SSO:** Supported for enterprise organizations.
-- **SCIM 2.0:** Supported for automatic user provisioning.
 
 ---
 
@@ -34,24 +32,11 @@ Manage the core knowledge vault.
 - `DELETE /api/items/:id`: Permanent removal.
 - `POST /api/items/:id/ai-enrich`: Trigger LLM classification and summarization.
 
-### 3.2 AI Agents (Wave 16)
-- `POST /api/agent/chat`: Interactive agent chat (Server-Sent Events).
-- Supports multi-step orchestration and tool calling.
-
-### 3.3 Organizations & Teams (Wave 15)
-- `GET /api/orgs`: List user organizations.
-- `POST /api/orgs`: Create a new team vault.
-- `GET /api/orgs/:id/insights`: Aggregated adoption analytics (Admin only).
-- `GET /api/orgs/:id/discovery/trending`: Team-wide trending tags (Hot Topics).
-- `GET /api/orgs/:id/discovery/recommendations`: Smart tool suggestions from the team.
-
-### 3.4 Identity & Enterprise (Wave 14)
+### 3.2 Identity
 - `GET /api/auth/me`: Current user profile and onboarding status.
 - `PATCH /api/auth/me/onboarding/complete`: Mark product tour as finished.
-- `GET /api/saml/metadata`: SP Metadata for identity providers.
-- `POST /api/scim/v2/Users`: Standard SCIM provisioning endpoint.
 
-### 3.5 Global Search
+### 3.3 Global Search
 - `GET /api/search?q=query&mode=hybrid`: Unified search across items and cheatsheets.
 - Modes: `text` (fuzzy), `vector` (semantic), `hybrid` (RRF merge).
 
@@ -81,9 +66,7 @@ Errors follow a predictable structure:
 
 ## 5. Rate Limits
 - **Standard:** 2000 req/5m.
-- **AI Agent:** 50 req/1h (Cloud Pro) | 5 req/1h (Free).
-- **Public Feed:** 500 req/1m.
 
 ---
 
-*Last updated: May 2026 (v1.0.0 Stable)*
+*Last updated: June 2026 (0.5.0 Public Beta)*

--- a/docs/LANDING_COPY.es.md
+++ b/docs/LANDING_COPY.es.md
@@ -1,6 +1,6 @@
 # DevDeck — Copy y estructura de contenido para devdeck.ai (versión en inglés)
 
-> Versión: 1.0.0 (Stable) · Última actualización: Mayo 2026
+> Versión: 0.5.0 (Beta Pública) · Última actualización: Mayo 2026
 
 Este documento define el contenido, copy y estructura de secciones para la landing page de **devdeck.ai**.
 Refleja el estado final del producto tras completar las 17 olas del roadmap.

--- a/docs/LAUNCH_KIT.md
+++ b/docs/LAUNCH_KIT.md
@@ -1,68 +1,133 @@
-# DevDeck v1.0.0 — Launch Kit 🚀
+# DevDeck — Community Launch Kit
 
-Este documento contiene los assets y textos preparados para el lanzamiento público de DevDeck en comunidades de desarrollo.
+This document contains honest, community-ready copy for introducing DevDeck on GitHub, Reddit, forums, Discord groups, newsletters, and social channels.
 
----
-
-## 1. Product Hunt Launch 🐈
-
-**Tagline:** Your AI-assisted external memory for development work.  
-**Description:**  
-DevDeck isn't just another bookmark manager. It's a full Knowledge OS designed for developers.
-Save repositories, CLIs, shortcuts, and snippets with a single click. 
-
-**Key Features for Launch:**
-- **Autonomous AI Agents:** Locally supervised command execution (Hybrid model).
-- **Collective Intelligence:** Team insights and shared tool discovery.
-- **Offline-First:** Built with SQLite/OPFS for ultra-fast, internet-optional usage.
-- **Enterprise Ready:** SAML 2.0 and SCIM integration.
+DevDeck is not being positioned as a finished enterprise platform. The launch angle is stronger and safer: **an open-source developer memory app looking for early users, contributors, and sharp feedback.**
 
 ---
 
-## 2. Twitter / X Announcement 🐦
+## Version framing
 
-**Option A (The Problem):**
-Developers discover 100 useful repos a week and forget 99 of them. 
-Bookmarks are a graveyard. GitHub Stars are messy.
-
-We built DevDeck.ai to solve this. It's your external memory with AI that actually understands code. v1.0 is officially LIVE! 🚀
-#Devtools #BuildInPublic
-
-**Option B (The Tech):**
-Spent months building a Knowledge OS for devs. 
-- Go backend (Multi-Pool architecture)
-- React 18 Monorepo
-- pgvector for semantic brain
-- Yjs for real-time CRDTs
-- Hybrid AI Agent execution
-
-Open Source. Offline-first. v1.0 out now! 🖤
+DevDeck should be presented as **0.5.0 Public Beta**. Do not call it stable or 1.0 yet. The honest message is: useful today, actively polished, and looking for early users/contributors before a stable release.
 
 ---
 
-## 3. GitHub Release Notes 📦
+## Core positioning
 
-### DevDeck v1.0.0 Stable
+**Short tagline:**
+The developer memory layer for everything useful you discover, build, and share.
 
-Welcome to the official 1.0 release. We have completed all 17 waves of the roadmap.
+**One-liner:**
+DevDeck helps developers capture repos, CLIs, snippets, prompts, shortcuts, notes, and workflows — then rediscover them by context, intent, and community signal.
 
-**What's New:**
-- **AI Agents**: Multi-step tool calling and local shell execution.
-- **Team Vaults**: Organization multi-tenancy and collective discovery.
-- **Global Sync**: Multi-region synchronization with conflict resolution.
-- **Onboarding**: New guided tour and Starter Kits for Go, Node, and AI.
-
-**Join the Community:**
-- Documentation: https://docs.devdeck.ai
-- Discord: coming soon
+**30-second pitch:**
+Developers discover useful tools every week and then lose them across chats, bookmarks, GitHub stars, and browser tabs. DevDeck turns those scattered discoveries into a searchable engineering memory. Save the artifact, add why it matters, retrieve it later by intent, use it inside Workbench, and share high-signal findings with trusted Circles.
 
 ---
 
-## 4. Checklist de Lanzamiento (Día 0)
+## GitHub README hook
 
-1. [ ] **Build Extension**: Ejecutar `pnpm -F @devdeck/extension package`.
-2. [ ] **Upload to Store**: Subir el zip generado a la [Chrome Developer Console](https://chrome.google.com/webstore/devconsole).
-3. [ ] **Merge to Main**: El push disparará el CD automático al VPS (Paso 1).
-4. [ ] **Tag Release**: `git tag -a v1.0.0 -m "Official release"` y `git push origin v1.0.0`.
-5. [ ] **Product Hunt**: Publicar usando el copy del punto 1.
-6. [ ] **Announce**: Publicar en Twitter y LinkedIn.
+> I am building DevDeck as an open-source external memory for developers: a place to save useful repos, CLIs, prompts, snippets, shortcuts, notes, and runbooks with enough context to actually find and reuse them later.
+>
+> The current focus is launch readiness: better onboarding, UI polish, shared Circles for community knowledge, and making it easy for contributors to jump in.
+
+---
+
+## Reddit / forum post draft
+
+**Title ideas:**
+- I’m building an open-source external memory app for developers — looking for feedback and contributors
+- Bookmarks and GitHub stars keep failing me, so I’m building DevDeck
+- DevDeck: save developer tools, snippets, prompts, and workflows with context
+
+**Post:**
+
+Hey folks — I’m building **DevDeck**, an open-source developer memory app.
+
+The problem I’m trying to solve: I keep finding useful repos, CLIs, snippets, prompts, shortcuts, and workflow notes, but weeks later I can’t remember where I saw them or why they mattered. Bookmarks become a graveyard. GitHub stars are too broad. Chat history disappears.
+
+DevDeck is my attempt to make that memory reusable:
+
+- Capture repos, CLIs, prompts, snippets, shortcuts, articles, notes, and how-tos.
+- Add context like “why this matters”, tags, source, and gotchas.
+- Retrieve things later with fuzzy/semantic search.
+- Use saved context inside a Developer Workbench.
+- Share high-signal findings with private Circles so a community can build collective memory.
+
+It’s built with Go, React, Electron, Postgres, pgvector, pnpm workspaces, and a shared Web/Desktop feature layer.
+
+I’m not claiming it’s perfect yet. I’m actively polishing the onboarding, UI, docs, demo flow, and contributor experience. I’d love feedback from developers who collect tools/workflows or participate in dev communities.
+
+Repo: https://github.com/tiagofur/dev_deck
+Site: https://devdeck.ai
+
+If this problem resonates with you, I’m especially looking for:
+
+- UX feedback.
+- Contributors for small polish PRs.
+- Ideas for the Circles/community knowledge loop.
+- People willing to try the app with their real saved dev resources.
+
+---
+
+## X / LinkedIn post
+
+Developers discover useful tools every week and lose them across chats, bookmarks, tabs, and GitHub stars.
+
+I’m building DevDeck: an open-source memory layer for repos, CLIs, snippets, prompts, shortcuts, notes, workflows, and community findings.
+
+Looking for feedback + contributors.
+
+https://github.com/tiagofur/dev_deck
+
+---
+
+## Contributor call-to-action
+
+DevDeck needs contributors who care about developer tooling, knowledge management, and community workflows.
+
+Good first contribution areas:
+
+- Polish one UI state.
+- Improve onboarding copy.
+- Add a focused test.
+- Improve README/docs clarity.
+- Fix Desktop/Web parity issues.
+- Improve a Circle sharing surface.
+- Make self-hosting smoother.
+
+Rule: small PRs beat giant PRs.
+
+---
+
+## Support / sustainability copy
+
+DevDeck is an indie open-source project. If the idea helps you, you can support the work here:
+
+https://www.buymeacoffee.com/tiagofur
+
+Possible future sustainability paths:
+
+- Hosted community Circles.
+- Paid setup/support for teams or communities.
+- Premium workflow/template packs.
+- Sponsorships from developer-tooling companies.
+
+The goal is to keep the open-source core useful while finding a realistic way to fund continued development.
+
+---
+
+## Launch readiness checklist
+
+Before posting widely:
+
+1. [ ] README explains the value in under 30 seconds.
+2. [ ] Repo has screenshots or a short demo GIF/video.
+3. [ ] Contributor guide has a clear first-PR path.
+4. [ ] At least 5 `good first issue` tasks exist.
+5. [ ] Demo flow works with realistic sample data.
+6. [ ] Local setup instructions are verified on a clean machine.
+7. [ ] Known limitations are stated honestly.
+8. [ ] Support link is visible but not pushy.
+9. [ ] Reddit/forum post asks for feedback, not hype validation.
+10. [ ] Follow-up plan exists for issues, comments, and contributors after launch.

--- a/docs/TECHNICAL_ROADMAP_AI_OFFLINE.es.md
+++ b/docs/TECHNICAL_ROADMAP_AI_OFFLINE.es.md
@@ -1,6 +1,6 @@
-# DevDeck — Roadmap Técnico: Offline-first + Sync + Multi-usuario + IA (v1.0)
+# DevDeck — Roadmap Técnico: Offline-first + Sync + Multi-usuario + IA (v0.5 beta)
 
-> Versión: 1.0.0 (Stable) · Última actualización: Mayo 2026
+> Versión: 0.5.0 (Beta Pública) · Última actualización: Mayo 2026
 
 Este documento detalla la arquitectura implementada para las Olas 5 y 6.
 Todas las fases técnicas descritas aquí se encuentran **COMPLETADAS** y en producción.
@@ -64,4 +64,4 @@ Sistema multi-tenant con perfiles públicos y vaults compartidos (Teams).
 
 ---
 
-*Misión técnica v1.0.0 cumplida. Roadmap finalizado.*
+*Misión técnica de beta pública en progreso. Roadmap hacia 1.0 pendiente de hardening.*

--- a/docs/VERSIONING.es.md
+++ b/docs/VERSIONING.es.md
@@ -9,14 +9,25 @@
 DevDeck usa [Semantic Versioning](https://semver.org/) (SemVer) con el formato `MAJOR.MINOR.PATCH`:
 
 | Componente | Cuándo cambia | Ejemplo |
-|-----------|-------------|--------|
-| **MAJOR** | Cambios incompatibles en la API | `0.x.0` → `1.0.0` |
-| **MINOR** | Nueva funcionalidad compatibles | `0.1.0` → `0.2.0` |
-| **PATCH** | Bug fixes compatibles | `0.1.0` → `0.1.1` |
+|-----------|---------------|---------|
+| **MAJOR** | Contrato de producto/API estable y cambios incompatibles | `0.x.0` → `1.0.0` |
+| **MINOR** | Nuevas funcionalidades compatibles o hitos de beta pública | `0.5.0` → `0.6.0` |
+| **PATCH** | Bug fixes compatibles | `0.5.0` → `0.5.1` |
 
-**Estado actual:** `1.0.0` (Ola 17 - Lanzamiento estable)
+**Estado actual:** `0.5.0` — beta pública / hito de launch-readiness.
 
-> DevDeck ha alcanzado su versión `1.0.0` estable tras completar las 17 olas del roadmap.
+> DevDeck todavía no es un producto estable `1.0.0`. La posición pública honesta es: beta open-source funcional, con dirección clara de memoria para developers, polish activo y lanzamiento comunitario en progreso.
+
+### Cuándo DevDeck puede ser 1.0.0
+
+DevDeck no debería etiquetarse como `1.0.0` hasta que esto sea verdad:
+
+- Onboarding/demo limpio para que una persona nueva vea valor en minutos.
+- Setup local y self-hosting verificados en una máquina limpia.
+- Flujos core de capture/search/workbench/Circles suficientemente estables para uso público.
+- README público, screenshots/GIFs y docs de contribución confiables.
+- Limitaciones conocidas documentadas con honestidad.
+- CI/E2E crítico confiable.
 
 ---
 
@@ -33,19 +44,13 @@ Usamos el formato [Keep a Changelog](https://keepachangelog.com/):
 ### Removed
 ### Fixed
 ### Security
-
----
-
-## [0.1.0] - 2026-05-03
-### Added
-- Stack filter
-- Smart tags
-...
 ```
 
 **Archivos:**
-- `CHANGELOG.md` — Changelog del proyecto
-- `package.json` — Versión del monorepo
+- `CHANGELOG.md` — changelog del proyecto
+- `package.json` — versión del monorepo
+- `apps/*/package.json` y `packages/*/package.json` — versiones de paquetes workspace
+- `apps/extension/manifest.json` — versión de la extensión
 
 ---
 
@@ -53,45 +58,34 @@ Usamos el formato [Keep a Changelog](https://keepachangelog.com/):
 
 Los mensajes de commit siguen [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
-<tipo>[ámbito opcional]: <descripción>
-
-[body opcional]
-
-[footer opcional]
+```txt
+<tipo>[scope opcional]: <descripción>
 ```
 
 **Tipos:**
 
-| Tipo | Descripción | Genera release |
-|------|------------|--------------|
+| Tipo | Descripción | Release |
+|------|-------------|---------|
 | `feat` | Nueva funcionalidad | `minor` bump |
 | `fix` | Bug fix | `patch` bump |
-| `docs` | Documentación | ❌ |
-| `style` | Formateo (CSS, etc) | ❌ |
-| `refactor` | Refactor sin cambio funcional | ❌ |
-| `perf` | Optimización de performance | ❌ |
-| `test` | Agregar/modificar tests | ❌ |
-| `build` | Cambios en build system | ❌ |
-| `ci` | Cambios en CI/CD | ❌ |
-| `chore` | Mantenimiento | ❌ |
-| `revert` | Revertir commit anterior | ❌ |
-| `improvement` | Mejora de feature existente | `patch` bump |
+| `docs` | Documentación | sin bump automático |
+| `style` | Formato/CSS-only | sin bump automático |
+| `refactor` | Refactor sin cambio funcional | sin bump automático |
+| `perf` | Optimización | patch/minor según impacto |
+| `test` | Tests | sin bump automático |
+| `build` | Build system | sin bump automático |
+| `ci` | CI/CD | sin bump automático |
+| `chore` | Mantenimiento | sin bump automático |
+| `revert` | Revert de commit anterior | depende del cambio revertido |
 
 **Ejemplos:**
 
 ```bash
-feat(ui): add stack filter with multi-select pills
-fix(items): resolve N+1 query in items list
-docs(api): update authentication endpoint docs
-chore: add release workflow
+feat(circles): share workbench output with context
+fix(items): resolve duplicate capture regression
+docs(launch): clarify public beta positioning
+chore(release): set public beta version to 0.5.0
 ```
-
-**Reglas de validación:**
-- Header máximo 72 caracteres
-- Subject en minúsculas
-- Tipo obligatorio
-- Descripción obligatoria (sin punto al final)
 
 ---
 
@@ -109,74 +103,50 @@ pnpm release
 ```
 
 **Qué hace `bumpp`:**
-1. Detecta tipo de cambio (feat→minor, fix→patch)
-2. Sube versión en `package.json`
-3. Actualiza `CHANGELOG.md` con nuevos cambios
-4. Crea git tag (`v0.1.0`)
-5. push con tags
+1. Detecta tipo de cambio.
+2. Actualiza versión en `package.json`.
+3. Actualiza `CHANGELOG.md`.
+4. Crea git tag.
+5. Pushea tags cuando se confirma.
 
-### Release automático (CI)
+### Disciplina de release
 
-El workflow `.github/workflows/release.yml` se ejecuta en cada push a `main`:
-
-1. **Checkout** con todo el history (`fetch-depth: 0`)
-2. **Install** dependencias
-3. **Test** + **Build**
-4. **bumpp** — detecta tipo, actualiza versión, crea tag
-5. **conventional-changelog** — regenera changelog completo
-6. **GitHub Release** — crea release en GitHub con notes
+No llamar una release “stable” si el producto no es realmente estable para usuarios públicos. Por ahora, usar lenguaje de **beta pública**.
 
 ---
 
 ## 5. Scripts disponibles
 
 ```bash
-# Verificar mensajes de commit
-pnpm lint:commit
-
-# Generar changelog (solo cambios desde último tag)
-pnpm changelog
-
-# Regenerar changelog completo
-pnpm changelog:all
-
-# Release local (bump + tag + changelog)
-pnpm release
+pnpm lint:commit      # Verificar mensajes de commit
+pnpm changelog        # Generar changelog desde cambios recientes
+pnpm changelog:all    # Regenerar changelog completo
+pnpm release          # Release local: bump + tag + changelog
 ```
 
 ---
 
 ## 6. Git Tags
 
-Tags siguen el formato `v<versión>`:
+Los tags siguen el formato `v<versión>`:
 
 ```bash
-v0.1.0    # Versión 0.1.0
-v0.1.1    # Patch posterior
-v0.2.0    # Nueva funcionalidad
-v1.0.0    # Primer release estable
-```
-
-**Ver tags locales:**
-```bash
-git tag -l
-```
-
-**Push de tags:**
-```bash
-git push --tags
+v0.5.0    # Beta pública / hito de launch-readiness
+v0.5.1    # Patch para fixes beta
+v0.6.0    # Próximo hito beta
+v1.0.0    # Primer release estable, solo al cumplir criterios de launch-readiness
 ```
 
 ---
 
 ## 7. GitHub Releases
 
-Las releases se crean automáticamente en cada merge a `main` via `.github/workflows/release.yml`.
+Cada release debería incluir:
 
-Cada release incluye:
-- **Tag** con versión
-- **Release notes** generadas automáticamente desde commits
-- **Changelog** desde `CHANGELOG.md`
+- Tag con versión.
+- Release notes generadas desde commits o curadas manualmente.
+- Estado honesto: alpha, beta, release candidate o stable.
+- Limitaciones conocidas cuando corresponda.
 
 ---
 
@@ -186,30 +156,8 @@ Cada release incluye:
 |---------|-----------|
 | `CHANGELOG.md` | Changelog del proyecto |
 | `.commitlintrc.json` | Reglas de validación de commits |
-| `.github/workflows/release.yml` | CI para auto-release |
-| `package.json` | Scripts de release (`pnpm release`) |
-
----
-
-## 9. Ejemplo de flujo completo
-
-```bash
-# 1. Trabajar en feature
-git checkout -b feat/new-feature
-git commit -m "feat(items): add new feature"
-git commit -m "fix(items): resolve bug"
-git push
-
-# 2. Crear PR y merge a main
-# (CI corre tests + typecheck + build)
-
-# 3. En merge a main → Release workflow se dispara
-#    - CI genera: v0.2.0
-#    - GitHub crea: Release v0.2.0
-
-# 4. Ver changelog
-pnpm changelog
-```
+| `package.json` | Scripts de release y versión del monorepo |
+| `apps/extension/manifest.json` | Versión de la extensión |
 
 ---
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -6,17 +6,28 @@
 
 ## 1. Semantic Versioning
 
-DevDeck uses [Semantic Versioning](https://semver.org/) (SemVer) with the format `MAJOR.MINOR.PATCH`:
+DevDeck uses [Semantic Versioning](https://semver.org/) with the format `MAJOR.MINOR.PATCH`:
 
 | Component | When to bump | Example |
 |-----------|-------------|---------|
-| **MAJOR** | Incompatible API changes | `0.x.0` → `1.0.0` |
-| **MINOR** | New backward-compatible features | `0.1.0` → `0.2.0` |
-| **PATCH** | Backward-compatible bug fixes | `0.1.0` → `0.1.1` |
+| **MAJOR** | Stable product/API contract and incompatible changes | `0.x.0` → `1.0.0` |
+| **MINOR** | New backward-compatible features or public beta milestones | `0.5.0` → `0.6.0` |
+| **PATCH** | Backward-compatible bug fixes | `0.5.0` → `0.5.1` |
 
-**Current state:** `1.0.0` (Wave 17 - Stable release)
+**Current state:** `0.5.0` — public beta / launch-readiness milestone.
 
-> DevDeck has reached its stable `1.0.0` version after completing the 17-wave roadmap.
+> DevDeck is not yet a stable `1.0.0` product. The honest public position is: functional open-source beta with a clear developer-memory direction, active polish, and a contributor/community launch in progress.
+
+### When DevDeck can become 1.0.0
+
+DevDeck should not be tagged as `1.0.0` until these are true:
+
+- Clean onboarding/demo flow works for a new user in minutes.
+- Local setup and self-hosting instructions are verified on a clean machine.
+- Core capture/search/workbench/Circles flows are stable enough for public use.
+- Public README, screenshots/GIFs, and contributor docs are trustworthy.
+- Known limitations are documented honestly.
+- Critical CI/E2E checks are reliable.
 
 ---
 
@@ -33,19 +44,13 @@ We use [Keep a Changelog](https://keepachangelog.com/) format:
 ### Removed
 ### Fixed
 ### Security
-
----
-
-## [0.1.0] - 2026-05-03
-### Added
-- Stack filter
-- Smart tags
-...
 ```
 
 **Files:**
 - `CHANGELOG.md` — Project changelog
 - `package.json` — Monorepo version
+- `apps/*/package.json` and `packages/*/package.json` — workspace package versions
+- `apps/extension/manifest.json` — browser extension version
 
 ---
 
@@ -53,45 +58,34 @@ We use [Keep a Changelog](https://keepachangelog.com/) format:
 
 Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+```txt
 <type>[<scope>]: <description>
-
-[optional body]
-
-[optional footer]
 ```
 
 **Types:**
 
 | Type | Description | Triggers release |
-|------|------------|----------------|
+|------|-------------|------------------|
 | `feat` | New feature | `minor` bump |
 | `fix` | Bug fix | `patch` bump |
-| `docs` | Documentation | ❌ |
-| `style` | Formatting (CSS, etc) | ❌ |
-| `refactor` | Refactor without functional change | ❌ |
-| `perf` | Performance optimization | ❌ |
-| `test` | Add/modify tests | ❌ |
-| `build` | Build system changes | ❌ |
-| `ci` | CI/CD changes | ❌ |
-| `chore` | Maintenance | ❌ |
-| `revert` | Revert previous commit | ❌ |
-| `improvement` | Improve existing feature | `patch` bump |
+| `docs` | Documentation | no automatic bump |
+| `style` | Formatting/CSS-only change | no automatic bump |
+| `refactor` | Refactor without functional change | no automatic bump |
+| `perf` | Performance optimization | patch/minor by impact |
+| `test` | Add/modify tests | no automatic bump |
+| `build` | Build system changes | no automatic bump |
+| `ci` | CI/CD changes | no automatic bump |
+| `chore` | Maintenance | no automatic bump |
+| `revert` | Revert previous commit | depends on reverted change |
 
 **Examples:**
 
 ```bash
-feat(ui): add stack filter with multi-select pills
-fix(items): resolve N+1 query in items list
-docs(api): update authentication endpoint docs
-chore: add release workflow
+feat(circles): share workbench output with context
+fix(items): resolve duplicate capture regression
+docs(launch): clarify public beta positioning
+chore(release): set public beta version to 0.5.0
 ```
-
-**Validation rules:**
-- Header max 72 characters
-- Subject in lowercase
-- Type required
-- Description required (no period at end)
 
 ---
 
@@ -109,39 +103,25 @@ pnpm release
 ```
 
 **What `bumpp` does:**
-1. Detects change type (feat→minor, fix→patch)
-2. Updates version in `package.json`
-3. Updates `CHANGELOG.md` with new changes
-4. Creates git tag (`v0.1.0`)
-5. Pushes with tags
+1. Detects change type.
+2. Updates version in `package.json`.
+3. Updates `CHANGELOG.md`.
+4. Creates git tag.
+5. Pushes tags when confirmed.
 
-### Automatic release (CI)
+### Release discipline
 
-The `.github/workflows/release.yml` workflow runs on every push to `main`:
-
-1. **Checkout** with full history (`fetch-depth: 0`)
-2. **Install** dependencies
-3. **Test** + **Build**
-4. **bumpp** — detects type, updates version, creates tag
-5. **conventional-changelog** — regenerates full changelog
-6. **GitHub Release** — creates release with notes
+Do not call a release “stable” unless the product is actually stable for public users. For now, use **public beta** language.
 
 ---
 
 ## 5. Available Scripts
 
 ```bash
-# Verify commit messages
-pnpm lint:commit
-
-# Generate changelog (changes since last tag)
-pnpm changelog
-
-# Regenerate full changelog
-pnpm changelog:all
-
-# Local release (bump + tag + changelog)
-pnpm release
+pnpm lint:commit      # Verify commit messages
+pnpm changelog        # Generate changelog from recent changes
+pnpm changelog:all    # Regenerate full changelog
+pnpm release          # Local release bump + tag + changelog
 ```
 
 ---
@@ -151,32 +131,22 @@ pnpm release
 Tags follow the format `v<version>`:
 
 ```bash
-v0.1.0    # Version 0.1.0
-v0.1.1    # Subsequent patch
-v0.2.0    # New features
-v1.0.0    # First stable release
-```
-
-**List local tags:**
-```bash
-git tag -l
-```
-
-**Push tags:**
-```bash
-git push --tags
+v0.5.0    # Public beta / launch-readiness milestone
+v0.5.1    # Patch for beta fixes
+v0.6.0    # Next beta milestone
+v1.0.0    # First stable release, only after launch-readiness criteria are met
 ```
 
 ---
 
 ## 7. GitHub Releases
 
-Releases are automatically created on every merge to `main` via `.github/workflows/release.yml`.
+Each release should include:
 
-Each release includes:
-- **Tag** with version
-- **Release notes** auto-generated from commits
-- **Changelog** from `CHANGELOG.md`
+- Tag with version.
+- Release notes generated from commits or manually curated.
+- Honest status: alpha, beta, release candidate, or stable.
+- Known limitations when relevant.
 
 ---
 
@@ -186,30 +156,8 @@ Each release includes:
 |------|---------|
 | `CHANGELOG.md` | Project changelog |
 | `.commitlintrc.json` | Commit validation rules |
-| `.github/workflows/release.yml` | Auto-release CI |
-| `package.json` | Release scripts (`pnpm release`) |
-
----
-
-## 9. Complete Flow Example
-
-```bash
-# 1. Work on feature
-git checkout -b feat/new-feature
-git commit -m "feat(items): add new feature"
-git commit -m "fix(items): resolve bug"
-git push
-
-# 2. Create PR and merge to main
-# (CI runs tests + typecheck + build)
-
-# 3. On merge to main → Release workflow triggers
-#    - CI generates: v0.2.0
-#    - GitHub creates: Release v0.2.0
-
-# 4. View changelog
-pnpm changelog
-```
+| `package.json` | Release scripts and monorepo version |
+| `apps/extension/manifest.json` | Browser extension version |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devdeck",
-  "version": "1.0.0",
-  "description": "DevDeck monorepo — desktop, web, shared packages.",
+  "version": "0.5.0",
+  "description": "DevDeck monorepo \u2014 desktop, web, shared packages.",
   "scripts": {
     "dev:desktop": "pnpm -F @devdeck/desktop dev",
     "dev:web": "pnpm -F @devdeck/web dev",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/api-client",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/features",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/i18n",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/realtime-client/package.json
+++ b/packages/realtime-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/realtime-client",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/ui",
-  "version": "1.0.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Linked Issue
Closes #81

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Repositions DevDeck honestly as `0.5.0 Public Beta` instead of premature `1.0.0 Stable`.
- Rewrites the public README, roadmap, launch kit, changelog, and versioning docs around launch-readiness and contributor trust.
- Updates workspace package versions and browser extension manifest/package version to `0.5.0`.

## Changes
| File | Change |
|------|--------|
| `README.md` | Clarifies product story, current public beta version, daily loop, setup, contribution, and support path. |
| `ROADMAP.md` | Replaces over-claimed completed enterprise/agent roadmap with honest beta milestones and 1.0 criteria. |
| `CHANGELOG.md` | Replaces premature 1.0 notes with 0.5.0 public beta notes. |
| `docs/LAUNCH_KIT.md` | Adds beta framing and honest community launch copy. |
| `docs/VERSIONING.md` / `docs/VERSIONING.es.md` | Documents 0.5.0 current state and 1.0 criteria. |
| `package.json`, `apps/*/package.json`, `packages/*/package.json`, `apps/extension/manifest.json` | Sets current version to 0.5.0. |
| Related public docs | Removes or softens misleading 1.0 stable language. |

## Test Plan
- [x] `git diff --check`
- [x] Parsed all edited package/manifest JSON files successfully.
- [x] Verified README links referenced in this PR exist locally.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
