### PR TITLE
docs(contributing): add contributor funnel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report something that is broken or behaving unexpectedly.
+title: "fix(scope): describe the bug"
+labels: [bug, status:needs-review]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I understand this issue needs `status:approved` before a PR can be opened.
+          required: true
+  - type: textarea
+    id: bug
+    attributes:
+      label: Bug description
+      description: What is broken?
+      placeholder: DevDeck does X, but I expected Y.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened? Include screenshots or logs if useful.
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Web app
+        - Desktop app
+        - Browser extension
+        - CLI
+        - Backend/API
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: OS, browser, commit, logs, screenshots, or workaround.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Questions, ideas, and community discussion
+    url: https://github.com/tiagofur/dev_deck/discussions
+    about: Ask usage questions, shape rough ideas, and share community workflows before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest a focused improvement for DevDeck.
+title: "feat(scope): describe the improvement"
+labels: [enhancement, status:needs-review]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I understand this issue needs `status:approved` before a PR can be opened.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem description
+      description: What user pain or contributor friction does this solve?
+      placeholder: New users struggle to understand ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Keep the first version small and reviewable.
+      placeholder: Add a focused change that ...
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Vault/items
+        - Workbench
+        - Circles/community
+        - Search/AI enrichment
+        - Onboarding/demo data
+        - Desktop/Web parity
+        - CLI/extension
+        - Self-hosting/deploy
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: What other approaches did you consider?

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -1,0 +1,42 @@
+name: Good first issue candidate
+description: Propose a small, contributor-friendly task.
+title: "docs(scope): make one contributor-friendly improvement"
+labels: [good first issue, help wanted, status:needs-review]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I understand this issue needs `status:approved` before a PR can be opened.
+          required: true
+  - type: textarea
+    id: task
+    attributes:
+      label: Small task
+      description: What exactly should a new contributor change?
+      placeholder: Improve one empty state, add one test, or clarify one doc section.
+    validations:
+      required: true
+  - type: textarea
+    id: files
+    attributes:
+      label: Suggested files
+      description: List likely files or folders so contributors know where to start.
+      placeholder: |
+        - packages/features/src/...
+        - docs/...
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      placeholder: |
+        - Copy is updated.
+        - A focused test is added or a verification note is included.
+        - PR links this issue.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+Closes #
+
+## PR Type
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation only
+- [ ] Code refactoring
+- [ ] Maintenance/tooling
+- [ ] Breaking change
+
+## Summary
+- 
+- 
+
+## Changes
+| File | Change |
+|------|--------|
+| `path/to/file` | What changed |
+
+## Test Plan
+- [ ] I ran the relevant command(s): `...`
+- [ ] I manually verified the affected flow, if applicable.
+- [ ] I included screenshots/GIFs for user-facing UI changes, if applicable.
+
+## Contributor Checklist
+- [ ] Linked an approved issue with `Closes #...`
+- [ ] Added exactly one `type:*` label
+- [ ] Kept the PR small and focused
+- [ ] Included tests or a clear verification note
+- [ ] Updated docs if behavior changed
+- [ ] Used a conventional commit message
+- [ ] No `Co-Authored-By` or AI attribution trailers

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+DevDeck is a community for developers who want to build useful, high-signal tools together. We want contributors to feel safe asking questions, sharing feedback, and making small improvements.
+
+## Expected behavior
+
+- Be respectful, direct, and constructive.
+- Assume good intent, but do not ignore harmful impact.
+- Keep feedback focused on the work, not the person.
+- Make space for new contributors and first-time open-source participants.
+- Prefer small, reviewable contributions over large, hard-to-review changes.
+
+## Unacceptable behavior
+
+- Harassment, insults, threats, or personal attacks.
+- Discriminatory language or behavior.
+- Publishing private information without consent.
+- Repeatedly derailing technical discussions.
+- Spam, self-promotion without context, or low-signal drive-by comments.
+
+## Reporting
+
+If you see behavior that makes the project unsafe or unwelcoming, contact the maintainer through the email or profile listed on GitHub. Include links, screenshots, or context when possible.
+
+Reports will be reviewed privately. Maintainers may remove comments, close threads, block users, or take other action needed to protect the community.
+
+## Scope
+
+This code of conduct applies to this repository, GitHub issues and pull requests, and community spaces directly connected to DevDeck.

--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -5,7 +5,7 @@ Gracias por querer ayudar. DevDeck es un proyecto indie con visión fuerte, así
 ## Antes de empezar
 
 1. Leé `docs/VISION.md` y `docs/PRD.md`. Si tu propuesta no encaja, probablemente te digamos que no. Mejor ahorrarte el tiempo.
-2. Para features nuevas: abrí un **issue de discusión** primero. No envíes PRs grandes sin ack previo.
+2. Para features nuevas o ideas todavía verdes: empezá en [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions). No envíes PRs grandes sin ack previo.
 3. Para bugs: abrí un issue con repro pasos, versión, OS, stack trace si aplica.
 
 ## Setup local
@@ -114,6 +114,7 @@ Closes #123
 
 - Branch desde `main`, nombre descriptivo: `feat/capture-endpoint`, `fix/reorder-race`.
 - Un PR = una cosa. Si estás tocando backend + frontend para una misma feature, ok, pero no mezcles features distintas.
+- Usá [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) para preguntas, propuestas verdes o coordinación comunitaria antes de abrir un PR grande.
 - Descripción del PR debe tener:
   - **Qué** cambia.
   - **Por qué** (link al issue).

--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -114,7 +114,7 @@ Closes #123
 
 - Branch desde `main`, nombre descriptivo: `feat/capture-endpoint`, `fix/reorder-race`.
 - Un PR = una cosa. Si estás tocando backend + frontend para una misma feature, ok, pero no mezcles features distintas.
-- Usá [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) para preguntas, propuestas verdes o coordinación comunitaria antes de abrir un PR grande.
+- Usá [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) para preguntas, propuestas verdes o coordinación comunitaria antes de abrir un PR grande. Ver [docs/DISCUSSIONS.md](docs/DISCUSSIONS.md) para categorías y formatos sugeridos.
 - Descripción del PR debe tener:
   - **Qué** cambia.
   - **Por qué** (link al issue).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The short version:
 
 1.  **Read the vision**: Check `docs/VISION.md` and `docs/PRD.md`. If your proposal doesn't align with the project's direction, we might decline it. Save yourself some time!
 2.  **Issue first**: For code or docs changes, open or claim an issue and wait for `status:approved` before opening a PR.
-3.  **Shape unclear ideas carefully**: If the idea is still rough, open a feature request and explain the uncertainty instead of sending a large PR.
+3.  **Shape unclear ideas carefully**: If the idea is still rough, start in [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) to ask questions, share context, and narrow the first useful step before opening an issue.
 4.  **Reporting bugs**: Use the bug report template with clear reproduction steps, version, OS, and logs if applicable.
 
 ## Best First Contributions
@@ -38,7 +38,7 @@ DevDeck is currently preparing for a community launch. The most useful contribut
 - Improve one Circle sharing or community-memory flow.
 - Make local setup or self-hosting easier to follow.
 
-If you are new here, look for issues labeled `good first issue` or ask for a small launch-readiness task.
+If you are new here, look for issues labeled `good first issue` or ask for a small launch-readiness task in [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions).
 
 The best first issues are already scoped to fit a small PR. If a change starts growing, split it before opening the PR.
 
@@ -124,6 +124,7 @@ We follow **Conventional Commits**: `feat:`, `fix:`, `docs:`, `test:`, `refactor
 - Branch from `main` with a descriptive name: `feat/capture-endpoint`.
 - One PR = One concern.
 - Link an approved issue with `Closes #...`.
+- Use [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) for questions or rough proposals before opening a large PR.
 - Add exactly one `type:*` label.
 - Ensure the CI is green before requesting a review.
 - A minimum of one maintainer approval is required for merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ DevDeck is currently preparing for a community launch. The most useful contribut
 - Improve one Circle sharing or community-memory flow.
 - Make local setup or self-hosting easier to follow.
 
-If you are new here, look for issues labeled `good first issue` or ask for a small launch-readiness task in [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions).
+If you are new here, look for issues labeled `good first issue` or ask for a small launch-readiness task in [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions). See [docs/DISCUSSIONS.md](docs/DISCUSSIONS.md) before opening rough proposals.
 
 The best first issues are already scoped to fit a small PR. If a change starts growing, split it before opening the PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,26 @@ Thank you for your interest in contributing to DevDeck! This is an indie project
 
 ---
 
+## Fast Path
+
+If this is your first contribution, start with [docs/FIRST_CONTRIBUTION.md](docs/FIRST_CONTRIBUTION.md).
+
+The short version:
+
+1. Pick or open an issue.
+2. Wait for `status:approved`.
+3. Keep the PR focused on that one issue.
+4. Run the smallest relevant verification command.
+5. Open a PR with `Closes #...` and exactly one `type:*` label.
+
+---
+
 ## Before You Start
 
 1.  **Read the vision**: Check `docs/VISION.md` and `docs/PRD.md`. If your proposal doesn't align with the project's direction, we might decline it. Save yourself some time!
-2.  **Discussion first**: For new features, please open a **Discussion Issue** first. Do not send large PRs without prior acknowledgment.
-3.  **Reporting bugs**: Open an issue with clear reproduction steps, version, OS, and stack traces if applicable.
+2.  **Issue first**: For code or docs changes, open or claim an issue and wait for `status:approved` before opening a PR.
+3.  **Shape unclear ideas carefully**: If the idea is still rough, open a feature request and explain the uncertainty instead of sending a large PR.
+4.  **Reporting bugs**: Use the bug report template with clear reproduction steps, version, OS, and logs if applicable.
 
 ## Best First Contributions
 
@@ -24,6 +39,8 @@ DevDeck is currently preparing for a community launch. The most useful contribut
 - Make local setup or self-hosting easier to follow.
 
 If you are new here, look for issues labeled `good first issue` or ask for a small launch-readiness task.
+
+The best first issues are already scoped to fit a small PR. If a change starts growing, split it before opening the PR.
 
 ---
 
@@ -106,15 +123,18 @@ We follow **Conventional Commits**: `feat:`, `fix:`, `docs:`, `test:`, `refactor
 
 - Branch from `main` with a descriptive name: `feat/capture-endpoint`.
 - One PR = One concern.
+- Link an approved issue with `Closes #...`.
+- Add exactly one `type:*` label.
 - Ensure the CI is green before requesting a review.
 - A minimum of one maintainer approval is required for merging.
 - Keep PRs small. Large PRs are harder to review, harder to debug, and more likely to be split.
+- Do not add `Co-Authored-By` or AI attribution trailers.
 
 ---
 
 ## Code of Conduct
 
-Be respectful. If you have an issue with another contributor, please contact a maintainer privately. We keep the drama out of public discussions.
+Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Be respectful, direct, and constructive. If you have an issue with another contributor, contact a maintainer privately.
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,7 @@ Una app **offline-first, multi-usuario y multiplataforma** donde guardar, organi
 
 Dominio: **[devdeck.ai](https://devdeck.ai)**
 
-[English](README.md) · [Roadmap](ROADMAP.md) · [Contribuir](CONTRIBUTING.es.md) · [Discusiones](https://github.com/tiagofur/dev_deck/discussions) · [Soporte](docs/SUPPORT.md) · [Modelo de comunidad](docs/CIRCLES_COMMUNITY.md)
+[English](README.md) · [Roadmap](ROADMAP.md) · [Contribuir](CONTRIBUTING.es.md) · [Discusiones](https://github.com/tiagofur/dev_deck/discussions) · [Guía de discusiones](docs/DISCUSSIONS.md) · [Soporte](docs/SUPPORT.md) · [Modelo de comunidad](docs/CIRCLES_COMMUNITY.md)
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -6,6 +6,8 @@ Una app **offline-first, multi-usuario y multiplataforma** donde guardar, organi
 
 Dominio: **[devdeck.ai](https://devdeck.ai)**
 
+[English](README.md) · [Roadmap](ROADMAP.md) · [Contribuir](CONTRIBUTING.es.md) · [Discusiones](https://github.com/tiagofur/dev_deck/discussions) · [Soporte](docs/SUPPORT.md) · [Modelo de comunidad](docs/CIRCLES_COMMUNITY.md)
+
 ---
 
 ## ¿Por qué DevDeck?

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **The developer memory layer for everything useful you discover, build, and share.**
 
-[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
+[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [First contribution](docs/FIRST_CONTRIBUTION.md) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
 
 DevDeck is an open-source desktop/web app for developers who keep losing useful repos, CLIs, snippets, prompts, shortcuts, cheatsheets, and workflow notes across chats, bookmarks, browser tabs, and GitHub stars.
 
@@ -157,6 +157,8 @@ Before opening a PR:
 
 Small, high-quality PRs are more valuable than giant feature drops.
 
+New here? Start with [docs/FIRST_CONTRIBUTION.md](docs/FIRST_CONTRIBUTION.md), then pick a `good first issue` with `status:approved`.
+
 ---
 
 ## Support the project
@@ -178,6 +180,7 @@ Possible future sustainability paths include hosted community Circles, paid setu
 | Doc | Content |
 |-----|---------|
 | [docs/CIRCLES_COMMUNITY.md](docs/CIRCLES_COMMUNITY.md) | Circles as private collective memory for developer communities |
+| [docs/FIRST_CONTRIBUTION.md](docs/FIRST_CONTRIBUTION.md) | Short path for a first issue-backed PR |
 | [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) | Developer Workbench direction and workflows |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture and technical design |
 | [docs/API.md](docs/API.md) | API documentation |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **The developer memory layer for everything useful you discover, build, and share.**
 
-[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [First contribution](docs/FIRST_CONTRIBUTION.md) · [Discussions](https://github.com/tiagofur/dev_deck/discussions) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
+[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [First contribution](docs/FIRST_CONTRIBUTION.md) · [Discussions](https://github.com/tiagofur/dev_deck/discussions) · [Discussions guide](docs/DISCUSSIONS.md) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
 
 DevDeck is an open-source desktop/web app for developers who keep losing useful repos, CLIs, snippets, prompts, shortcuts, cheatsheets, and workflow notes across chats, bookmarks, browser tabs, and GitHub stars.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **The developer memory layer for everything useful you discover, build, and share.**
 
-[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [First contribution](docs/FIRST_CONTRIBUTION.md) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
+[Leer en español](README.es.md) · [Roadmap](ROADMAP.md) · [Contributing](CONTRIBUTING.md) · [First contribution](docs/FIRST_CONTRIBUTION.md) · [Discussions](https://github.com/tiagofur/dev_deck/discussions) · [Support](docs/SUPPORT.md) · [Community model](docs/CIRCLES_COMMUNITY.md)
 
 DevDeck is an open-source desktop/web app for developers who keep losing useful repos, CLIs, snippets, prompts, shortcuts, cheatsheets, and workflow notes across chats, bookmarks, browser tabs, and GitHub stars.
 

--- a/docs/DISCUSSIONS.md
+++ b/docs/DISCUSSIONS.md
@@ -1,0 +1,98 @@
+# GitHub Discussions guide
+
+GitHub Discussions is the place for early collaboration around DevDeck. Use it when the topic needs conversation before it becomes a focused issue or pull request.
+
+## When to use Discussions
+
+Use Discussions for:
+
+- Questions about setup, usage, self-hosting, or contribution flow.
+- Rough product ideas that still need shape.
+- Community workflows, Circle use cases, and collaboration patterns.
+- Show-and-tell posts with screenshots, demos, or personal DevDeck setups.
+- Feedback from people trying DevDeck before a public launch.
+
+Use Issues for:
+
+- Approved, scoped work that can become one focused PR.
+- Bugs with reproduction steps.
+- Feature requests that are already clear enough to review and implement.
+
+Use Pull Requests for:
+
+- One approved issue at a time.
+- Small, reviewable changes with clear verification notes.
+
+## Categories
+
+| Category | Use it for | Expected outcome |
+| --- | --- | --- |
+| Announcements | Maintainer updates, releases, launch notes, and roadmap highlights. | Keep contributors aligned. |
+| General | Open conversation that does not fit another category. | Clarify context or route to a better category. |
+| Ideas | Rough feature proposals, Circle workflows, community-memory concepts, monetization/support ideas. | Turn strong ideas into approved issues. |
+| Q&A | Setup help, usage questions, contribution questions. | Mark the best answer when resolved. |
+| Show and tell | Screenshots, demos, personal workflows, community examples. | Surface inspiring examples for the community. |
+| Polls | Lightweight votes when maintainers need directional feedback. | Inform prioritization, not replace product judgment. |
+
+## Starter discussions
+
+Start with these pinned-style entry points:
+
+- [Welcome to DevDeck Discussions](https://github.com/tiagofur/dev_deck/discussions/96) — orientation and community flow.
+- [Share ideas for DevDeck Circles and community workflows](https://github.com/tiagofur/dev_deck/discussions/97) — rough Circle/community proposals.
+- [Ask setup, usage, and contribution questions here](https://github.com/tiagofur/dev_deck/discussions/98) — Q&A for users and contributors.
+- [Show us your DevDeck workflow](https://github.com/tiagofur/dev_deck/discussions/99) — demos, screenshots, workflows, and inspiration.
+
+## Recommended posting format
+
+For ideas:
+
+```markdown
+## Problem
+What problem are you seeing?
+
+## Proposal
+What should DevDeck do?
+
+## Community value
+Who benefits from this?
+
+## Smallest first step
+What could be shipped in one focused PR?
+```
+
+For Q&A:
+
+```markdown
+## Question
+What are you trying to do?
+
+## Context
+OS, app version, local/self-hosted setup, and relevant logs if any.
+
+## What you tried
+What did you already test?
+```
+
+For show-and-tell:
+
+```markdown
+## What I built or discovered
+Short summary.
+
+## Why it helps
+How this improves a developer workflow.
+
+## Screenshots or demo
+Add images, GIFs, or links when useful.
+```
+
+## Maintainer workflow
+
+1. Let rough ideas start in Discussions instead of issues.
+2. Ask for the smallest useful first step.
+3. Convert only focused, actionable work into an issue.
+4. Add `status:approved` only when the issue is ready for a PR.
+5. Keep PRs small and linked to one approved issue.
+
+This keeps the repository welcoming without turning Issues into an unreviewable backlog.

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -58,4 +58,6 @@ Every PR should:
 
 ## Need help?
 
-Open an issue with a clear problem statement. If the idea is still rough, say what is uncertain and keep the proposed first step small.
+Use [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) for questions, rough ideas, community workflows, and early feedback.
+
+Open an issue only when the problem or proposal is clear enough to become a focused, reviewable task. If the idea is still rough, start in Discussions first and keep the proposed first step small.

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -58,6 +58,6 @@ Every PR should:
 
 ## Need help?
 
-Use [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) for questions, rough ideas, community workflows, and early feedback.
+Use [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) for questions, rough ideas, community workflows, and early feedback. See [docs/DISCUSSIONS.md](DISCUSSIONS.md) for category guidance and posting formats.
 
 Open an issue only when the problem or proposal is clear enough to become a focused, reviewable task. If the idea is still rough, start in Discussions first and keep the proposed first step small.

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -1,0 +1,61 @@
+# First contribution guide
+
+Thanks for considering a contribution to DevDeck. The best first PR is small, useful, and easy to review.
+
+## Quick path
+
+1. Pick an issue labeled [`good first issue`](https://github.com/tiagofur/dev_deck/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [`help wanted`](https://github.com/tiagofur/dev_deck/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).
+2. Make sure the issue has `status:approved`.
+3. Create a focused branch from `main`.
+4. Change only what the issue needs.
+5. Run the smallest relevant verification command.
+6. Open a PR that links the issue with `Closes #...`.
+
+## Local setup
+
+```bash
+pnpm install
+pnpm typecheck
+pnpm test
+```
+
+Run the web app:
+
+```bash
+pnpm dev:web
+```
+
+Run the backend locally:
+
+```bash
+cd backend
+cp .env.example .env
+docker compose -f ../deploy/docker-compose.local.yml up -d db
+go run ./cmd/api
+```
+
+## What makes a good first PR?
+
+Good first PRs usually do one of these:
+
+- Improve one empty state or UI copy block.
+- Add one focused test around existing behavior.
+- Clarify one setup or self-hosting doc section.
+- Improve one screenshot/demo/readme detail.
+- Fix one small Desktop/Web parity gap.
+
+Avoid starting with broad rewrites, large refactors, or multi-feature PRs. Those are harder to review and easier to break.
+
+## PR expectations
+
+Every PR should:
+
+- Link an approved issue.
+- Use a conventional commit title such as `docs(readme): clarify setup`.
+- Have exactly one `type:*` label.
+- Include tests or a clear verification note.
+- Avoid `Co-Authored-By` or AI attribution trailers.
+
+## Need help?
+
+Open an issue with a clear problem statement. If the idea is still rough, say what is uncertain and keep the proposed first step small.


### PR DESCRIPTION
Closes #94

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds GitHub issue templates for bug reports, feature requests, and good-first-issue candidates.
- Adds a pull request template, code of conduct, and first-contribution guide.
- Links the first-contribution path from README and CONTRIBUTING.

## Changes
| File | Change |
|------|--------|
| `.github/ISSUE_TEMPLATE/*` | Adds structured issue forms and disables blank issues. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Adds PR checklist for issue linkage, type label, test plan, screenshots, and no attribution trailers. |
| `CODE_OF_CONDUCT.md` | Adds community behavior and reporting expectations. |
| `docs/FIRST_CONTRIBUTION.md` | Adds a short first-PR guide for new contributors. |
| `README.md` / `CONTRIBUTING.md` | Links and aligns contributor flow docs. |

## Test Plan
- [x] YAML parsed successfully for all issue templates.
- [x] `git diff --check`
- [x] Verified GitHub Discussions are disabled and avoided linking to them.
- [x] Created `status:needs-review` label so templates match the approval workflow.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
