### PR TITLE
feat(workbench): improve project context empty state

### DIFF
--- a/packages/features/src/components/Workbench/ProjectContextTool.tsx
+++ b/packages/features/src/components/Workbench/ProjectContextTool.tsx
@@ -153,15 +153,9 @@ export function ProjectContextTool() {
           <h3 className="font-display text-sm font-black uppercase">Related vault context</h3>
           {isLoading && <span className="font-mono text-xs text-ink-soft">Searching...</span>}
         </div>
-        {!query && (
-          <p className="font-mono text-sm text-ink-soft">
-            Add a project name or remote to search your vault.
-          </p>
-        )}
+        {!query && <ProjectContextEmptyState state="missing-project" />}
         {query && !isLoading && results.length === 0 && (
-          <p className="font-mono text-sm text-ink-soft">
-            No related items yet. Save a command, request, note, or runbook with this project name.
-          </p>
+          <ProjectContextEmptyState state="no-related-context" projectTag={projectTag} />
         )}
         <div className="grid gap-2">
           {results.slice(0, 8).map((result) => (
@@ -179,6 +173,61 @@ export function ProjectContextTool() {
         </div>
       </div>
     </ToolFrame>
+  )
+}
+
+function ProjectContextEmptyState({
+  state,
+  projectTag,
+}: {
+  state: 'missing-project' | 'no-related-context'
+  projectTag?: string
+}) {
+  if (state === 'missing-project') {
+    return (
+      <div className="grid gap-4 border-2 border-ink bg-bg-card p-4 shadow-hard-sm">
+        <div>
+          <p className="font-display text-base font-black uppercase">Start with one real project</p>
+          <p className="mt-1 font-mono text-sm text-ink-soft">
+            Add a project name or Git remote so Workbench can pull matching commands, notes, requests,
+            and runbooks from your vault.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <EmptyStep title="1. Name it" body="Use the repo or folder name you actually work in." />
+          <EmptyStep title="2. Add notes" body="Capture local gotchas, scripts, services, and setup hints." />
+          <EmptyStep title="3. Link context" body="Tag useful vault items so the project becomes reusable." />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 border-2 border-ink bg-accent-yellow/25 p-4 shadow-hard-sm">
+      <div>
+        <p className="font-display text-base font-black uppercase">Build this project memory</p>
+        <p className="mt-1 font-mono text-sm text-ink-soft">
+          No related items yet. Save one command, API request, note, or workflow with this project in mind.
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <EmptyStep title="Save a command" body="Example: pnpm test, make migrate, docker compose up." />
+        <EmptyStep title="Save a gotcha" body="Write the setup detail future you would forget." />
+        <EmptyStep
+          title="Use the project tag"
+          body={projectTag ? `Tag related items with ${projectTag}.` : 'Add a project name to generate a project tag.'}
+        />
+      </div>
+    </div>
+  )
+}
+
+function EmptyStep({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="border-2 border-ink bg-bg-elevated p-3">
+      <p className="font-display text-xs font-black uppercase">{title}</p>
+      <p className="mt-1 font-mono text-xs text-ink-soft">{body}</p>
+    </div>
   )
 }
 

--- a/packages/features/src/pages/WorkbenchPage.test.tsx
+++ b/packages/features/src/pages/WorkbenchPage.test.tsx
@@ -120,6 +120,27 @@ describe('<WorkbenchPage>', () => {
     })
   })
 
+  it('guides users to start Project Context with a real project', () => {
+    renderWorkbench('/workbench?tool=project')
+
+    expect(screen.getByText('Start with one real project')).toBeInTheDocument()
+    expect(screen.getByText('1. Name it')).toBeInTheDocument()
+    expect(screen.getByText('2. Add notes')).toBeInTheDocument()
+    expect(screen.getByText('3. Link context')).toBeInTheDocument()
+  })
+
+  it('guides users to build project memory when no related context exists', () => {
+    renderWorkbench('/workbench?tool=project')
+
+    fireEvent.change(screen.getByLabelText('Project name'), { target: { value: 'dev_deck' } })
+
+    expect(screen.getByText('Build this project memory')).toBeInTheDocument()
+    expect(screen.getByText('Save a command')).toBeInTheDocument()
+    expect(screen.getByText('Save a gotcha')).toBeInTheDocument()
+    expect(screen.getByText('Use the project tag')).toBeInTheDocument()
+    expect(screen.getByText('Tag related items with project:dev_deck.')).toBeInTheDocument()
+  })
+
   it('links an existing item to the current project with a project tag', async () => {
     const mutateAsync = vi.fn().mockResolvedValue({})
     mocks.useGlobalSearch.mockReturnValue({


### PR DESCRIPTION
Closes #86

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Improves the Workbench Project Context empty state with launch-ready guidance and concrete next steps.
- Adds a second state for projects with no related vault context yet, including the generated project tag.
- Covers both states in the Workbench page test suite.

## Changes
| File | Change |
|------|--------|
| `packages/features/src/components/Workbench/ProjectContextTool.tsx` | Adds guided empty states for missing project context and no related vault context. |
| `packages/features/src/pages/WorkbenchPage.test.tsx` | Adds tests for both Project Context empty-state paths. |

## Test Plan
- [x] `pnpm -F @devdeck/features test -- WorkbenchPage.test.tsx --run`
- [x] `pnpm -F @devdeck/web typecheck`
- [x] `git diff --check`
- [x] Visual verification with the local web app at `/workbench?tool=project` using safe mocked auth/search data.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
