### PR TITLE
fix(authservice): make jwt tamper test deterministic

### DIFF
--- a/backend/internal/authservice/jwt_test.go
+++ b/backend/internal/authservice/jwt_test.go
@@ -54,8 +54,21 @@ func TestService_ValidateAccessToken_RejectsTamperedToken(t *testing.T) {
 	user := auth.User{ID: uuid.New(), Login: "x", Role: "user"}
 	token, _, _ := svc.GenerateAccessToken(user)
 
-	// Flip a character in the signature.
-	tampered := token[:len(token)-2] + "AA"
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[2] == "" {
+		t.Fatalf("expected JWT with non-empty signature, got %q", token)
+	}
+
+	replacement := "A"
+	if parts[2][0] == 'A' {
+		replacement = "B"
+	}
+	parts[2] = replacement + parts[2][1:]
+	tampered := strings.Join(parts, ".")
+	if tampered == token {
+		t.Fatal("tampered token should differ from original token")
+	}
+
 	if _, _, _, err := svc.ValidateAccessToken(tampered); err != ErrInvalidToken {
 		t.Errorf("expected ErrInvalidToken on tampered jwt, got %v", err)
 	}


### PR DESCRIPTION
Closes #107

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Makes the JWT tamper test mutate the signature deterministically.
- Avoids the flaky no-op case where a generated token already ended with `AA`.
- Keeps the assertion focused on rejecting genuinely modified JWT signatures.

## Changes
| File | Change |
|------|--------|
| `backend/internal/authservice/jwt_test.go` | Mutates the first signature character to a guaranteed different base64url character and asserts the tampered token differs. |

## Test Plan
- [x] I ran the relevant command(s): `GOCACHE="$PWD/.gocache" go test -run TestService_ValidateAccessToken_RejectsTamperedToken -count=1000 ./internal/authservice` from `backend`.
- [x] I ran the relevant command(s): `GOCACHE="$PWD/.gocache" go test ./internal/authservice` from `backend`.
- [x] I ran the relevant command(s): `GOCACHE="$PWD/.gocache" go test -race -timeout=10m -run TestService_ValidateAccessToken_RejectsTamperedToken -count=100 ./internal/authservice` from `backend`.
- [x] I ran the relevant command(s): `GOCACHE="$PWD/.gocache" go test -race -timeout=10m -coverprofile=coverage.out -covermode=atomic ./internal/authservice` from `backend`.
- [ ] I manually verified the affected flow, if applicable.
- [ ] I included screenshots/GIFs for user-facing UI changes, if applicable.

## Contributor Checklist
- [x] Linked an approved issue with `Closes #...`
- [x] Added exactly one `type:*` label
- [x] Kept the PR small and focused
- [x] Included tests or a clear verification note
- [x] Updated docs if behavior changed
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` or AI attribution trailers