### PR TITLE
docs: align docs with implementation reality

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,8 @@ The priority before a stable `1.0.0` is not more hype. It is trust:
 - stable capture/search/workbench/Circles flows,
 - and a contributor path that makes small PRs easy.
 
+Offline-first sync is intentionally deferred until after `1.0.0` (see [docs/FEATURE_REVIEW_2026_06.md](docs/FEATURE_REVIEW_2026_06.md), decision A5). Today DevDeck runs in honest cloud mode; Workbench utilities work fully local, and a full vault export (#122) covers data ownership in the meantime.
+
 ---
 
 ## 0.5.x — Public beta / launch readiness
@@ -28,9 +30,9 @@ The priority before a stable `1.0.0` is not more hype. It is trust:
 
 - [x] Clarify public README and launch story.
 - [x] Position DevDeck honestly as `0.5.0 Public Beta`.
-- [ ] Add screenshots and/or a short demo GIF.
-- [ ] Add realistic demo/seed data for a first-run experience.
-- [ ] Document known limitations clearly.
+- [x] Add screenshots and/or a short demo GIF.
+- [ ] Add realistic demo/seed data for a first-run experience (#117).
+- [ ] Document known limitations clearly (#129).
 - [ ] Verify local setup on a clean machine.
 
 ### Core developer memory loop
@@ -39,14 +41,14 @@ The priority before a stable `1.0.0` is not more hype. It is trust:
 - [x] Add context such as notes, tags, source, and why it matters.
 - [x] Support fuzzy/semantic retrieval direction with Postgres search extensions.
 - [x] Share useful findings into Circles with context and attribution.
-- [ ] Tighten empty/loading/error states across core flows.
-- [ ] Improve first-run onboarding around capture → retrieve → share.
+- [ ] Tighten empty/loading/error states across core flows (#119).
+- [ ] Improve first-run onboarding around capture → retrieve → share (#118).
 
 ### Workbench
 
 - [x] Establish Developer Workbench as a daily-use surface.
 - [x] Support reusable utilities, snippets, runbooks, requests, and project context direction.
-- [ ] Improve Workbench onboarding and examples.
+- [ ] Improve Workbench onboarding and examples (#120).
 - [ ] Add more tests around save/share flows.
 
 ### Circles / community memory
@@ -64,7 +66,7 @@ The priority before a stable `1.0.0` is not more hype. It is trust:
 - [x] Add contributor call-to-action in README.
 - [x] Add best-first-contribution guidance.
 - [ ] Create at least 5 `good first issue` tasks.
-- [ ] Add a short architecture map for new contributors.
+- [ ] Add a short architecture map for new contributors (#129).
 - [ ] Keep PRs small, issue-backed, and CI-verified.
 
 ---

--- a/docs/COMPETITIVE_ANALYSIS.es.md
+++ b/docs/COMPETITIVE_ANALYSIS.es.md
@@ -1,6 +1,8 @@
 # DevDeck — Análisis Competitivo
 
-> Versión: 1.0 · Owner: tfurt · Última actualización: 2026-04-08
+> Versión: 1.1 · Owner: tfurt · Última actualización: 2026-06-10
+
+> **Nota de estado (junio 2026):** las menciones a "offline-first" en este documento describen la dirección de producto, no el estado actual. El sync offline está pospuesto a post-1.0; hoy la app funciona en cloud mode (las utilities del Workbench sí corren 100% local, sin red). La IA (resúmenes, tags, búsqueda semántica) requiere un provider configurado (OpenAI u Ollama local); sin provider, DevDeck usa un tagger heurístico integrado. Ver [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md) (decisión A5) y el [ROADMAP](../ROADMAP.md).
 
 ---
 
@@ -220,7 +222,7 @@ GitHub Stars es el punto de partida conceptual de DevDeck (de hecho, el producto
 
 | Herramienta | Categoría | Offline-first | IA útil para devs | Assets de dev como 1er nivel | Búsqueda semántica | Multiplataforma |
 |-------------|-----------|:---:|:---:|:---:|:---:|:---:|
-| **DevDeck** | Knowledge OS para devs | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **DevDeck** | Knowledge OS para devs | 🟡 (roadmap) | ✅ (con provider) | ✅ | ✅ (con provider) | ✅ |
 | Raindrop.io | Bookmark manager | ❌ | ❌ | ❌ | ❌ | ✅ |
 | Notion | PKM / workspace | ❌ | Parcial* | ❌ | ❌ | ✅ |
 | Obsidian | PKM offline | ✅ | Parcial** | ❌ | Parcial** | ✅ |
@@ -231,7 +233,8 @@ GitHub Stars es el punto de partida conceptual de DevDeck (de hecho, el producto
 > \* Notion AI escribe y resume texto, pero no entiende el dominio de dev tools.  
 > \*\* Obsidian tiene plugins de IA y búsqueda semántica, pero requieren configuración avanzada; no son out-of-the-box.  
 > \*\*\* Raycast AI responde preguntas, pero no organiza tu colección personal de herramientas.  
-> † Dash es macOS; Zeal es Linux/Windows. Ninguno es multiplataforma completo.
+> † Dash es macOS; Zeal es Linux/Windows. Ninguno es multiplataforma completo.  
+> 🟡 El offline-first de DevDeck está pospuesto a post-1.0; hoy la app funciona en cloud mode (las utilities del Workbench sí corren 100% local). "Con provider" = requiere OpenAI u Ollama configurado; sin provider se usa el tagger heurístico y búsqueda de texto/fuzzy.
 
 ---
 

--- a/docs/COMPETITIVE_ANALYSIS.md
+++ b/docs/COMPETITIVE_ANALYSIS.md
@@ -38,12 +38,15 @@ How **DevDeck.ai** compares to other bookmarking and knowledge management tools.
 
 | Feature | DevDeck | Raindrop | GitHub Stars | Notion |
 |---------|---------|----------|--------------|--------|
-| **AI Summary** | ✅ (Built-in) | ❌ | ❌ | ⚠️ (Manual) |
+| **AI Summary** | ✅ (With provider)* | ❌ | ❌ | ⚠️ (Manual) |
 | **CLI Capture** | ✅ (Native) | ❌ | ❌ | ❌ |
 | **Snippet Support** | ✅ (High) | ⚠️ (Basic) | ❌ | ✅ (High) |
-| **Offline-First** | ✅ (Desktop) | ⚠️ (Pro only) | ❌ | ⚠️ (Sync issues) |
+| **Offline-First** | 🟡 (Planned)** | ⚠️ (Pro only) | ❌ | ⚠️ (Sync issues) |
 | **Open Source** | ✅ | ❌ | ❌ | ❌ |
 | **Self-Hostable** | ✅ | ❌ | ❌ | ❌ |
+
+> \* AI summaries and tags require a configured provider (OpenAI or local Ollama). Without one, DevDeck falls back to a built-in heuristic tagger.
+> \*\* Offline-first sync is product direction, deferred until after 1.0. Today DevDeck runs in cloud mode; Workbench utilities do run fully local without network access.
 
 ---
 

--- a/docs/PRD.es.md
+++ b/docs/PRD.es.md
@@ -30,9 +30,11 @@ El `.ai` no debe ser decorativo. La IA en DevDeck existe para clasificar, resumi
 
 DevDeck ayuda a guardar, organizar, recuperar y reutilizar todo lo útil que un developer encuentra o construye: repos, CLIs, plugins, cheatsheets, shortcuts, snippets, agentes, prompts, requests, runbooks y workflows.
 
-El siguiente paso de producto es el **Developer Workbench**:
+El **Developer Workbench** ya materializó esta dirección (ver estado por fase en [DEV_WORKBENCH.es.md](DEV_WORKBENCH.es.md)):
 
 > Guardás conocimiento útil, lo encontrás cuando importa y lo convertís en acciones reutilizables.
+
+El paso actual de producto es la preparación para el lanzamiento: primera experiencia, documentación honesta y Circles como memoria comunitaria (ver el [ROADMAP](../ROADMAP.es.md)).
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -14,9 +14,11 @@
 
 DevDeck helps developers save, organize, retrieve, and reuse useful development knowledge: repos, CLIs, plugins, cheatsheets, shortcuts, snippets, agents, prompts, requests, runbooks, and workflows.
 
-The next product step is the **Developer Workbench**:
+The **Developer Workbench** shipped this direction (see phase status in [DEV_WORKBENCH.md](DEV_WORKBENCH.md)):
 
 > Save useful knowledge, find it when it matters, and turn it into reusable actions.
+
+The current product step is launch readiness: first-run experience, honest docs, and Circles as community memory (see the [ROADMAP](../ROADMAP.md)).
 
 ---
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -8,7 +8,7 @@
 
 | Archivo | Descripción |
 |---------|-------------|
-| [PRD.md](PRD.md) | **Product Requirements Document.** Visión, tipos de items, funcionalidades por ola (1–7), user stories, métricas, constraints, decisiones y riesgos. Punto de entrada principal para entender el producto. |
+| [PRD.md](PRD.md) | **Product Requirements Document.** Visión, problema, solución en capas (vault polimórfico + recuperación inteligente + acciones reutilizables), pilares, alcance (core + Workbench + fuera de scope) y métricas de éxito. Punto de entrada principal para entender el producto. |
 | [VISION.md](VISION.md) | **Visión y posicionamiento.** Qué es DevDeck (y qué no es), diferenciadores genuinos, taglines por audiencia, roadmap de posicionamiento y preguntas frecuentes de posicionamiento. |
 | [DEV_WORKBENCH.md](DEV_WORKBENCH.md) · [DEV_WORKBENCH.es.md](DEV_WORKBENCH.es.md) | **Developer Workbench.** Evolución de memoria a acción contextual: utilities locales, paleta, requests reutilizables, límites de producto y roadmap recomendado. |
 | [CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md) · [CIRCLES_COMMUNITY.es.md](CIRCLES_COMMUNITY.es.md) | **Circles y contribución comunitaria.** Modelo de producto para convertir hallazgos individuales en memoria reutilizable para grupos/comunidades de developers. |
@@ -37,6 +37,33 @@
 | [TECHNICAL_ROADMAP_AI_OFFLINE.es.md](TECHNICAL_ROADMAP_AI_OFFLINE.es.md) | **Roadmap técnico detallado.** Plan de implementación de las Olas 5–7: offline-first con SQLite local + sync engine, embeddings + búsqueda vectorial, multi-usuario. |
 | [API.es.md](API.es.md) | **Referencia de API REST.** Especificación OpenAPI de todos los endpoints (`/api/repos`, `/api/cheatsheets`, `/api/search`, `/api/auth`, etc.). |
 | [DESIGN_SYSTEM.es.md](DESIGN_SYSTEM.es.md) | **Design system.** Tokens CSS, paleta de colores neo-brutalist, tipografía, componentes, estados de la mascota Snarkel y principios de diseño de la UI. |
+| [CAPTURE.md](CAPTURE.md) · [CAPTURE.es.md](CAPTURE.es.md) | **Captura multi-canal.** Cómo funciona la captura desde CLI, extensión, paste interceptor y endpoint `/api/items/capture`. |
+| [SELF_HOSTING.md](SELF_HOSTING.md) · [SELF_HOSTING.es.md](SELF_HOSTING.es.md) | **Guía de self-hosting.** Despliegue con Docker Compose + Caddy, variables de entorno, migraciones y verificación. |
+| [TESTING_STRATEGY.md](TESTING_STRATEGY.md) · [TESTING_STRATEGY.es.md](TESTING_STRATEGY.es.md) | **Estrategia de testing y CI.** Tests de backend, unitarios de frontend, E2E y pipeline de GitHub Actions. |
+
+---
+
+## Comunidad y lanzamiento
+
+| Archivo | Descripción |
+|---------|-------------|
+| [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md) | **Primera contribución.** Camino corto para un primer PR respaldado por un issue. |
+| [DISCUSSIONS.md](DISCUSSIONS.md) | **Guía de GitHub Discussions.** Categorías y cómo participar. |
+| [SUPPORT.md](SUPPORT.md) | **Soporte y sustentabilidad.** Qué financia el apoyo al proyecto y caminos futuros de sostenibilidad. |
+| [LAUNCH_KIT.md](LAUNCH_KIT.md) | **Kit de lanzamiento.** Copy por canal, checklist de launch y plan de follow-up. |
+
+---
+
+## Reviews y auditorías (históricos)
+
+> Snapshots con fecha. Para el estado actual del producto, ver siempre [ROADMAP.md](../ROADMAP.md).
+
+| Archivo | Descripción |
+|---------|-------------|
+| [REVIEW_2026_04.md](REVIEW_2026_04.md) | **Review técnica (abril 2026).** Hardening, captura y deuda de testing — origen de la Ola 4.5. |
+| [APP_AUDIT_2026_05.md](APP_AUDIT_2026_05.md) | **Auditoría de app (mayo 2026).** Inventario completo de features, clasificación por impacto de usuario y plan P0–P2 de progressive disclosure. |
+| [APP_AUDIT_REVIEW_2026_05.md](APP_AUDIT_REVIEW_2026_05.md) | **Verificación de la auditoría (mayo 2026).** Evidencia del trabajo P0/P1 y plan de comunidad alrededor de Circles. |
+| [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md) | **Revisión de producto y docs (junio 2026).** Menú de decisiones Sí/No sobre mejoras de app y documentación; origen de los issues #113–#130. |
 
 ---
 

--- a/docs/VISION.es.md
+++ b/docs/VISION.es.md
@@ -136,9 +136,13 @@ R: Hoy es para uso individual o muy pequeño (allowlist de GitHub). El plan es e
 
 ---
 
-## El Futuro: Developer Workbench
+## Developer Workbench: de memoria a acción
 
-DevDeck está evolucionando más allá del almacenamiento pasivo de conocimiento para convertirse en una herramienta de **acción contextual** en el día a día. La frontera es clara: no buscamos reemplazar cada app que un developer ya usa, sino conectar memoria, búsqueda y acciones reutilizables.
+DevDeck ya evolucionó más allá del almacenamiento pasivo: el Developer Workbench (utilities locales, paleta de comandos, requests reutilizables, contexto de proyecto) está implementado en su mayor parte. La frontera sigue siendo clara: no buscamos reemplazar cada app que un developer ya usa, sino conectar memoria, búsqueda y acciones reutilizables.
 
-Para más detalles técnicos y de producto sobre esta evolución, revisar:
+Para el estado por fase de esta evolución, revisar:
 👉 **[DEV_WORKBENCH.es.md](DEV_WORKBENCH.es.md)**
+
+## Foco actual
+
+Con el Workbench implementado, el próximo paso no es más superficie: es confianza y comunidad. Primera experiencia sólida, documentación honesta y Circles como puente entre la memoria personal y la memoria compartida de ingeniería. Ver [CIRCLES_COMMUNITY.es.md](CIRCLES_COMMUNITY.es.md) y el [ROADMAP](../ROADMAP.es.md).

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -52,10 +52,14 @@ DevDeck aims to become the **standard repository for developer workflows**. Not 
 
 ---
 
-## 6. Next Step: Developer Workbench
+## 6. Developer Workbench: From Memory to Action
 
-DevDeck should evolve from passive storage into contextual action, without becoming a generic launcher or a clone of existing tools. The product boundary is:
+DevDeck evolved from passive storage into contextual action without becoming a generic launcher or a clone of existing tools. The Developer Workbench — local utilities, command palette, reusable requests, and project context — is largely shipped (see phase status in [DEV_WORKBENCH.md](DEV_WORKBENCH.md)). The product boundary remains:
 
 > Save useful developer knowledge, retrieve it by intent, and turn it into reusable actions.
 
-See [DEV_WORKBENCH.md](DEV_WORKBENCH.md) for the proposed roadmap.
+---
+
+## 7. Current Focus
+
+With the Workbench shipped, the next step is not more surface area. It is trust and community: a strong first-run experience, honest docs, and Circles as the bridge from personal memory to shared engineering memory. See [CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md) and the [ROADMAP](../ROADMAP.md).


### PR DESCRIPTION
Closes #128

Applies the same honesty standard the UI got (P0.2 "Cloud Mode") to the public docs, per the June 2026 review (`docs/FEATURE_REVIEW_2026_06.md`, items B1.1–B1.4).

## Changes

- **COMPETITIVE_ANALYSIS (en/es):** the comparison matrices no longer claim offline-first and built-in AI summaries as current state. Footnotes explain that AI requires a configured provider (heuristic fallback by default) and that offline-first sync is deferred until after 1.0 (review decision A5). The Spanish doc gets a status note up top since its prose describes offline-first as a current differentiator throughout.
- **ROADMAP.md:** checked the completed "screenshots/demo GIF" item (README has them since #84/#101); linked open 0.5.x items to their tracking issues (#117, #118, #119, #120, #129); recorded the offline-first deferral decision under "Current product direction".
- **VISION (en/es) §6 + PRD (en/es) §1:** the Workbench is shipped, not "the next step". New "Current Focus" wording: launch readiness, honest docs, and Circles as community memory.
- **docs/README.es.md index:** fixed the stale PRD description (the PRD no longer has waves 1–7); indexed the previously missing docs (CAPTURE, SELF_HOSTING, TESTING_STRATEGY, FIRST_CONTRIBUTION, DISCUSSIONS, SUPPORT, LAUNCH_KIT) and added a "historical reviews/audits" section for the dated snapshots.

## Verification

Docs-only change. All relative links added in this PR were checked against existing files on this branch.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_