### PR TITLE
refactor(profile): extract reputation and achievements domain logic

### DIFF
--- a/packages/features/src/components/Profile/reputation.test.ts
+++ b/packages/features/src/components/Profile/reputation.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { calculateReputation, buildAchievements, REPUTATION_POINTS } from './reputation'
+
+const t = (key: string) => key
+
+describe('calculateReputation', () => {
+  it('returns 0 for a brand new user', () => {
+    expect(calculateReputation({ totalItems: 0, decksCount: 0, streakDays: 0 })).toBe(0)
+  })
+
+  it('weights items, decks, and streak days', () => {
+    const expected =
+      10 * REPUTATION_POINTS.item + 2 * REPUTATION_POINTS.deck + 3 * REPUTATION_POINTS.streakDay
+    expect(calculateReputation({ totalItems: 10, decksCount: 2, streakDays: 3 })).toBe(expected)
+  })
+})
+
+describe('buildAchievements', () => {
+  it('always unlocks early_adopter', () => {
+    const achievements = buildAchievements({ totalItems: 0, decksCount: 0, streakDays: 0 }, t)
+    expect(achievements.find((a) => a.id === 'early_adopter')?.unlocked).toBe(true)
+  })
+
+  it('keeps threshold achievements locked below their thresholds', () => {
+    const achievements = buildAchievements({ totalItems: 4, decksCount: 0, streakDays: 0 }, t)
+    expect(achievements.find((a) => a.id === 'curator_master')?.unlocked).toBe(false)
+    expect(achievements.find((a) => a.id === 'deck_builder')?.unlocked).toBe(false)
+    expect(achievements.find((a) => a.id === 'flame_keeper')?.unlocked).toBe(false)
+  })
+
+  it('unlocks curator_master at 5 items, deck_builder at 1 deck, flame_keeper at 1 streak day', () => {
+    const achievements = buildAchievements({ totalItems: 5, decksCount: 1, streakDays: 1 }, t)
+    expect(achievements.find((a) => a.id === 'curator_master')?.unlocked).toBe(true)
+    expect(achievements.find((a) => a.id === 'deck_builder')?.unlocked).toBe(true)
+    expect(achievements.find((a) => a.id === 'flame_keeper')?.unlocked).toBe(true)
+  })
+
+  it('resolves descriptions through the translator', () => {
+    const achievements = buildAchievements({ totalItems: 0, decksCount: 0, streakDays: 0 }, t)
+    expect(achievements.map((a) => a.description)).toEqual([
+      'profile.achievement_early_adopter_desc',
+      'profile.achievement_curator_master_desc',
+      'profile.achievement_deck_builder_desc',
+      'profile.achievement_flame_keeper_desc'
+    ])
+  })
+})

--- a/packages/features/src/components/Profile/reputation.ts
+++ b/packages/features/src/components/Profile/reputation.ts
@@ -1,0 +1,61 @@
+import type { Achievement } from './ReputationDashboard'
+
+export interface ReputationInputs {
+  totalItems: number
+  decksCount: number
+  streakDays: number
+}
+
+export const REPUTATION_POINTS = {
+  item: 5,
+  deck: 15,
+  streakDay: 50
+} as const
+
+export function calculateReputation({ totalItems, decksCount, streakDays }: ReputationInputs): number {
+  return (
+    totalItems * REPUTATION_POINTS.item +
+    decksCount * REPUTATION_POINTS.deck +
+    streakDays * REPUTATION_POINTS.streakDay
+  )
+}
+
+export function buildAchievements(
+  { totalItems, decksCount, streakDays }: ReputationInputs,
+  t: (key: string) => string
+): Achievement[] {
+  return [
+    {
+      id: 'early_adopter',
+      title: 'Early Adopter',
+      description: t('profile.achievement_early_adopter_desc'),
+      icon: '🚀',
+      unlocked: true,
+      color: 'bg-accent-yellow'
+    },
+    {
+      id: 'curator_master',
+      title: 'Curator Master',
+      description: t('profile.achievement_curator_master_desc'),
+      icon: '🛡️',
+      unlocked: totalItems >= 5,
+      color: 'bg-accent-cyan'
+    },
+    {
+      id: 'deck_builder',
+      title: 'Deck Builder',
+      description: t('profile.achievement_deck_builder_desc'),
+      icon: '🏗️',
+      unlocked: decksCount >= 1,
+      color: 'bg-accent-pink'
+    },
+    {
+      id: 'flame_keeper',
+      title: 'Flame Keeper',
+      description: t('profile.achievement_flame_keeper_desc'),
+      icon: '🔥',
+      unlocked: streakDays >= 1,
+      color: 'bg-accent-lime'
+    }
+  ]
+}

--- a/packages/features/src/pages/ProfilePage.tsx
+++ b/packages/features/src/pages/ProfilePage.tsx
@@ -26,6 +26,7 @@ import { useTranslation } from '@devdeck/i18n'
 // Import modular presentational components
 import { EditProfileModal } from '../components/Profile/EditProfileModal'
 import { ReputationDashboard } from '../components/Profile/ReputationDashboard'
+import { calculateReputation, buildAchievements } from '../components/Profile/reputation'
 import { TechStackSection } from '../components/Profile/TechStackSection'
 import { ActivityTimeline } from '../components/Profile/ActivityTimeline'
 import { UserAvatar } from '../components/UserAvatar'
@@ -72,45 +73,14 @@ export function ProfilePage() {
     )
   }
 
-  // Calculate Gamified Reputation Points
   const totalItemsCount = itemsRes?.total || 0
-  const reputation = (totalItemsCount * 5) + (decks.length * 15) + ((stats?.streak_days || 0) * 50)
-
-  // Achievements evaluation
-  const achievements = [
-    {
-      id: 'early_adopter',
-      title: 'Early Adopter',
-      description: t('profile.achievement_early_adopter_desc'),
-      icon: '🚀',
-      unlocked: true,
-      color: 'bg-accent-yellow'
-    },
-    {
-      id: 'curator_master',
-      title: 'Curator Master',
-      description: t('profile.achievement_curator_master_desc'),
-      icon: '🛡️',
-      unlocked: totalItemsCount >= 5,
-      color: 'bg-accent-cyan'
-    },
-    {
-      id: 'deck_builder',
-      title: 'Deck Builder',
-      description: t('profile.achievement_deck_builder_desc'),
-      icon: '🏗️',
-      unlocked: decks.length >= 1,
-      color: 'bg-accent-pink'
-    },
-    {
-      id: 'flame_keeper',
-      title: 'Flame Keeper',
-      description: t('profile.achievement_flame_keeper_desc'),
-      icon: '🔥',
-      unlocked: (stats?.streak_days || 0) >= 1,
-      color: 'bg-accent-lime'
-    }
-  ]
+  const reputationInputs = {
+    totalItems: totalItemsCount,
+    decksCount: decks.length,
+    streakDays: stats?.streak_days || 0
+  }
+  const reputation = calculateReputation(reputationInputs)
+  const achievements = buildAchievements(reputationInputs, t)
 
   const recentItems = itemsRes?.items || []
 


### PR DESCRIPTION
Closes #116

Finishes the ProfilePage simplification left "mostly done" by the May audit review (P1.7): the page no longer owns scoring rules.

## Changes

- New `packages/features/src/components/Profile/reputation.ts`: pure domain module with `calculateReputation` (items × 5 + decks × 15 + streak days × 50, now expressed via a `REPUTATION_POINTS` constant) and `buildAchievements` (threshold evaluation for the four achievements).
- `ProfilePage.tsx` consumes the module instead of computing reputation/achievements inline (~40 lines of domain logic removed from the page).
- New `reputation.test.ts` with 6 unit tests covering the formula, unlock thresholds, and translator pass-through.

## Notes on avatar/crop coverage

The review also suggested covering the avatar/crop flow. Avatar rendering and fallback behavior is already covered by `UserAvatar.test.tsx` (added with #110/#111). `CropModal` UI testing was evaluated and intentionally skipped: the component is canvas-2D dependent and would require mocking the entire drawing context in jsdom for very little signal.

## Verification

- `tsc --noEmit -p packages/features/tsconfig.json` — passes.
- `vitest run src/components/Profile/reputation.test.ts` — 6/6 tests pass.
- Behavior-identical refactor: same formula, same thresholds, same rendered props.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_