### PR TITLE
docs(self-hosting): verify public beta quickstart

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,75 +1,212 @@
-# Self-Hosting Guide
+# DevDeck Self-Hosting Guide
 
-This guide explains how to deploy your own instance of **DevDeck.ai**.
+This guide explains how to deploy your own **DevDeck.ai** instance on a small
+VPS using the repository's current production stack: **Docker Compose + Caddy +
+Postgres + DevDeck API + Web app**.
 
 [Leer en español](SELF_HOSTING.es.md)
 
 ---
 
 ## 1. Prerequisites
-- A VPS or server with **Docker** and **Docker Compose** installed.
-- A domain or subdomain (e.g., `devdeck.yourdomain.com`).
-- A GitHub OAuth App (for authentication).
+
+- A Linux VPS or server. Ubuntu 22.04+ or Debian 12+ are the safest targets.
+- At least **1 vCPU**, **1 GB RAM**, and **10 GB disk** for a small personal or
+  team install.
+- A domain pointed at the VPS, for example `devdeck.yourdomain.com`.
+- Docker 24+ and Docker Compose v2 installed.
+- A GitHub account so you can create a GitHub OAuth App for sign-in.
 
 ---
 
-## 2. GitHub OAuth Setup
-1. Go to your GitHub [Developer Settings](https://github.com/settings/developers).
+## 2. Create the GitHub OAuth App
+
+1. Open GitHub [Developer Settings](https://github.com/settings/developers).
 2. Create a new **OAuth App**.
-3. Set the **Authorization callback URL** to: `https://api.yourdomain.com/v1/auth/github/callback`.
-4. Note down your **Client ID** and **Client Secret**.
+3. Set **Homepage URL** to `https://devdeck.yourdomain.com`.
+4. Set **Authorization callback URL** to:
+   `https://devdeck.yourdomain.com/api/auth/github/callback`
+5. Save the app, then copy the **Client ID** and **Client Secret**.
+
+GitHub does not show the client secret again later, so store it now.
 
 ---
 
-## 3. Deployment Steps
+## 3. Clone the Repository
 
-### 3.1 Clone the Repository
 ```bash
 git clone https://github.com/tiagofur/dev_deck.git
 cd dev_deck/deploy
 ```
 
-### 3.2 Configure Environment Variables
-Copy `.env.example` to `.env` and fill in the values:
+---
+
+## 4. Configure `deploy/.env`
+
+Start from the tracked example:
+
 ```bash
-# Database
-PG_PASS=your_strong_password
+cp .env.example .env
+```
+
+Update the file with your real values:
+
+```env
+# Public domain
+DOMAIN=devdeck.yourdomain.com
+FRONTEND_URL=https://devdeck.yourdomain.com
+
+# Postgres
+PG_PASS=<strong-random-password>
 
 # Auth
-JWT_SECRET=your_random_secret
-OAUTH_GITHUB_CLIENT_ID=your_id
-OAUTH_GITHUB_CLIENT_SECRET=your_secret
-OAUTH_REDIRECT_URL=https://api.yourdomain.com/v1/auth/github/callback
-ALLOWED_GITHUB_LOGINS=your_username
+AUTH_MODE=jwt
+LOCAL_AUTH_ENABLED=true
+ALLOWED_GITHUB_LOGINS=your-github-login
+GITHUB_CLIENT_ID=<from GitHub OAuth App>
+GITHUB_CLIENT_SECRET=<from GitHub OAuth App>
+GITHUB_OAUTH_CALLBACK_URL=https://devdeck.yourdomain.com/api/auth/github/callback
+WEB_OAUTH_REDIRECT_URL=https://devdeck.yourdomain.com/auth/callback
+DESKTOP_OAUTH_REDIRECT_URL=devdeck://auth/callback
 
-# AI (Optional)
-OPENAI_API_KEY=sk-...
+# JWT secrets
+JWT_SECRET=<openssl rand -hex 32>
+REFRESH_SECRET=<openssl rand -hex 32>
+
+# Optional AI provider
+AI_PROVIDER=heuristic
+# If you switch to OpenAI, also set:
+# AI_EXTERNAL_OPT_IN=true
+# OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o-mini
+
+# Operational defaults
+LOG_LEVEL=info
+CORS_ORIGINS=https://devdeck.yourdomain.com,app://.
+SEED_CHEATSHEETS=true
 ```
 
-### 3.3 Start the Services
+Generate the JWT secrets with:
+
 ```bash
-docker compose up -d
+openssl rand -hex 32
 ```
 
-### 3.4 Configure Caddy (Reverse Proxy)
-Edit the `Caddyfile` to match your domain and run:
+Notes:
+
+- `AUTH_MODE=jwt` is the current default for the production compose stack.
+- `LOCAL_AUTH_ENABLED=true` enables email/password login alongside OAuth. If
+  you want GitHub-only auth, set it to `false`.
+- `ALLOWED_GITHUB_LOGINS` acts as a login allowlist. Leave it empty only if you
+  intentionally want any GitHub account to be allowed.
+- If `AI_PROVIDER=openai`, the backend requires both
+  `AI_EXTERNAL_OPT_IN=true` and `OPENAI_API_KEY`.
+
+Never commit `.env`. It is already ignored by Git.
+
+---
+
+## 5. Start the Stack
+
+Build and launch the full production stack:
+
 ```bash
-docker compose restart caddy
+docker compose up -d --build
+```
+
+This starts:
+
+- `db` for Postgres 16
+- `api` for the Go backend
+- `web` for the React app
+- `caddy` for HTTPS and reverse proxying
+- `prometheus` and `grafana` for basic monitoring
+
+Check service status and live logs:
+
+```bash
+docker compose ps
+docker compose logs -f api
+docker compose logs -f web
 ```
 
 ---
 
-## 4. Troubleshooting
-- **Logs:** Check logs with `docker compose logs -f api`.
-- **Database:** Ensure the `db` container is healthy and migrations have run.
-- **Auth:** If you get a 403 error, double-check that your GitHub username is in `ALLOWED_GITHUB_LOGINS`.
+## 6. Apply Database Migrations
+
+The production stack does **not** currently run migrations automatically. Apply
+them after the first boot:
+
+```bash
+for f in ../backend/migrations/*.sql; do
+  echo "Applying $f..."
+  docker compose exec -T db psql -U devdeck devdeck -v ON_ERROR_STOP=1 -f - < "$f"
+done
+```
+
+If you keep `SEED_CHEATSHEETS=true`, the API will also load the bundled
+cheatsheet seed data during startup.
 
 ---
 
-## 5. Updates
-To update to the latest version:
+## 7. Verify the Deployment
+
+Confirm the public health endpoint responds:
+
 ```bash
+curl https://devdeck.yourdomain.com/healthz
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+Then open `https://devdeck.yourdomain.com` in the browser and verify that the
+GitHub login flow returns to `/auth/callback` successfully.
+
+---
+
+## 8. Public Beta Notes
+
+Current `0.5.0` public beta limitations worth knowing up front:
+
+- Self-hosting is workable, but the docs and deployment flow are still being
+  tightened up.
+- Production migrations are a manual step today.
+- OpenAI usage is strictly opt-in and requires explicit environment settings.
+- The GitHub login allowlist is easy to misconfigure; a missing login will
+  result in a `403` during sign-in.
+
+---
+
+## 9. Troubleshooting
+
+- **The API is crash-looping:** run `docker compose logs api` and confirm
+  `PG_PASS`, `JWT_SECRET`, `GITHUB_CLIENT_ID`, and
+  `GITHUB_OAUTH_CALLBACK_URL` are all set correctly.
+- **Migrations failed:** connect to Postgres with
+  `docker compose exec db psql -U devdeck devdeck` and inspect which migration
+  stopped.
+- **GitHub login returns 403:** add your GitHub login to
+  `ALLOWED_GITHUB_LOGINS`, then restart the API with
+  `docker compose up -d api`.
+- **HTTPS certificate is not issued:** confirm DNS is pointed at the VPS and
+  ports `80` and `443` are open, then inspect `docker compose logs caddy`.
+
+---
+
+## 10. Updates
+
+To pull the latest code and restart the stack:
+
+```bash
+cd ../
 git pull
-docker compose pull
-docker compose up -d
+cd deploy
+docker compose up -d --build
 ```
+
+Run the migration loop again after updates whenever new files were added under
+`backend/migrations/`.


### PR DESCRIPTION
## Summary
- align the English self-hosting guide with the current single-domain production stack
- document the real environment variable names, manual migration step, health check, and beta caveats
- keep the change docs-only and scoped to the approved self-hosting quickstart issue

Closes #87

## Validation
- git diff --check
- verified every documented env var and endpoint name against deploy/.env.example, deploy/docker-compose.yml, deploy/Caddyfile, and backend/internal/config/config.go