### PR TITLE
fix(profile): render uploaded avatars

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -14,6 +14,11 @@
         reverse_proxy api:8080
     }
 
+    # Uploaded user assets
+    handle /uploads/* {
+        reverse_proxy api:8080
+    }
+
     # SPA — serve React app
     handle /* {
         reverse_proxy web:3000

--- a/packages/api-client/src/api-client.test.ts
+++ b/packages/api-client/src/api-client.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from './api-client'
+import { configureApiClient } from './config'
+import { localStorageAdapter } from './auth/storage/localStorage'
+import { setTokenStorage } from './auth/storage/types'
+
+function mockJSONResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response
+}
+
+describe('api-client', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setTokenStorage(localStorageAdapter)
+    configureApiClient({ baseUrl: '', authMode: 'jwt', staticToken: undefined })
+    vi.restoreAllMocks()
+  })
+
+  it('prefixes backend upload URLs in *_url response fields when an API base URL is configured', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockJSONResponse({
+      avatar_url: '/uploads/me.png',
+      github_url: 'https://github.com/tiagofur',
+      feed: [
+        {
+          curator_avatar_url: '/uploads/curator.png',
+          item: {
+            url: '/uploads/not-an-asset-url',
+          },
+        },
+      ],
+    })))
+
+    configureApiClient({ baseUrl: 'https://api.example.test/', authMode: 'jwt' })
+
+    const data = await api.get<{
+      avatar_url: string
+      github_url: string
+      feed: Array<{ curator_avatar_url: string; item: { url: string } }>
+    }>('/api/auth/me')
+
+    expect(data.avatar_url).toBe('https://api.example.test/uploads/me.png')
+    expect(data.github_url).toBe('https://github.com/tiagofur')
+    expect(data.feed[0].curator_avatar_url).toBe('https://api.example.test/uploads/curator.png')
+    expect(data.feed[0].item.url).toBe('/uploads/not-an-asset-url')
+  })
+
+  it('keeps backend upload URLs relative for same-origin web deployments', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockJSONResponse({
+      avatar_url: '/uploads/me.png',
+    })))
+
+    configureApiClient({ baseUrl: '', authMode: 'jwt' })
+
+    const data = await api.get<{ avatar_url: string }>('/api/auth/me')
+
+    expect(data.avatar_url).toBe('/uploads/me.png')
+  })
+})

--- a/packages/api-client/src/api-client.ts
+++ b/packages/api-client/src/api-client.ts
@@ -60,6 +60,40 @@ function getBearerToken(): string {
   return staticToken ?? ''
 }
 
+function resolveUploadUrl(value: string): string {
+  if (!value.startsWith('/uploads/')) return value
+
+  const { baseUrl } = getConfig()
+  if (!baseUrl) return value
+
+  return `${baseUrl.replace(/\/$/, '')}${value}`
+}
+
+function normalizeUploadUrls<T>(value: T, key?: string): T {
+  if (typeof value === 'string') {
+    return (key?.toLowerCase().endsWith('_url') ? resolveUploadUrl(value) : value) as T
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeUploadUrls(item)) as T
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        normalizeUploadUrls(entryValue, entryKey),
+      ]),
+    ) as T
+  }
+
+  return value
+}
+
+async function readJSON<T>(res: Response): Promise<T> {
+  return normalizeUploadUrls((await res.json()) as T)
+}
+
 async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   const { baseUrl, authMode } = getConfig()
   const { activeOrgId } = getPreferences()
@@ -104,7 +138,7 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
         throw new APIError(retryRes.status, code, message)
       }
       if (retryRes.status === 204) return undefined as T
-      return (await retryRes.json()) as T
+      return readJSON<T>(retryRes)
     }
   }
 
@@ -122,7 +156,7 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   }
 
   if (res.status === 204) return undefined as T
-  return (await res.json()) as T
+  return readJSON<T>(res)
 }
 
 export const api = {


### PR DESCRIPTION
Closes #105

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Routes uploaded assets through the API in the production Caddy proxy.
- Normalizes backend `/uploads/...` response URLs against the configured API base URL for desktop and absolute-API deployments.
- Adds focused API-client coverage for uploaded asset URL handling.

## Changes
| File | Change |
|------|--------|
| `deploy/Caddyfile` | Proxies `/uploads/*` to the API before the SPA fallback. |
| `packages/api-client/src/api-client.ts` | Normalizes `/uploads/...` values in `*_url` response fields when `baseUrl` is configured. |
| `packages/api-client/src/api-client.test.ts` | Covers upload URL normalization and same-origin preservation. |

## Test Plan
- [x] I ran the relevant command(s): `node_modules/.bin/vitest run --reporter=verbose` from `packages/api-client`.
- [x] I ran the relevant command(s): `node_modules/.bin/tsc --noEmit` from `packages/api-client`.
- [x] I manually verified the affected flow by checking that the web host returned `text/html` for `/uploads/...` while the API host returned `image/png` before the fix.
- [ ] I included screenshots/GIFs for user-facing UI changes, if applicable.

## Contributor Checklist
- [x] Linked an approved issue with `Closes #...`
- [x] Added exactly one `type:*` label
- [x] Kept the PR small and focused
- [x] Included tests or a clear verification note
- [x] Updated docs if behavior changed
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` or AI attribution trailers