### PR TITLE
docs: archive historical reviews and define bilingual docs policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,5 +28,6 @@ Closes #
 - [ ] Kept the PR small and focused
 - [ ] Included tests or a clear verification note
 - [ ] Updated docs if behavior changed
+- [ ] If I changed a doc with a language counterpart (`*.es.md`), I updated it too or flagged it as translation-pending
 - [ ] Used a conventional commit message
 - [ ] No `Co-Authored-By` or AI attribution trailers

--- a/README.es.md
+++ b/README.es.md
@@ -87,7 +87,9 @@ Ambas apps importan pages y componentes del package `@devdeck/features` — solo
 | [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Guía paso a paso para self-host |
 | [docs/CAPTURE.md](docs/CAPTURE.md) | Spec de canales de captura (extensión, CLI, paste, share) |
 | [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Plan de tests y CI |
-| [docs/REVIEW_2026_04.md](docs/REVIEW_2026_04.md) | **Review técnico de abril 2026** — motiva Ola 4.5 |
+| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | Limitaciones conocidas de la 0.5.0 Public Beta |
+| [docs/ARCHITECTURE_MAP.md](docs/ARCHITECTURE_MAP.md) | Mapa de arquitectura en una página para contribuidores |
+| [docs/archive/REVIEW_2026_04.md](docs/archive/REVIEW_2026_04.md) | **Review técnico de abril 2026** — motiva Ola 4.5 |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Cómo contribuir |
 | [SECURITY.md](SECURITY.md) | Política de seguridad |
 

--- a/ROADMAP.es.md
+++ b/ROADMAP.es.md
@@ -29,7 +29,7 @@ Fortalecer la captura, recuperación y reutilización diaria del conocimiento gu
 
 ## 🌊 Ola 4.5 — Hardening & Capture (NUEVO)
 
-> **Por qué existe esta ola:** la review de abril 2026 (ver `docs/REVIEW_2026_04.md`) identificó dos riesgos bloqueantes para Ola 5: (1) cero tests, (2) captura con fricción. Esta ola atiende ambos en ~4 semanas y deja la base lista para iterar rápido.
+> **Por qué existe esta ola:** la review de abril 2026 (ver `docs/archive/REVIEW_2026_04.md`) identificó dos riesgos bloqueantes para Ola 5: (1) cero tests, (2) captura con fricción. Esta ola atiende ambos en ~4 semanas y deja la base lista para iterar rápido.
 
 ### Fase 16.5 — Higiene de repo ✅
 - Remover `backend/api.exe` y agregar `*.exe`, `api`, `api.bin` a `.gitignore`. ✅
@@ -327,7 +327,7 @@ Fortalecer la captura, recuperación y reutilización diaria del conocimiento gu
 > - Modelo polimórfico de `items`: **Opción A (single-table + JSONB + generated columns)**. Ver `docs/adr/0001-items-polymorphism.md`.
 > - Quick capture: endpoint `POST /api/items/capture` ya existe desde Ola 4.5. Ola 5 solo expande tipos soportados.
 > - IA: Ollama como default, OpenAI opt-in. Rate limits obligatorios desde el primer endpoint (ver Fase 18).
-> - Búsqueda híbrida: RRF (Reciprocal Rank Fusion), no ponderación lineal. Ver `docs/REVIEW_2026_04.md §3.2`.
+> - Búsqueda híbrida: RRF (Reciprocal Rank Fusion), no ponderación lineal. Ver `docs/archive/REVIEW_2026_04.md §3.2`.
 
 > **Objetivo:** convertir DevDeck de directorio de repos a knowledge OS para developers. Justificar el `.ai` con features de IA que resuelven fricción real, no decorativas.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ The priority before a stable `1.0.0` is not more hype. It is trust:
 - stable capture/search/workbench/Circles flows,
 - and a contributor path that makes small PRs easy.
 
-Offline-first sync is intentionally deferred until after `1.0.0` (see [docs/FEATURE_REVIEW_2026_06.md](docs/FEATURE_REVIEW_2026_06.md), decision A5). Today DevDeck runs in honest cloud mode; Workbench utilities work fully local, and a full vault export (#122) covers data ownership in the meantime.
+Offline-first sync is intentionally deferred until after `1.0.0` (see [docs/archive/FEATURE_REVIEW_2026_06.md](docs/archive/FEATURE_REVIEW_2026_06.md), decision A5). Today DevDeck runs in honest cloud mode; Workbench utilities work fully local, and a full vault export (#122) covers data ownership in the meantime.
 
 ---
 
@@ -32,7 +32,7 @@ Offline-first sync is intentionally deferred until after `1.0.0` (see [docs/FEAT
 - [x] Position DevDeck honestly as `0.5.0 Public Beta`.
 - [x] Add screenshots and/or a short demo GIF.
 - [ ] Add realistic demo/seed data for a first-run experience (#117).
-- [ ] Document known limitations clearly (#129).
+- [x] Document known limitations clearly (#129).
 - [ ] Verify local setup on a clean machine.
 
 ### Core developer memory loop
@@ -66,7 +66,7 @@ Offline-first sync is intentionally deferred until after `1.0.0` (see [docs/FEAT
 - [x] Add contributor call-to-action in README.
 - [x] Add best-first-contribution guidance.
 - [ ] Create at least 5 `good first issue` tasks.
-- [ ] Add a short architecture map for new contributors (#129).
+- [x] Add a short architecture map for new contributors (#129).
 - [ ] Keep PRs small, issue-backed, and CI-verified.
 
 ---

--- a/docs/COMPETITIVE_ANALYSIS.es.md
+++ b/docs/COMPETITIVE_ANALYSIS.es.md
@@ -2,7 +2,7 @@
 
 > Versión: 1.1 · Owner: tfurt · Última actualización: 2026-06-10
 
-> **Nota de estado (junio 2026):** las menciones a "offline-first" en este documento describen la dirección de producto, no el estado actual. El sync offline está pospuesto a post-1.0; hoy la app funciona en cloud mode (las utilities del Workbench sí corren 100% local, sin red). La IA (resúmenes, tags, búsqueda semántica) requiere un provider configurado (OpenAI u Ollama local); sin provider, DevDeck usa un tagger heurístico integrado. Ver [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md) (decisión A5) y el [ROADMAP](../ROADMAP.md).
+> **Nota de estado (junio 2026):** las menciones a "offline-first" en este documento describen la dirección de producto, no el estado actual. El sync offline está pospuesto a post-1.0; hoy la app funciona en cloud mode (las utilities del Workbench sí corren 100% local, sin red). La IA (resúmenes, tags, búsqueda semántica) requiere un provider configurado (OpenAI u Ollama local); sin provider, DevDeck usa un tagger heurístico integrado. Ver [FEATURE_REVIEW_2026_06.md](archive/FEATURE_REVIEW_2026_06.md) (decisión A5) y el [ROADMAP](../ROADMAP.md).
 
 ---
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -8,7 +8,7 @@
 
 ## Sync and offline
 
-- **There is no offline-first sync yet.** DevDeck runs in honest cloud mode: the app needs to reach the API to read and write your vault. Offline sync (local SQLite + conflict resolution) is intentionally deferred until after `1.0.0` (see [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md), decision A5).
+- **There is no offline-first sync yet.** DevDeck runs in honest cloud mode: the app needs to reach the API to read and write your vault. Offline sync (local SQLite + conflict resolution) is intentionally deferred until after `1.0.0` (see [FEATURE_REVIEW_2026_06.md](archive/FEATURE_REVIEW_2026_06.md), decision A5).
 - **Workbench utilities do run fully local.** JSON formatter, JWT decoder, Base64/URL tools, UUID/timestamp, hashes, regex tester, and the secret scanner work in-app without network access.
 - **Full vault export is not available yet.** Today only cheatsheets and decks can be exported; a complete vault export/backup (JSON + Markdown) is tracked in #122.
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -13,6 +13,7 @@
 | [DEV_WORKBENCH.md](DEV_WORKBENCH.md) · [DEV_WORKBENCH.es.md](DEV_WORKBENCH.es.md) | **Developer Workbench.** Evolución de memoria a acción contextual: utilities locales, paleta, requests reutilizables, límites de producto y roadmap recomendado. |
 | [CIRCLES_COMMUNITY.md](CIRCLES_COMMUNITY.md) · [CIRCLES_COMMUNITY.es.md](CIRCLES_COMMUNITY.es.md) | **Circles y contribución comunitaria.** Modelo de producto para convertir hallazgos individuales en memoria reutilizable para grupos/comunidades de developers. |
 | [COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md) | **Análisis competitivo.** Comparación detallada con GitHub Stars, Raindrop, Pocket, Notion, Obsidian, Raycast y Pieces.app. Incluye tablas de pros/contras y posicionamiento relativo. |
+| [LIMITATIONS.md](LIMITATIONS.md) | **Limitaciones conocidas.** Lista honesta de lo que la 0.5.0 Public Beta todavía no hace. |
 
 ---
 
@@ -30,6 +31,7 @@
 | Archivo | Descripción |
 |---------|-------------|
 | [ARCHITECTURE.es.md](ARCHITECTURE.es.md) | **Arquitectura del sistema.** Diagrama de alto nivel, stack técnico (Go + Chi + Postgres + pgvector, monorepo pnpm workspaces con Electron + React desktop y React web que comparten `@devdeck/ui` / `@devdeck/api-client` / `@devdeck/features`), decisiones de arquitectura y schema de la base de datos. |
+| [ARCHITECTURE_MAP.md](ARCHITECTURE_MAP.md) | **Mapa de arquitectura para contribuidores.** Orientación en una página: flujo de requests, layout del monorepo, dónde cambiar qué y cómo verificar antes de un PR. |
 | [VERSIONING.es.md](VERSIONING.es.md) | **Versionado y release.** Sistema de versionado SemVer, estrategia de release, Conventional Commits, changelog (Keep a Changelog), scripts de release, GitHub Actions para auto-release. |
 | [adr/0001-items-polymorphism.es.md](adr/0001-items-polymorphism.es.md) | **ADR 0001.** Modelo polimórfico de `items` (single-table + JSONB + generated columns). |
 | [adr/0002-sync-strategy.es.md](adr/0002-sync-strategy.es.md) | **ADR 0002.** Estrategia de sync offline-first. |
@@ -60,10 +62,10 @@
 
 | Archivo | Descripción |
 |---------|-------------|
-| [REVIEW_2026_04.md](REVIEW_2026_04.md) | **Review técnica (abril 2026).** Hardening, captura y deuda de testing — origen de la Ola 4.5. |
-| [APP_AUDIT_2026_05.md](APP_AUDIT_2026_05.md) | **Auditoría de app (mayo 2026).** Inventario completo de features, clasificación por impacto de usuario y plan P0–P2 de progressive disclosure. |
-| [APP_AUDIT_REVIEW_2026_05.md](APP_AUDIT_REVIEW_2026_05.md) | **Verificación de la auditoría (mayo 2026).** Evidencia del trabajo P0/P1 y plan de comunidad alrededor de Circles. |
-| [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md) | **Revisión de producto y docs (junio 2026).** Menú de decisiones Sí/No sobre mejoras de app y documentación; origen de los issues #113–#130. |
+| [REVIEW_2026_04.md](archive/REVIEW_2026_04.md) | **Review técnica (abril 2026).** Hardening, captura y deuda de testing — origen de la Ola 4.5. |
+| [APP_AUDIT_2026_05.md](archive/APP_AUDIT_2026_05.md) | **Auditoría de app (mayo 2026).** Inventario completo de features, clasificación por impacto de usuario y plan P0–P2 de progressive disclosure. |
+| [APP_AUDIT_REVIEW_2026_05.md](archive/APP_AUDIT_REVIEW_2026_05.md) | **Verificación de la auditoría (mayo 2026).** Evidencia del trabajo P0/P1 y plan de comunidad alrededor de Circles. |
+| [FEATURE_REVIEW_2026_06.md](archive/FEATURE_REVIEW_2026_06.md) | **Revisión de producto y docs (junio 2026).** Menú de decisiones Sí/No sobre mejoras de app y documentación; origen de los issues #113–#130. |
 
 ---
 
@@ -95,5 +97,9 @@ Para contribuir o extender el producto:
 
 ---
 
-> **Idioma de la documentación:** español rioplatense (casual) — la misma voz de la app.
-> Excepción: [LANDING_COPY.md](LANDING_COPY.md) está en inglés porque es la versión pública para audiencia global.
+## Política de idiomas
+
+- **El inglés es el idioma canónico** de toda la documentación pública: ante cualquier diferencia entre un doc y su contraparte, vale la versión en inglés.
+- Las versiones en español (`*.es.md` y este índice) son traducciones best-effort en voz rioplatense (la misma de la app) y **pueden quedar desfasadas**.
+- Si cambiás un doc que tiene contraparte de idioma: actualizala en el mismo PR, o agregale una nota visible de "traducción pendiente" — el checklist del PR template lo recuerda.
+- Excepción: [LANDING.md](LANDING.md) es contenido propio en español (no traducción), igual que [LANDING_COPY.md](LANDING_COPY.md) lo es en inglés.

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,10 +64,10 @@
 
 | File | Description |
 |------|-------------|
-| [REVIEW_2026_04.md](REVIEW_2026_04.md) | **Technical review (April 2026).** Hardening, capture, and testing debt — origin of Wave 4.5. |
-| [APP_AUDIT_2026_05.md](APP_AUDIT_2026_05.md) | **App audit (May 2026).** Full feature inventory, user-impact classification, and the P0–P2 progressive disclosure plan. |
-| [APP_AUDIT_REVIEW_2026_05.md](APP_AUDIT_REVIEW_2026_05.md) | **Audit verification (May 2026).** Evidence for the P0/P1 work and the community plan around Circles. |
-| [FEATURE_REVIEW_2026_06.md](FEATURE_REVIEW_2026_06.md) | **Product and docs review (June 2026).** Yes/no decision menu on app and docs improvements; origin of issues #113–#130. |
+| [REVIEW_2026_04.md](archive/REVIEW_2026_04.md) | **Technical review (April 2026).** Hardening, capture, and testing debt — origin of Wave 4.5. |
+| [APP_AUDIT_2026_05.md](archive/APP_AUDIT_2026_05.md) | **App audit (May 2026).** Full feature inventory, user-impact classification, and the P0–P2 progressive disclosure plan. |
+| [APP_AUDIT_REVIEW_2026_05.md](archive/APP_AUDIT_REVIEW_2026_05.md) | **Audit verification (May 2026).** Evidence for the P0/P1 work and the community plan around Circles. |
+| [FEATURE_REVIEW_2026_06.md](archive/FEATURE_REVIEW_2026_06.md) | **Product and docs review (June 2026).** Yes/no decision menu on app and docs improvements; origin of issues #113–#130. |
 
 ---
 
@@ -88,3 +88,12 @@ To contribute or extend the product:
 - Start with [FIRST_CONTRIBUTION.md](FIRST_CONTRIBUTION.md) and pick an approved `good first issue`.
 - Keep ROADMAP.md updated when you complete roadmap items.
 - Keep ARCHITECTURE.md in sync with infra/schema changes.
+
+---
+
+## Language policy
+
+- **English is the canonical language** for all public documentation: when a doc and its counterpart disagree, the English version wins.
+- Spanish versions (`*.es.md` and the [Spanish index](README.es.md)) are best-effort translations in the app's rioplatense voice and **may lag behind**.
+- If you change a doc that has a language counterpart, update it in the same PR or add a visible "translation pending" note — the PR template checklist reminds you.
+- Exception: [LANDING.md](LANDING.md) is original Spanish content (not a translation), just as [LANDING_COPY.md](LANDING_COPY.md) is original English content.

--- a/docs/SELF_HOSTING.es.md
+++ b/docs/SELF_HOSTING.es.md
@@ -187,7 +187,7 @@ Migrations corren automáticamente al boot del `api` container. **Siempre hacer 
 - `JWT_SECRET` cambió: todos los tokens viejos quedan inválidos. Normal después de rotar el secret.
 
 ### SSRF o scraping bloqueado
-- El scraper de Open Graph bloquea IPs privadas por seguridad (ver `REVIEW_2026_04.md §3.4`). Si necesitás scrapear una URL interna, no es el caso de uso — usá "guardar como note" manual.
+- El scraper de Open Graph bloquea IPs privadas por seguridad (ver `archive/REVIEW_2026_04.md §3.4`). Si necesitás scrapear una URL interna, no es el caso de uso — usá "guardar como note" manual.
 
 ---
 

--- a/docs/archive/APP_AUDIT_2026_05.md
+++ b/docs/archive/APP_AUDIT_2026_05.md
@@ -1,5 +1,7 @@
 # DevDeck — App Audit (May 2026)
 
+> ⚠️ **Historical document (archived).** This is a dated snapshot; parts of it no longer reflect the current state of the product. See [ROADMAP.md](../../ROADMAP.md) for current status.
+
 > **Date:** 2026-05-21
 > **Scope:** Full feature inventory, gap analysis, and UX improvement recommendations.
 > **Goal:** Balance feature count vs. real user utility. No new features — improve what exists.

--- a/docs/archive/APP_AUDIT_REVIEW_2026_05.md
+++ b/docs/archive/APP_AUDIT_REVIEW_2026_05.md
@@ -1,5 +1,7 @@
 # DevDeck — App Audit Review & Community Plan (May 2026)
 
+> ⚠️ **Historical document (archived).** This is a dated snapshot; parts of it no longer reflect the current state of the product. See [ROADMAP.md](../../ROADMAP.md) for current status.
+
 > Date: 2026-05-23  
 > Source audit: `docs/APP_AUDIT_2026_05.md`  
 > Goal: verify that claimed P0/P1 work is not only present, but product-quality, then turn the social/community surface into a daily-use growth loop for developer communities.

--- a/docs/archive/FEATURE_REVIEW_2026_06.md
+++ b/docs/archive/FEATURE_REVIEW_2026_06.md
@@ -1,5 +1,7 @@
 # DevDeck — Revisión de producto y documentación (Junio 2026)
 
+> ⚠️ **Documento histórico (archivado).** Es un snapshot con fecha; partes ya no reflejan el estado actual del producto. Ver [ROADMAP.md](../../ROADMAP.md) para el estado vigente.
+
 > **Fecha:** 2026-06-10
 > **Objetivo:** proponer mejoras en la app y en la documentación, manteniendo el principio rector: *una app útil para la mayoría de los usuarios, sin abrumar*. Cada propuesta es una decisión Sí/No para el owner.
 > **Método:** lectura completa de `docs/` (PRD, VISION, DEV_WORKBENCH, CIRCLES, auditorías de abril/mayo, ROADMAP, análisis competitivo) + verificación puntual contra el código.

--- a/docs/archive/REVIEW_2026_04.es.md
+++ b/docs/archive/REVIEW_2026_04.es.md
@@ -1,5 +1,7 @@
 # DevDeck — Review técnico y de producto (abril 2026)
 
+> ⚠️ **Documento histórico (archivado).** Es un snapshot con fecha; partes ya no reflejan el estado actual del producto. Ver [ROADMAP.md](../../ROADMAP.md) para el estado vigente.
+
 > Autor: revisión externa · Fecha: 2026-04-08 · Estado: input para planning de Ola 4.5 y Ola 5
 >
 > Este documento captura un análisis honesto del repo en el cierre de Ola 4, con foco en qué hay que arreglar **antes** de avanzar a Ola 5, y qué falta para que DevDeck pase de "buen proyecto de ingeniería" a "producto memorable".

--- a/docs/archive/REVIEW_2026_04.md
+++ b/docs/archive/REVIEW_2026_04.md
@@ -1,5 +1,7 @@
 # Technical Review - April 2026
 
+> ⚠️ **Historical document (archived).** This is a dated snapshot; parts of it no longer reflect the current state of the product. See [ROADMAP.md](../../ROADMAP.md) for current status.
+
 **Author:** Senior Architect (AI Agent)
 **Objective:** Evaluate the current state of DevDeck.ai and define the focus for Wave 4.5.
 


### PR DESCRIPTION
Closes #130

Final piece of the June 2026 docs work (items B3.1–B3.2). Reduces `docs/` from ~26 to ~21 living files by separating dated snapshots from living docs.

## Changes

- **`docs/archive/`**: moved the five dated snapshots (`REVIEW_2026_04` en/es, `APP_AUDIT_2026_05`, `APP_AUDIT_REVIEW_2026_05`, `FEATURE_REVIEW_2026_06`) with a "⚠️ Historical document (archived)" banner pointing readers to ROADMAP.md for current state (Spanish banner for the Spanish-language files).
- **Reference rewrite**: every link/mention of the moved files updated across `ROADMAP.md`, `ROADMAP.es.md`, `README.es.md`, both docs indexes, `COMPETITIVE_ANALYSIS.es.md`, `SELF_HOSTING.es.md`, and `LIMITATIONS.md`. Verified zero stale references remain.
- **Language policy** in both docs indexes: English is canonical; Spanish versions are best-effort and may lag; counterpart updates expected in the same PR or flagged as translation-pending. The old "documentation language: rioplatense Spanish" footer in the Spanish index is replaced by this policy (LANDING docs noted as original content, not translations).
- **PR template**: new checklist item — "If I changed a doc with a language counterpart (`*.es.md`), I updated it too or flagged it as translation-pending".
- **Housekeeping deferred from #132**: ticked the two completed ROADMAP 0.5.x boxes (#129) and indexed `LIMITATIONS.md` / `ARCHITECTURE_MAP.md` in the Spanish docs index and root Spanish README.

## Verification

Docs-only change. `grep` confirms no references to the old paths remain outside `docs/archive/`, and all archive files exist at their new paths.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_