### PR TITLE
fix(circles): persist captured share context

### DIFF
--- a/packages/features/src/components/Workbench/shared.tsx
+++ b/packages/features/src/components/Workbench/shared.tsx
@@ -100,7 +100,7 @@ export function ResultActions({
       const itemId = captured.item?.id || captured.duplicate_of
       if (!itemId) throw new Error('Could not capture output before sharing.')
 
-      await shareToCircle.mutateAsync({ circleId, itemId })
+      await shareToCircle.mutateAsync({ circleId, itemId, shareContext: context })
       showToast('Shared to Circle', 'success')
       setShareOpen(false)
     } catch (err) {

--- a/packages/features/src/pages/CheatsheetDetailPage.test.tsx
+++ b/packages/features/src/pages/CheatsheetDetailPage.test.tsx
@@ -123,7 +123,11 @@ describe('<CheatsheetDetailPage>', () => {
         tags: ['cheatsheet', 'vcs', 'circle-share'],
         why_saved: 'Useful baseline commands for onboarding.',
       })
-      expect(shareToCircle).toHaveBeenCalledWith({ circleId: 'circle-1', itemId: 'item-1' })
+      expect(shareToCircle).toHaveBeenCalledWith({
+        circleId: 'circle-1',
+        itemId: 'item-1',
+        shareContext: 'Useful baseline commands for onboarding.',
+      })
     })
   })
 })

--- a/packages/features/src/pages/CheatsheetDetailPage.tsx
+++ b/packages/features/src/pages/CheatsheetDetailPage.tsx
@@ -150,7 +150,7 @@ export function CheatsheetDetailPage() {
       const itemId = captured.item?.id || captured.duplicate_of
       if (!itemId) throw new Error('Could not capture cheatsheet before sharing.')
 
-      await shareToCircle.mutateAsync({ circleId, itemId })
+      await shareToCircle.mutateAsync({ circleId, itemId, shareContext: context })
       showToast('Cheatsheet shared to Circle', 'success')
       setShareOpen(false)
     } catch (err) {

--- a/packages/features/src/pages/ItemDetailPage.test.tsx
+++ b/packages/features/src/pages/ItemDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { ItemDetailPage } from './ItemDetailPage'
 
@@ -13,6 +13,14 @@ const mocks = vi.hoisted(() => ({
 	useReviewItemAITags: vi.fn(),
 	useUserTags: vi.fn(),
 	useRelatedItems: vi.fn(),
+	useItemRunbooks: vi.fn(),
+	useCreateRunbook: vi.fn(),
+	useAddRunbookStep: vi.fn(),
+	useUpdateRunbookStep: vi.fn(),
+	useDeleteRunbook: vi.fn(),
+	useCapture: vi.fn(),
+	useCircles: vi.fn(),
+	useShareToCircle: vi.fn(),
 	showToast: vi.fn(),
 	confirm: vi.fn(),
 }))
@@ -37,6 +45,14 @@ vi.mock('@devdeck/api-client', async () => {
 		useReviewItemAITags: mocks.useReviewItemAITags,
 		useUserTags: mocks.useUserTags,
 		useRelatedItems: mocks.useRelatedItems,
+		useItemRunbooks: mocks.useItemRunbooks,
+		useCreateRunbook: mocks.useCreateRunbook,
+		useAddRunbookStep: mocks.useAddRunbookStep,
+		useUpdateRunbookStep: mocks.useUpdateRunbookStep,
+		useDeleteRunbook: mocks.useDeleteRunbook,
+		useCapture: mocks.useCapture,
+		useCircles: mocks.useCircles,
+		useShareToCircle: mocks.useShareToCircle,
 	}
 })
 
@@ -88,6 +104,14 @@ describe('<ItemDetailPage>', () => {
 		mocks.useReviewItemAITags.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
 		mocks.useUserTags.mockReturnValue({ data: ['cli', 'search'], isLoading: false })
 		mocks.useRelatedItems.mockReturnValue({ data: [], isLoading: false, error: null })
+		mocks.useItemRunbooks.mockReturnValue({ data: [], isLoading: false })
+		mocks.useCreateRunbook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useAddRunbookStep.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useUpdateRunbookStep.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useDeleteRunbook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
+		mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
 	})
 
 	it('renders AI summary and suggested tags', () => {
@@ -141,6 +165,74 @@ describe('<ItemDetailPage>', () => {
 		expect(mutateAsync).toHaveBeenCalledWith({
 			id: 'item-1',
 			input: { tags: ['search'], is_favorite: true },
+		})
+	})
+
+
+
+	it('shares a runbook to a Circle with persisted context', async () => {
+		const capture = vi.fn().mockResolvedValue({
+			item: { id: 'captured-runbook' },
+			duplicate_of: null,
+			enrichment_status: 'ok',
+		})
+		const shareToCircle = vi.fn().mockResolvedValue({})
+		mocks.useItemRunbooks.mockReturnValue({
+			data: [
+				{
+					id: 'runbook-1',
+					item_id: 'item-1',
+					title: 'Deploy API',
+					created_at: '2026-04-30T00:00:00Z',
+					steps: [
+						{
+							id: 'step-1',
+							runbook_id: 'runbook-1',
+							position: 1,
+							label: 'Restart API',
+							command: 'docker compose up -d api',
+							description: 'Restart only the API service.',
+							created_at: '2026-04-30T00:00:00Z',
+						},
+					],
+				},
+			],
+			isLoading: false,
+		})
+		mocks.useCapture.mockReturnValue({ mutateAsync: capture, isPending: false })
+		mocks.useCircles.mockReturnValue({
+			data: [{ id: 'circle-1', name: 'Ops Guild' }],
+			isLoading: false,
+		})
+		mocks.useShareToCircle.mockReturnValue({ mutateAsync: shareToCircle, isPending: false })
+
+		render(<ItemDetailPage />)
+		fireEvent.click(screen.getByRole('button', { name: /runbooks/i }))
+		fireEvent.click(screen.getByTitle('Share runbook to Circle'))
+
+		const saveAndShare = screen.getByRole('button', { name: /save and share runbook/i })
+		expect(saveAndShare).toBeDisabled()
+
+		fireEvent.change(screen.getByLabelText('Circle'), { target: { value: 'circle-1' } })
+		fireEvent.change(screen.getByLabelText('Why this matters'), {
+			target: { value: 'Useful for production deploy handoffs.' },
+		})
+		fireEvent.click(saveAndShare)
+
+		await waitFor(() => {
+			expect(capture).toHaveBeenCalledWith({
+				source: 'manual',
+				text: expect.stringContaining('docker compose up -d api'),
+				title_hint: 'Runbook: Deploy API',
+				type_hint: 'workflow',
+				tags: ['runbook', 'circle-share'],
+				why_saved: 'Useful for production deploy handoffs.',
+			})
+			expect(shareToCircle).toHaveBeenCalledWith({
+				circleId: 'circle-1',
+				itemId: 'captured-runbook',
+				shareContext: 'Useful for production deploy handoffs.',
+			})
 		})
 	})
 

--- a/packages/features/src/pages/ItemDetailPage.tsx
+++ b/packages/features/src/pages/ItemDetailPage.tsx
@@ -391,7 +391,7 @@ function RunbookCard({ runbook }: { runbook: Runbook }) {
 			const itemId = captured.item?.id || captured.duplicate_of
 			if (!itemId) throw new Error('Could not capture runbook before sharing.')
 
-			await shareToCircle.mutateAsync({ circleId, itemId })
+			await shareToCircle.mutateAsync({ circleId, itemId, shareContext: context })
 			showToast('Runbook shared to Circle', 'success')
 			setShareOpen(false)
 		} catch (err) {

--- a/packages/features/src/pages/WorkbenchPage.test.tsx
+++ b/packages/features/src/pages/WorkbenchPage.test.tsx
@@ -224,7 +224,11 @@ describe('<WorkbenchPage>', () => {
         tags: ['workbench', 'circle-share'],
         why_saved: 'Useful payload shape for our API examples.',
       })
-      expect(shareToCircle).toHaveBeenCalledWith({ circleId: 'circle-1', itemId: 'item-1' })
+      expect(shareToCircle).toHaveBeenCalledWith({
+        circleId: 'circle-1',
+        itemId: 'item-1',
+        shareContext: 'Useful payload shape for our API examples.',
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #103

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Persists the required Circle share context for Workbench output shares.
- Persists the required Circle share context for cheatsheet and runbook captured shares.
- Updates focused tests so captured share flows assert `shareContext` is sent to the API.

## Changes

| File | Change |
|------|--------|
| `packages/features/src/components/Workbench/shared.tsx` | Sends `shareContext` when sharing captured Workbench outputs. |
| `packages/features/src/pages/CheatsheetDetailPage.tsx` | Sends `shareContext` when sharing captured cheatsheets. |
| `packages/features/src/pages/ItemDetailPage.tsx` | Sends `shareContext` when sharing captured runbooks. |
| `packages/features/src/pages/*test.tsx` | Covers persisted context for Workbench, cheatsheet, and runbook shares. |

## Test Plan

- [x] `pnpm -F @devdeck/features test -- --run src/pages/WorkbenchPage.test.tsx src/pages/CheatsheetDetailPage.test.tsx src/pages/ItemDetailPage.test.tsx`
- [x] `pnpm -F @devdeck/features typecheck`
- [x] `git diff --check`

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or confirmed no scripts changed
- [x] Skills tested in at least one agent or not applicable
- [x] Docs updated if behavior changed or not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
