### PR TITLE
docs(support): add public support plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **The developer memory layer for everything useful you discover, build, and share.**
 
-[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
+[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
 
 DevDeck is an open-source desktop/web app for developers who keep losing useful repos, CLIs, snippets, prompts, shortcuts, cheatsheets, and workflow notes across chats, bookmarks, browser tabs, and GitHub stars.
 
@@ -161,9 +161,10 @@ Small, high-quality PRs are more valuable than giant feature drops.
 
 ## Support the project
 
-DevDeck is an indie open-source project. If it helps you, or if you want to support the push toward a polished public launch:
+DevDeck is an indie open-source project. Support helps fund domain/hosting costs, CI, development time, public beta polish, and AI-assisted coding tools used to move faster while still reviewing changes carefully.
 
 - Sponsor/support: [Buy Me a Coffee](https://www.buymeacoffee.com/tiagofur)
+- Read the support plan: [docs/SUPPORT.md](docs/SUPPORT.md)
 - Share the repo with developers who collect tools, repos, commands, and workflows.
 - Open issues with sharp feedback.
 - Contribute small PRs that improve launch readiness.
@@ -183,6 +184,7 @@ Possible future sustainability paths include hosted community Circles, paid setu
 | [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Self-hosting guide |
 | [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Testing and CI strategy |
 | [docs/LAUNCH_KIT.md](docs/LAUNCH_KIT.md) | Community launch copy and checklist |
+| [docs/SUPPORT.md](docs/SUPPORT.md) | Funding, support, and sustainability plan |
 | [ROADMAP.md](ROADMAP.md) | Product roadmap |
 
 ---

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,103 @@
+# Support DevDeck
+
+DevDeck is an indie open-source project. The goal is to build a useful developer-memory tool without hiding the core value behind a closed product.
+
+Support is not required to use DevDeck. It helps keep the project moving faster and makes the public beta more sustainable.
+
+---
+
+## Why support matters
+
+DevDeck is being built in public as a `0.5.0 Public Beta`. That means the project is already useful, but still needs polish before a stable 1.0 release:
+
+- clearer onboarding,
+- better screenshots and demo assets,
+- reliable setup and self-hosting docs,
+- smoother Workbench and Circle flows,
+- stronger tests and CI,
+- contributor-friendly issues,
+- and continued development time.
+
+If DevDeck helps you save, rediscover, or share developer knowledge, support helps fund the work needed to make it dependable for more people.
+
+---
+
+## What support helps pay for
+
+Support goes toward practical project costs:
+
+- Domain and hosting for `devdeck.ai`.
+- CI, test infrastructure, and release verification.
+- Development time for bug fixes, polish, docs, and onboarding.
+- AI-assisted coding tools used to move faster while still reviewing changes carefully.
+- Community launch work: screenshots, demos, good-first-issues, support docs, and contributor guidance.
+
+---
+
+## Ways to support
+
+### Financial support
+
+- [Buy Me a Coffee](https://www.buymeacoffee.com/tiagofur)
+
+If GitHub Sponsors becomes available for the project, it should be added here and to the README.
+
+### Non-financial support
+
+You can also help by:
+
+- starring the repository,
+- sharing DevDeck with developers who collect tools, repos, prompts, commands, and workflows,
+- opening sharp issues with real feedback,
+- testing the public beta with your own developer resources,
+- improving docs,
+- contributing small PRs,
+- and helping shape the Circles/community-memory workflow.
+
+---
+
+## Sustainability ideas
+
+The open-source core should stay useful. Potential future income paths should fund continued development without compromising that:
+
+### Hosted Circles
+
+Managed hosting for communities or small teams that want shared developer memory without running their own instance.
+
+### Paid setup and support
+
+Help individuals, teams, or communities self-host DevDeck, configure capture flows, and create a useful first vault.
+
+### Workflow and template packs
+
+Curated packs for common developer workflows, such as:
+
+- onboarding a codebase,
+- incident response runbooks,
+- AI prompt libraries,
+- CLI/tool collections,
+- community-curated starter vaults.
+
+### Sponsorships
+
+Sponsorship from developer-tooling companies that align with the project and do not compromise user trust.
+
+---
+
+## Funding principles
+
+- Keep the public message honest: DevDeck is a public beta, not a fake 1.0.
+- Keep the open-source core useful.
+- Prefer sustainable support over manipulative paywalls.
+- Do not over-promise enterprise features before they are real.
+- Make it easy for contributors to help without paying.
+
+---
+
+## Current launch-readiness work
+
+The current milestone is focused on getting DevDeck ready for public community promotion:
+
+- [0.5.0 Launch Readiness](https://github.com/tiagofur/dev_deck/milestone/1)
+
+If you want to contribute, start with issues labeled `good first issue` or `help wanted`.


### PR DESCRIPTION
## Linked Issue
Closes #83

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a public Support DevDeck page explaining funding, non-financial support, and sustainability paths.
- Links the support plan from the README top nav, support section, and documentation table.
- Frames support honestly for the 0.5.0 Public Beta without making payment required.

## Changes
| File | Change |
|------|--------|
| `docs/SUPPORT.md` | Adds support/funding plan, support principles, sustainability ideas, and milestone link. |
| `README.md` | Links the support doc and clarifies what support helps fund. |

## Test Plan
- [x] `git diff --check`
- [x] Verified linked docs exist locally.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
