### PR TITLE
feat(orgs): guided empty states for team pages without an active org

### DIFF
--- a/packages/features/src/components/OrgRequiredEmptyState.tsx
+++ b/packages/features/src/components/OrgRequiredEmptyState.tsx
@@ -1,0 +1,59 @@
+import { useNavigate } from 'react-router-dom'
+import { Plus, Users } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { setPreferences, useCreateOrg } from '@devdeck/api-client'
+import { Button, showToast } from '@devdeck/ui'
+import { useTranslation } from '@devdeck/i18n'
+import { AppShell } from './AppShell'
+
+export interface OrgRequiredEmptyStateProps {
+  /** Page-specific explanation of what this team surface does. */
+  description: string
+}
+
+/**
+ * Guided empty state for team/org-only pages reached without an active org.
+ * Explains the surface and offers the real path in: create a team or switch
+ * to one from the workspace switcher.
+ */
+export function OrgRequiredEmptyState({ description }: OrgRequiredEmptyStateProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const createOrg = useCreateOrg()
+  const qc = useQueryClient()
+
+  const handleCreate = async () => {
+    const name = window.prompt(t('workspace.team_name_prompt'))
+    if (!name) return
+    try {
+      const newOrg = await createOrg.mutateAsync(name)
+      setPreferences({ activeOrgId: newOrg.id })
+      qc.invalidateQueries()
+    } catch (err) {
+      showToast((err as Error).message || t('common.error'), 'error')
+    }
+  }
+
+  return (
+    <AppShell contentClassName="flex-1 p-12 text-center flex flex-col items-center justify-center gap-4 bg-bg-primary">
+      <Users size={48} strokeWidth={3} className="text-accent-pink" />
+      <h2 className="font-display font-black text-2xl uppercase">{t('feed.org_required_title')}</h2>
+      <p className="text-ink-soft font-mono text-sm max-w-md">{description}</p>
+      <p className="text-ink-soft font-mono text-xs max-w-md">{t('feed.org_required_hint')}</p>
+      <div className="flex flex-wrap items-center justify-center gap-3 mt-2">
+        <Button
+          onClick={handleCreate}
+          variant="accent"
+          className="flex items-center gap-2"
+          disabled={createOrg.isPending}
+        >
+          <Plus size={16} strokeWidth={3} />
+          {t('feed.create_team')}
+        </Button>
+        <Button onClick={() => navigate('/')} variant="secondary">
+          {t('feed.back_to_personal')}
+        </Button>
+      </div>
+    </AppShell>
+  )
+}

--- a/packages/features/src/pages/TeamFeedPage.tsx
+++ b/packages/features/src/pages/TeamFeedPage.tsx
@@ -9,9 +9,9 @@ import {
   User as UserIcon
 } from 'lucide-react'
 import { useOrgFeed, usePreferences, type ActivityEntry } from '@devdeck/api-client'
-import { Button } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
 import { AppShell } from '../components/AppShell'
+import { OrgRequiredEmptyState } from '../components/OrgRequiredEmptyState'
 
 export function TeamFeedPage() {
   const { t } = useTranslation()
@@ -21,13 +21,7 @@ export function TeamFeedPage() {
   const events = data?.events || []
 
   if (!activeOrgId) {
-    return (
-      <AppShell contentClassName="flex-1 p-12 text-center flex flex-col items-center justify-center gap-4 bg-bg-primary">
-        <h2 className="font-display font-black text-2xl uppercase">{t('feed.access_denied')}</h2>
-        <p className="text-ink-soft font-mono text-sm">{t('feed.only_org_desc')}</p>
-        <Button onClick={() => navigate('/')}>{t('feed.back_to_personal')}</Button>
-      </AppShell>
-    )
+    return <OrgRequiredEmptyState description={t('feed.only_org_desc')} />
   }
 
   return (

--- a/packages/features/src/pages/TeamReviewPage.test.tsx
+++ b/packages/features/src/pages/TeamReviewPage.test.tsx
@@ -106,7 +106,7 @@ describe('<TeamReviewPage>', () => {
     expect(mocks.navigate).toHaveBeenCalledWith('/items/item-1')
   })
 
-  it('renders access denied if there is no active org configured', async () => {
+  it('renders guided org-required state if there is no active org configured', async () => {
     const user = userEvent.setup()
     mocks.usePreferences.mockReturnValue({ activeOrgId: null })
     mocks.useItems.mockReturnValue({
@@ -117,12 +117,17 @@ describe('<TeamReviewPage>', () => {
 
     renderPage()
 
-    expect(screen.getByText('Access Denied')).toBeInTheDocument()
-    expect(screen.getByText('The Team Feed is only available within an organization.')).toBeInTheDocument()
+    expect(screen.getByText('No Active Team')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Team Review is a shared curation queue where your organization triages items marked for review. It needs an active team workspace.',
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Create a Team/i })).toBeInTheDocument()
 
     const backButton = screen.getByRole('button', { name: 'Back to Personal Vault' })
     expect(backButton).toBeInTheDocument()
-    
+
     await user.click(backButton)
     expect(mocks.navigate).toHaveBeenCalledWith('/')
   })

--- a/packages/features/src/pages/TeamReviewPage.tsx
+++ b/packages/features/src/pages/TeamReviewPage.tsx
@@ -5,6 +5,7 @@ import { useItems, usePreferences } from '@devdeck/api-client'
 import { ItemCard } from '../components/ItemCard'
 import { detailPathForItem } from '../utils/itemRoutes'
 import { AppShell } from '../components/AppShell'
+import { OrgRequiredEmptyState } from '../components/OrgRequiredEmptyState'
 import { useTranslation } from '@devdeck/i18n'
 
 export function TeamReviewPage() {
@@ -19,13 +20,7 @@ export function TeamReviewPage() {
   const items = data?.items ?? []
 
   if (!activeOrgId) {
-    return (
-      <AppShell contentClassName="flex-1 p-12 text-center flex flex-col items-center justify-center gap-4 bg-bg-primary">
-        <h2 className="font-display font-black text-2xl uppercase">{t('feed.access_denied')}</h2>
-        <p className="text-ink-soft font-mono text-sm">{t('feed.only_org_desc')}</p>
-        <Button type="button" onClick={() => navigate('/')}>{t('feed.back_to_personal')}</Button>
-      </AppShell>
-    )
+    return <OrgRequiredEmptyState description={t('review.org_required_desc')} />
   }
 
   return (

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -405,7 +405,8 @@
     "empty_desc": "When you capture something important, mark it for review to bring it to this queue.",
     "waiting_count": "{{count}} items waiting for review",
     "view_all": "View all",
-    "go_to_items": "Go to items"
+    "go_to_items": "Go to items",
+    "org_required_desc": "Team Review is a shared curation queue where your organization triages items marked for review. It needs an active team workspace."
   },
   "waitlist": {
     "title": "Join the Waitlist",
@@ -425,7 +426,10 @@
     "view_more": "View more",
     "team_title": "Team Activity Feed",
     "access_denied": "Access Denied",
-    "only_org_desc": "The Team Feed is only available within an organization.",
+    "only_org_desc": "The Team Feed shows what your organization saves, updates, and curates. It needs an active team workspace.",
+    "org_required_title": "No Active Team",
+    "org_required_hint": "Create a team below, or pick one from the workspace switcher in the top bar. Your personal vault stays separate.",
+    "create_team": "Create a Team",
     "back_to_personal": "Back to Personal Vault",
     "connecting": "Connecting to activity stream...",
     "no_team_activity": "No activity in this team yet.",


### PR DESCRIPTION
Closes #127

Closes the gap noted in the May audit review: the org-gated routes showed a generic "Access Denied" with no explanation of how to actually get a team.

## Changes

- New shared `OrgRequiredEmptyState` component: explains what the team surface does, then offers the real path in — a **Create a Team** button (same `useCreateOrg` + workspace-switch flow the Topbar switcher uses, including activating the new org and invalidating queries) plus the existing "Back to Personal Vault" action. A hint points to the workspace switcher in the top bar.
- `TeamFeedPage` and `TeamReviewPage` use it instead of their duplicated "Access Denied" blocks, each with surface-specific copy (`feed.only_org_desc` reworded; new `review.org_required_desc`).
- New i18n keys: `feed.org_required_title`, `feed.org_required_hint`, `feed.create_team`, `review.org_required_desc`.
- Updated `TeamReviewPage.test.tsx` for the new guided state (title, description, create-team button, back navigation).

## Verified gating (second half of the issue)

`SettingsPage` already renders SAML, SCIM, and Org Insights only when `prefs.activeOrgId` exists — no enterprise surface leaks for org-less users. No changes needed there.

## Verification

- `tsc --noEmit` passes for `packages/features`, `apps/desktop`, and `apps/web`.
- `vitest run src/pages/TeamReviewPage.test.tsx` — 3/3 tests pass.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_