### PR TITLE
feat(notifications): provider-independent weekly digest

### DIFF
--- a/backend/internal/cron/digest.go
+++ b/backend/internal/cron/digest.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 
 	"devdeck/internal/ai"
 	"devdeck/internal/authctx"
@@ -12,6 +14,9 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// digestMaxTitles caps how many item titles appear in the digest body.
+const digestMaxTitles = 5
 
 type DigestJob struct {
 	store *store.Store
@@ -26,44 +31,49 @@ func NewDigestJob(s *store.Store, aiSvc *ai.Service) *DigestJob {
 }
 
 // Run executes the digest generation for all active users.
+//
+// The digest is provider-independent by design: it is a deterministic list
+// of what the user saved in the last week, so the notification bell works
+// for the majority of users who never configure an AI provider. AI-flavored
+// summaries can be layered on top later without changing this contract.
 func (j *DigestJob) Run(ctx context.Context) {
 	slog.Info("starting weekly digest job")
 
-	// 1. Get all users
 	users, err := j.store.ListUsersAdmin(ctx)
 	if err != nil {
 		slog.Error("failed to list users for digest", "err", err)
 		return
 	}
 
+	weekAgo := time.Now().AddDate(0, 0, -7)
+
 	for _, uMap := range users {
 		userID := uMap["id"].(uuid.UUID)
 		userCtx := authctx.WithUserID(ctx, userID)
 
-		// 2. Get up to the 10 newest items for the user
 		listRes, err := j.store.ListItems(userCtx, items.ListParams{
-			Limit: 10,
+			Limit:        10,
+			CreatedAfter: &weekAgo,
 		})
 		if err != nil {
 			slog.Error("failed to list items for user digest", "user_id", userID, "err", err)
 			continue
 		}
 
+		// Nothing new this week: stay silent instead of repeating stale digests.
 		if len(listRes.Items) == 0 {
 			continue
 		}
 
-		// 3. Generate summary with AI
-		summary, err := j.generateDigestSummary(ctx, listRes.Items)
-		if err != nil {
-			slog.Error("failed to generate digest summary", "user_id", userID, "err", err)
-			continue
+		count := listRes.Total
+		if count < len(listRes.Items) {
+			count = len(listRes.Items)
 		}
 
-		// 4. Create notification
-		title := fmt.Sprintf("Tu resumen semanal: %d descubrimientos", len(listRes.Items))
-		_, err = j.store.CreateNotification(ctx, userID, "weekly_digest", title, summary, nil)
-		if err != nil {
+		title := digestTitle(count)
+		summary := buildDigestSummary(listRes.Items, count)
+
+		if _, err := j.store.CreateNotification(ctx, userID, "weekly_digest", title, summary, nil); err != nil {
 			slog.Error("failed to create digest notification", "user_id", userID, "err", err)
 		}
 	}
@@ -71,24 +81,36 @@ func (j *DigestJob) Run(ctx context.Context) {
 	slog.Info("weekly digest job finished")
 }
 
-func (j *DigestJob) generateDigestSummary(ctx context.Context, itemNodes []*items.Item) (string, error) {
-	if !j.ai.Enabled() || len(itemNodes) == 0 {
-		return "Esta semana guardaste varios items interesantes. ¡No te olvides de revisarlos!", nil
+func digestTitle(count int) string {
+	if count == 1 {
+		return "Your weekly digest: 1 new find"
+	}
+	return fmt.Sprintf("Your weekly digest: %d new finds", count)
+}
+
+// buildDigestSummary renders the digest body without requiring any AI
+// provider: the newest item titles from the past week, plus a hint when
+// there are more than fit.
+func buildDigestSummary(itemNodes []*items.Item, total int) string {
+	var b strings.Builder
+	b.WriteString("Saved this week:\n")
+
+	shown := len(itemNodes)
+	if shown > digestMaxTitles {
+		shown = digestMaxTitles
+	}
+	for _, it := range itemNodes[:shown] {
+		title := strings.TrimSpace(it.Title)
+		if title == "" {
+			title = "(untitled)"
+		}
+		b.WriteString("• " + title + "\n")
 	}
 
-	// Build a simple text list for the AI context (simulated)
-	var list string
-	for i, it := range itemNodes {
-		desc := it.Notes
-		if it.Description != nil {
-			desc = *it.Description
-		}
-		list += fmt.Sprintf("- %s: %s\n", it.Title, desc)
-		if i >= 4 {
-			break
-		}
+	if total > shown {
+		b.WriteString(fmt.Sprintf("…and %d more in your vault.\n", total-shown))
 	}
 
-	// For Wave 8, we'll keep it simple:
-	return "Excelente semana. Guardaste herramientas clave como " + itemNodes[0].Title + ". ¡Seguí explorando!", nil
+	b.WriteString("\nRevisit them before they fade.")
+	return b.String()
 }

--- a/backend/internal/cron/digest_test.go
+++ b/backend/internal/cron/digest_test.go
@@ -1,0 +1,56 @@
+package cron
+
+import (
+	"strings"
+	"testing"
+
+	"devdeck/internal/domain/items"
+)
+
+func mkItem(title string) *items.Item {
+	return &items.Item{Title: title}
+}
+
+func TestDigestTitle(t *testing.T) {
+	if got := digestTitle(1); got != "Your weekly digest: 1 new find" {
+		t.Errorf("singular title: %q", got)
+	}
+	if got := digestTitle(7); got != "Your weekly digest: 7 new finds" {
+		t.Errorf("plural title: %q", got)
+	}
+}
+
+func TestBuildDigestSummary_ListsTitles(t *testing.T) {
+	summary := buildDigestSummary([]*items.Item{mkItem("ripgrep"), mkItem("fzf")}, 2)
+
+	if !strings.Contains(summary, "• ripgrep") || !strings.Contains(summary, "• fzf") {
+		t.Errorf("expected both titles in summary, got:\n%s", summary)
+	}
+	if strings.Contains(summary, "more in your vault") {
+		t.Errorf("should not mention overflow when everything fits, got:\n%s", summary)
+	}
+}
+
+func TestBuildDigestSummary_CapsTitlesAndShowsOverflow(t *testing.T) {
+	var list []*items.Item
+	for _, title := range []string{"a", "b", "c", "d", "e", "f", "g"} {
+		list = append(list, mkItem(title))
+	}
+
+	summary := buildDigestSummary(list, 9)
+
+	if strings.Contains(summary, "• f") {
+		t.Errorf("expected at most %d titles, got:\n%s", digestMaxTitles, summary)
+	}
+	if !strings.Contains(summary, "…and 4 more in your vault.") {
+		t.Errorf("expected overflow line for 9 total with 5 shown, got:\n%s", summary)
+	}
+}
+
+func TestBuildDigestSummary_HandlesUntitledItems(t *testing.T) {
+	summary := buildDigestSummary([]*items.Item{mkItem("  ")}, 1)
+
+	if !strings.Contains(summary, "• (untitled)") {
+		t.Errorf("expected placeholder for blank titles, got:\n%s", summary)
+	}
+}


### PR DESCRIPTION
Closes #115

The weekly digest cron existed and was wired (`cmd/api/main.go`), but its content path was broken for the majority case: it returned canned strings (in Spanish, while the app locale is English), and the "AI" branch didn't actually call the AI service. For users without an AI provider — the 90% — the bell was effectively a dead surface.

## Changes

- **Window the digest to the actual week:** items are now fetched with `ListParams.CreatedAfter = now − 7 days` (filter already supported by the store), instead of "newest 10 ever". If the user saved nothing this week, no notification is created — silent is more honest than repeating stale digests.
- **Provider-independent body:** deterministic summary listing up to 5 item titles plus an "…and N more in your vault" overflow line using the real total. No AI required, ever. AI-flavored summaries can be layered on top later without changing this contract (noted in the code).
- **English copy** consistent with the app locale, with singular/plural title handling.
- **Unit tests** (`internal/cron/digest_test.go`) for title pluralization, body content, the 5-title cap + overflow line, and blank-title placeholders — pure functions, no containers needed.

## Verification

- `go build ./...` passes.
- `go test ./internal/cron/` — all tests pass locally.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_