### PR TITLE
docs: add known limitations, contributor architecture map, and English docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ Possible future sustainability paths include hosted community Circles, paid setu
 | Doc | Content |
 |-----|---------|
 | [docs/CIRCLES_COMMUNITY.md](docs/CIRCLES_COMMUNITY.md) | Circles as private collective memory for developer communities |
+| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | Known limitations of the 0.5.0 Public Beta, stated honestly |
 | [docs/FIRST_CONTRIBUTION.md](docs/FIRST_CONTRIBUTION.md) | Short path for a first issue-backed PR |
+| [docs/ARCHITECTURE_MAP.md](docs/ARCHITECTURE_MAP.md) | One-page architecture orientation for new contributors |
 | [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) | Developer Workbench direction and workflows |
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture and technical design |
 | [docs/API.md](docs/API.md) | API documentation |

--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -1,0 +1,65 @@
+# DevDeck — Architecture Map for Contributors
+
+> One page to orient your first PR. For diagrams, schema, and decisions, see [ARCHITECTURE.md](ARCHITECTURE.md) and the [ADRs](adr/).
+
+---
+
+## The big picture
+
+```txt
+apps/web (React 18 + Vite) ──────┐
+apps/desktop (Electron + React) ─┼──> packages/features ──> packages/api-client ──> backend (Go API) ──> Postgres 16
+apps/extension (Manifest V3) ────┤      (pages + UI)        (fetch + TanStack       (Chi router)          (+ pg_trgm,
+cli/ (devdeck, Go) ──────────────┘                            Query hooks)                                  pgvector)
+```
+
+Web and Desktop render the **same pages** from `packages/features`. The extension and CLI talk to the API directly. Most UI work happens in `packages/features`; most server work follows the `router → handler → store → Postgres` path.
+
+## Backend (`backend/`)
+
+| Path | What lives there |
+|------|------------------|
+| `cmd/api` | Entrypoint: config, wiring, cron scheduling |
+| `internal/http` | `router.go` plus `handlers/` (one file per domain: items, repos, circles, …) |
+| `internal/store` | All SQL data access (pgx). Handlers stay thin; queries live here |
+| `internal/domain` | Domain types and params |
+| `internal/ai` | AI providers + the heuristic tagger (`heuristic.go`) |
+| `internal/enricher` | GitHub/OpenGraph enrichment (SSRF-guarded) |
+| `internal/cron` | Scheduled jobs (e.g. weekly digest) |
+| `internal/authservice`, `internal/authctx` | JWT auth and request user context |
+| `migrations/` | Numbered SQL migrations — schema changes always go through a new migration |
+
+Supporting packages: `cache`, `email`, `jobs`, `metrics`, `seed`, `webhooks`, `testutil` (testcontainers helpers).
+
+## Frontend (pnpm monorepo)
+
+| Path | What lives there |
+|------|------------------|
+| `packages/features` | **Shared pages and domain components used by both Web and Desktop.** Start here for UI changes |
+| `packages/api-client` | API wrapper, TanStack Query hooks, preferences, sync scaffolding |
+| `packages/ui` | Design system (neo-brutalist tokens and primitives) |
+| `packages/i18n` | Locale resources (en/es) |
+| `apps/web` | Web shell: routing + providers |
+| `apps/desktop` | Electron shell. Main-process IPC: API tester sender, project detection, global shortcuts |
+| `apps/extension` | Browser capture extension (Manifest V3 + Vite) |
+| `cli/` | `devdeck` CLI (Go) |
+
+## Where to change what
+
+| I want to… | Touch |
+|------------|-------|
+| Change a page or component | `packages/features/src/pages` or `src/components` (check both Web and Desktop routes render it) |
+| Add an API endpoint | `backend/internal/http/handlers` + `internal/store` (+ a migration if schema changes) → hook in `packages/api-client` → consume in `packages/features` |
+| Add a Workbench tool | `packages/features/src/components/Workbench/` |
+| Change design tokens/styles | `packages/ui` |
+| Add/adjust translations | `packages/i18n` |
+
+## Verify before opening a PR
+
+```bash
+pnpm typecheck
+pnpm test
+cd backend && go test ./...
+```
+
+CI runs workspace typecheck/tests, backend tests against Postgres, desktop and extension builds, and the CLI build. Keep PRs small, issue-backed (`Closes #...`), and include a test or a clear verification note — see [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md).

--- a/docs/FIRST_CONTRIBUTION.md
+++ b/docs/FIRST_CONTRIBUTION.md
@@ -2,6 +2,8 @@
 
 Thanks for considering a contribution to DevDeck. The best first PR is small, useful, and easy to review.
 
+Not sure where things live? Read the one-page [architecture map](ARCHITECTURE_MAP.md) first.
+
 ## Quick path
 
 1. Pick an issue labeled [`good first issue`](https://github.com/tiagofur/dev_deck/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) or [`help wanted`](https://github.com/tiagofur/dev_deck/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22).

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,0 +1,45 @@
+# DevDeck — Known Limitations
+
+> Honest limitations of the **0.5.0 Public Beta** · Last updated: June 2026
+>
+> Trust before hype: this page exists so nobody discovers a limitation the hard way. If you hit something not listed here, please [open an issue](https://github.com/tiagofur/dev_deck/issues).
+
+---
+
+## Sync and offline
+
+- **There is no offline-first sync yet.** DevDeck runs in honest cloud mode: the app needs to reach the API to read and write your vault. Offline sync (local SQLite + conflict resolution) is intentionally deferred until after `1.0.0` (see [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md), decision A5).
+- **Workbench utilities do run fully local.** JSON formatter, JWT decoder, Base64/URL tools, UUID/timestamp, hashes, regex tester, and the secret scanner work in-app without network access.
+- **Full vault export is not available yet.** Today only cheatsheets and decks can be exported; a complete vault export/backup (JSON + Markdown) is tracked in #122.
+
+## AI features
+
+- **AI enrichment requires a configured provider.** Summaries, smart tags, semantic search, and Ask DevDeck need OpenAI, Ollama, or another supported provider. Without one, DevDeck uses a built-in heuristic tagger and text/fuzzy search, and the interactive AI surfaces are hidden rather than shown as dead buttons.
+- **Heuristic tagging is more limited** than provider-backed enrichment: it works from URL patterns, metadata, and keywords, not from understanding content.
+- **The weekly digest currently depends on an AI provider** for its summary. A no-AI fallback is tracked in #115.
+
+## Search
+
+- **Semantic ("by intent") search needs pgvector plus embeddings** from a configured provider. Without them, search falls back to text and fuzzy matching — still fast, but it matches words, not meaning.
+
+## Social and team features
+
+- **Circles are built for groups.** Solo users can create one, but the value appears when a team or community shares findings. Activity feed, reactions, and Circle digests are planned for `0.7.x`.
+- **Explore/Trending depends on a community** and may look sparse while the user base grows.
+- **Organizations, SAML SSO, and SCIM exist in the backend** but their UI is hidden unless you belong to an org. They are early enterprise capabilities, not polished products.
+
+## Platform
+
+- **The web API tester is subject to browser CORS.** The Desktop app sends requests from the Electron main process, so CORS does not apply there.
+- **Desktop global shortcuts can conflict** with other apps; the shortcuts modal shows registration status and lets you change them.
+- **Runbooks document commands but do not execute them.** Local command execution requires a security model we have not shipped yet.
+- **No mobile app, PWA, or mobile share target yet.**
+
+## Self-hosting
+
+- **Postgres 16 with the pgvector extension is required** (the provided `deploy/` compose files use `pgvector/pgvector:pg16`).
+- **This is a beta:** API routes and database schema may still change before `1.0.0`. Migrations are provided, but back up your database before upgrading.
+
+---
+
+See the [ROADMAP](../ROADMAP.md) for what is being worked on, and [SELF_HOSTING.md](SELF_HOSTING.md) for deployment details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,90 @@
+# DevDeck — Documentation
+
+> Documentation index for the project. All docs live in this folder (`docs/`).
+>
+> [Leer en español](README.es.md)
+
+---
+
+## Product documentation
+
+| File | Description |
+|------|-------------|
+| [PRD.md](PRD.md) | **Product Requirements Document.** Vision, problem, layered solution (polymorphic vault + intelligent retrieval + reusable actions), pillars, scope (core + Workbench + out of scope), and success metrics. Main entry point to understand the product. |
+| [VISION.md](VISION.md) | **Vision and positioning.** What DevDeck is (and is not), genuine differentiators, target audience, and current focus. |
+| [DEV_WORKBENCH.md](DEV_WORKBENCH.md) | **Developer Workbench.** From memory to contextual action: local utilities, palette, reusable requests, product boundaries, and per-phase status. |
+| [CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md) | **Circles and community contribution.** Product model for turning individual findings into reusable memory for groups/communities of developers. |
+| [COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md) | **Competitive analysis.** Comparison against GitHub Stars, Raindrop, Pocket, Notion, Obsidian, and Raycast. |
+| [LIMITATIONS.md](LIMITATIONS.md) | **Known limitations.** Honest list of what the 0.5.0 Public Beta does not do yet. |
+
+---
+
+## Landing page documentation
+
+| File | Description |
+|------|-------------|
+| [LANDING_COPY.md](LANDING_COPY.md) | **Landing copy in English.** Full copy for `devdeck.ai` (global developer audience): hero, features, AI section, platforms, pricing, CTA, SEO tags, and implementation notes. |
+| [LANDING.md](LANDING.md) | **Landing copy in Spanish.** Same structure for the Spanish-speaking audience, plus extra micro-copy for the app UI. |
+
+---
+
+## Technical documentation
+
+| File | Description |
+|------|-------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | **System architecture.** High-level diagram, stack (Go + Chi + Postgres + pgvector; pnpm monorepo with Electron + React desktop and React web sharing `@devdeck/ui` / `@devdeck/api-client` / `@devdeck/features`), architecture decisions, and database schema. |
+| [ARCHITECTURE_MAP.md](ARCHITECTURE_MAP.md) | **Architecture map for contributors.** One-page orientation: request flow, monorepo layout, where to change what, and how to verify before a PR. |
+| [VERSIONING.md](VERSIONING.md) | **Versioning and releases.** SemVer, release strategy, Conventional Commits, changelog, release scripts, and auto-release GitHub Actions. |
+| [adr/0001-items-polymorphism.md](adr/0001-items-polymorphism.md) | **ADR 0001.** Polymorphic `items` model (single table + JSONB + generated columns). |
+| [adr/0002-sync-strategy.md](adr/0002-sync-strategy.md) | **ADR 0002.** Offline-first sync strategy. |
+| [adr/0003-monorepo-pnpm-workspaces.md](adr/0003-monorepo-pnpm-workspaces.md) | **ADR 0003.** pnpm workspaces monorepo + web client migration from Vue 3 to React 18. |
+| [TECHNICAL_ROADMAP_AI_OFFLINE.md](TECHNICAL_ROADMAP_AI_OFFLINE.md) | **Detailed technical roadmap.** Implementation plan for offline-first (local SQLite + sync engine), embeddings + vector search, and multi-user. |
+| [API.md](API.md) | **REST API reference.** Endpoint specification (`/api/repos`, `/api/cheatsheets`, `/api/search`, `/api/auth`, etc.). |
+| [DESIGN_SYSTEM.md](DESIGN_SYSTEM.md) | **Design system.** CSS tokens, neo-brutalist palette, typography, components, Snarkel mascot states, and UI design principles. |
+| [CAPTURE.md](CAPTURE.md) | **Multi-channel capture.** How capture works from the CLI, extension, paste interceptor, and the `/api/items/capture` endpoint. |
+| [SELF_HOSTING.md](SELF_HOSTING.md) | **Self-hosting guide.** Docker Compose + Caddy deployment, environment variables, migrations, and verification. |
+| [TESTING_STRATEGY.md](TESTING_STRATEGY.md) | **Testing and CI strategy.** Backend tests, frontend unit tests, E2E, and the GitHub Actions pipeline. |
+
+---
+
+## Community and launch
+
+| File | Description |
+|------|-------------|
+| [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md) | **First contribution.** Short path to a first issue-backed PR. |
+| [DISCUSSIONS.md](DISCUSSIONS.md) | **GitHub Discussions guide.** Categories and how to participate. |
+| [SUPPORT.md](SUPPORT.md) | **Support and sustainability.** What project support funds and future sustainability paths. |
+| [LAUNCH_KIT.md](LAUNCH_KIT.md) | **Launch kit.** Per-channel copy, launch checklist, and follow-up plan. |
+
+---
+
+## Reviews and audits (historical)
+
+> Dated snapshots. For current product state, always check the [ROADMAP](../ROADMAP.md).
+
+| File | Description |
+|------|-------------|
+| [REVIEW_2026_04.md](REVIEW_2026_04.md) | **Technical review (April 2026).** Hardening, capture, and testing debt — origin of Wave 4.5. |
+| [APP_AUDIT_2026_05.md](APP_AUDIT_2026_05.md) | **App audit (May 2026).** Full feature inventory, user-impact classification, and the P0–P2 progressive disclosure plan. |
+| [APP_AUDIT_REVIEW_2026_05.md](APP_AUDIT_REVIEW_2026_05.md) | **Audit verification (May 2026).** Evidence for the P0/P1 work and the community plan around Circles. |
+| [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md) | **Product and docs review (June 2026).** Yes/no decision menu on app and docs improvements; origin of issues #113–#130. |
+
+---
+
+## How to read this documentation
+
+If you are new here, the recommended order is:
+
+1. **[README.md](../README.md)** — what DevDeck is in 2 minutes
+2. **[VISION.md](VISION.md)** — why it exists and for whom
+3. **[PRD.md](PRD.md)** — what it does and what was decided
+4. **[DEV_WORKBENCH.md](DEV_WORKBENCH.md)** — memory + action, with per-phase status
+5. **[CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md)** — how findings become community memory
+6. **[ARCHITECTURE_MAP.md](ARCHITECTURE_MAP.md)** — how it is built, in one page
+7. **[ROADMAP.md](../ROADMAP.md)** — what is done and what comes next
+
+To contribute or extend the product:
+
+- Start with [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md) and pick an approved `good first issue`.
+- Keep ROADMAP.md updated when you complete roadmap items.
+- Keep ARCHITECTURE.md in sync with infra/schema changes.


### PR DESCRIPTION
Closes #129

Adds the three missing docs identified in the June 2026 review (`docs/FEATURE_REVIEW_2026_06.md`, items B2.1–B2.3). Two of them are unchecked ROADMAP 0.5.x items.

## Changes

- **`docs/LIMITATIONS.md`** — honest known-limitations page for the 0.5.0 Public Beta: no offline-first sync yet (deferred post-1.0, decision A5), AI features require a configured provider (heuristic fallback otherwise), semantic search needs pgvector + embeddings, social features need a community, web API tester is subject to CORS, runbooks don't execute commands, self-hosting requirements, and beta schema/API stability. Linked from the README docs table.
- **`docs/ARCHITECTURE_MAP.md`** — one-page contributor orientation: big-picture diagram, backend layout (`router → handler → store → Postgres`), monorepo packages, a "where to change what" table, and pre-PR verification commands. Linked from the README docs table and `FIRST_CONTRIBUTION.md`.
- **`docs/README.md`** — English documentation index (the index previously existed only in Spanish), including sections for community/launch docs and historical reviews/audits.

## Notes

- The corresponding ROADMAP 0.5.x checkboxes ("Document known limitations clearly", "Add a short architecture map") and the Spanish index entries are intentionally **not** touched here to avoid conflicting with #131, which edits those files. They can be ticked in the follow-up for #130 once both PRs merge.

## Verification

Docs-only change. All relative links added in this PR were checked against existing files.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_