### PR TITLE
docs(launch): add promotion follow-up plan

### DIFF
--- a/docs/LAUNCH_KIT.md
+++ b/docs/LAUNCH_KIT.md
@@ -60,6 +60,9 @@ I’m not claiming it’s perfect yet. I’m actively polishing the onboarding, 
 
 Repo: https://github.com/tiagofur/dev_deck
 Site: https://devdeck.ai
+Discussions: https://github.com/tiagofur/dev_deck/discussions
+Call for contributors: https://github.com/tiagofur/dev_deck/discussions/100
+Support: https://www.buymeacoffee.com/tiagofur
 
 If this problem resonates with you, I’m especially looking for:
 
@@ -82,6 +85,74 @@ https://github.com/tiagofur/dev_deck
 
 ---
 
+
+## Promotion targets
+
+Prioritize communities where people already discuss developer workflow, tooling, self-hosting, and knowledge management. Do not spam generic channels. Post once, respond carefully, and adapt the message to each community.
+
+| Channel | Angle | Call to action | Notes |
+| --- | --- | --- | --- |
+| GitHub Discussions | Contributor coordination and early product feedback. | Reply to the [Call for contributors](https://github.com/tiagofur/dev_deck/discussions/100). | Keep this as the home base for rough ideas. |
+| Reddit `r/selfhosted` | Self-hostable developer memory with Docker Compose + Caddy. | Ask for deployment feedback and VPS docs review. | Be transparent that DevDeck is 0.5.0 Public Beta. |
+| Reddit `r/opensource` | Open-source developer tooling looking for early contributors. | Ask for small PRs and architecture/doc feedback. | Emphasize contribution flow and good-first-issues. |
+| Reddit `r/programming` or language/tooling subs | Rediscovering useful dev artifacts by context. | Ask whether the problem resonates. | Avoid overclaiming AI; lead with workflow pain. |
+| Hacker News `Show HN` | Practical app for developer memory and shared findings. | Ask for critical feedback. | Only post once the README and self-hosting path are verified. |
+| Dev.to / Hashnode | Build-in-public story and technical architecture. | Invite contributors and self-hosting testers. | Longer-form post can reuse the 30-second pitch plus stack notes. |
+| Discord/Slack dev communities | Community knowledge and Circle workflows. | Ask what a group would share into a Circle. | Prefer communities where you already participate. |
+| X / LinkedIn | Short visibility loop. | Ask for feedback, stars, contributors, and shares. | Link to repo plus the contributor discussion. |
+
+---
+
+## Launch-day checklist
+
+Before posting widely:
+
+1. Confirm `main` CI is green after the latest docs and launch-readiness PRs.
+2. Confirm README screenshots and demo GIF render correctly on GitHub.
+3. Confirm [docs/SELF_HOSTING.md](SELF_HOSTING.md) matches the current Docker Compose stack.
+4. Confirm [docs/SUPPORT.md](SUPPORT.md) has a working support link.
+5. Confirm [GitHub Discussions](https://github.com/tiagofur/dev_deck/discussions) has starter threads.
+6. Confirm the [Call for contributors](https://github.com/tiagofur/dev_deck/discussions/100) is visible.
+7. Confirm at least five `good first issue` tasks are open or recently completed with clear examples.
+8. Prepare one short post, one longer post, and one screenshot/GIF attachment.
+9. Block time after posting to answer comments quickly.
+10. Capture recurring feedback into issues or Discussions instead of losing it in comment threads.
+
+---
+
+## Follow-up workflow
+
+The launch is only useful if feedback turns into product learning. Use this loop after every post:
+
+1. **Collect signal:** save links to comments, forks, stars, posts, and useful replies.
+2. **Route correctly:** questions go to Discussions, bugs go to issues, scoped improvements go to approved issues, and code changes go to small PRs.
+3. **Respond publicly:** thank people, ask for concrete reproduction/context, and avoid defensive replies.
+4. **Convert carefully:** only create issues for work that is clear enough to review and implement.
+5. **Protect review quality:** keep launch-driven PRs small, issue-linked, and CI-verified.
+6. **Update docs:** if two people ask the same thing, improve README, self-hosting docs, or first contribution docs.
+7. **Report progress:** post small updates in Discussions so early contributors see momentum.
+
+---
+
+## Response templates
+
+**When someone wants to contribute:**
+
+> Amazing — thank you. The best first step is a small PR linked to an approved issue. Start here: https://github.com/tiagofur/dev_deck/blob/main/docs/FIRST_CONTRIBUTION.md. If you are unsure where to begin, reply in the contributor thread and we can shape a focused first task.
+
+**When someone has a rough idea:**
+
+> This sounds worth exploring, but it is still bigger than one reviewable issue. Could you drop it in Discussions with the problem, proposal, community value, and smallest first step? That keeps the idea visible without turning Issues into a backlog graveyard.
+
+**When someone reports a bug:**
+
+> Thank you — can you open a bug issue with OS, setup path, expected behavior, actual behavior, and logs/screenshots if available? If we can reproduce it, we can scope a focused fix.
+
+**When someone asks how to support the project:**
+
+> The repo is open source and free to use. If you want to support development costs and launch polish, the support page is here: https://github.com/tiagofur/dev_deck/blob/main/docs/SUPPORT.md. Sharing feedback and small PRs also helps a lot.
+
+---
 ## Contributor call-to-action
 
 DevDeck needs contributors who care about developer tooling, knowledge management, and community workflows.
@@ -130,4 +201,4 @@ Before posting widely:
 7. [ ] Known limitations are stated honestly.
 8. [ ] Support link is visible but not pushy.
 9. [ ] Reddit/forum post asks for feedback, not hype validation.
-10. [ ] Follow-up plan exists for issues, comments, and contributors after launch.
+10. [x] Follow-up plan exists for issues, comments, and contributors after launch.


### PR DESCRIPTION
Closes #101

## Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds concrete promotion targets for DevDeck's 0.5.0 public beta launch.
- Adds a launch-day checklist, post-launch follow-up workflow, and response templates.
- Links launch copy to Discussions, the contributor call, and support.

## Changes

| File | Change |
|------|--------|
| `docs/LAUNCH_KIT.md` | Adds promotion targets, launch-day checklist, follow-up workflow, and response templates. |

## Test Plan

- [x] Documentation-only change reviewed manually.
- [x] Markdown links are absolute or repo-relative and intentional.
- [x] `git diff --check` passed.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or confirmed no scripts changed
- [x] Skills tested in at least one agent or not applicable for docs-only change
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
