### PR TITLE
feat(flags): hide premature social surfaces behind server feature flags

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -37,6 +37,14 @@ type Config struct {
 	RateLimitPerMinute int  `env:"RATE_LIMIT_PER_MINUTE" envDefault:"120"`
 	RateLimitDisabled  bool `env:"RATE_LIMIT_DISABLED" envDefault:"false"`
 
+	// ─── Feature flags (June 2026 review, issue #123) ───
+	// Premature social/enterprise surfaces ship default-off so solo users
+	// see a focused app. Flip them on when a community/team exists.
+	FeatureExplore    bool `env:"FEATURE_EXPLORE" envDefault:"false"`
+	FeatureReputation bool `env:"FEATURE_REPUTATION" envDefault:"false"`
+	FeatureTeamReview bool `env:"FEATURE_TEAM_REVIEW" envDefault:"false"`
+	FeatureRealtime   bool `env:"FEATURE_REALTIME" envDefault:"false"`
+
 	// ─── Wave 4: Auth ───
 	JWTSecret               string `env:"JWT_SECRET"`
 	GitHubClientID          string `env:"GITHUB_CLIENT_ID"`

--- a/backend/internal/http/handlers/system.go
+++ b/backend/internal/http/handlers/system.go
@@ -4,15 +4,26 @@ import (
 	"net/http"
 )
 
+// SystemFeatures are server-controlled feature flags surfaced to clients.
+// Anything absent or false stays hidden in the UI.
+type SystemFeatures struct {
+	Explore    bool `json:"explore"`
+	Reputation bool `json:"reputation"`
+	TeamReview bool `json:"team_review"`
+	Realtime   bool `json:"realtime"`
+}
+
 type SystemConfigHandler struct {
 	aiProvider  string
 	syncEnabled bool
+	features    SystemFeatures
 }
 
-func NewSystemConfigHandler(aiProvider string, syncEnabled bool) *SystemConfigHandler {
+func NewSystemConfigHandler(aiProvider string, syncEnabled bool, features SystemFeatures) *SystemConfigHandler {
 	return &SystemConfigHandler{
 		aiProvider:  aiProvider,
 		syncEnabled: syncEnabled,
+		features:    features,
 	}
 }
 
@@ -20,5 +31,6 @@ func (h *SystemConfigHandler) GetConfig(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ai_provider":  h.aiProvider,
 		"sync_enabled": h.syncEnabled,
+		"features":     h.features,
 	})
 }

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -117,7 +117,12 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 		FrontendURL: cfg.FrontendURL,
 	})
 	scimH := handlers.NewSCIMHandler(st)
-	systemH := handlers.NewSystemConfigHandler(cfg.AIProvider, false)
+	systemH := handlers.NewSystemConfigHandler(cfg.AIProvider, false, handlers.SystemFeatures{
+		Explore:    cfg.FeatureExplore,
+		Reputation: cfg.FeatureReputation,
+		TeamReview: cfg.FeatureTeamReview,
+		Realtime:   cfg.FeatureRealtime,
+	})
 
 	r.Route("/api", func(r chi.Router) {
 		// Optional auth for all public API routes
@@ -371,7 +376,9 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 
 		// Public deck (no auth)
 		r.Get("/decks/{slug}/public", publicDeckH.Get)
-		r.Get("/realtime/{roomID}", realtimeH.Connect)
+		if cfg.FeatureRealtime {
+			r.Get("/realtime/{roomID}", realtimeH.Connect)
+		}
 
 		// Public profile (no auth)
 		r.Get("/users/{username}/public", profileH.GetPublic)

--- a/packages/api-client/src/features/system/api.ts
+++ b/packages/api-client/src/features/system/api.ts
@@ -1,9 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from '../../api-client'
 
+export interface SystemFeatures {
+  explore: boolean
+  reputation: boolean
+  team_review: boolean
+  realtime: boolean
+}
+
 export interface SystemConfig {
   ai_provider: string
   sync_enabled: boolean
+  features?: Partial<SystemFeatures>
+}
+
+export const DEFAULT_FEATURES: SystemFeatures = {
+  explore: false,
+  reputation: false,
+  team_review: false,
+  realtime: false,
 }
 
 /** GET /api/system/config — get system environment settings. */
@@ -13,4 +28,10 @@ export function useSystemConfig() {
     queryFn: () => api.get<SystemConfig>('/api/system/config'),
     staleTime: Infinity, // System config doesn't change during session
   })
+}
+
+/** Server-controlled feature flags. Anything unknown or unloaded is off. */
+export function useFeatureFlags(): SystemFeatures {
+  const { data } = useSystemConfig()
+  return { ...DEFAULT_FEATURES, ...(data?.features ?? {}) }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -290,6 +290,6 @@ export type {
 } from './features/decks/api'
 
 // Feature hooks — system
-export { useSystemConfig } from './features/system/api'
-export type { SystemConfig } from './features/system/api'
+export { useSystemConfig, useFeatureFlags } from './features/system/api'
+export type { SystemConfig, SystemFeatures } from './features/system/api'
 

--- a/packages/features/src/components/FeatureDisabledState.tsx
+++ b/packages/features/src/components/FeatureDisabledState.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom'
+import { FlaskConical } from 'lucide-react'
+import { Button } from '@devdeck/ui'
+import { useTranslation } from '@devdeck/i18n'
+import { AppShell } from './AppShell'
+
+export interface FeatureDisabledStateProps {
+  /** Human name of the gated surface, already translated. */
+  featureName: string
+}
+
+/**
+ * Shown when a route exists but its feature flag is off on this server.
+ * Honest by design: explains the state instead of rendering a dead page.
+ */
+export function FeatureDisabledState({ featureName }: FeatureDisabledStateProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+
+  return (
+    <AppShell contentClassName="flex-1 p-12 text-center flex flex-col items-center justify-center gap-4 bg-bg-primary">
+      <FlaskConical size={48} strokeWidth={3} className="text-accent-lavender" />
+      <h2 className="font-display font-black text-2xl uppercase">
+        {t('features.disabled_title', { feature: featureName })}
+      </h2>
+      <p className="text-ink-soft font-mono text-sm max-w-md">{t('features.disabled_desc')}</p>
+      <Button onClick={() => navigate('/items')} variant="secondary">
+        {t('features.back_to_vault')}
+      </Button>
+    </AppShell>
+  )
+}

--- a/packages/features/src/components/NavSidebar.test.tsx
+++ b/packages/features/src/components/NavSidebar.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   usePreferences: vi.fn(),
   useMe: vi.fn(),
+  useFeatureFlags: vi.fn(),
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -24,6 +25,7 @@ vi.mock('@devdeck/api-client', async () => {
     ...actual,
     usePreferences: mocks.usePreferences,
     useMe: mocks.useMe,
+    useFeatureFlags: mocks.useFeatureFlags,
   }
 })
 
@@ -34,6 +36,12 @@ describe('<NavSidebar>', () => {
     mocks.navigate.mockReset()
     mocks.usePreferences.mockReturnValue({ activeOrgId: null })
     mocks.useMe.mockReturnValue({ data: { role: 'user', username: 'tiago', avatar_url: 'avatar.png' } })
+    mocks.useFeatureFlags.mockReturnValue({
+      explore: false,
+      reputation: false,
+      team_review: true,
+      realtime: false,
+    })
     onCloseMock = vi.fn()
   })
 
@@ -92,6 +100,21 @@ describe('<NavSidebar>', () => {
     expect(within(updatedSidebar).getByText('Team')).toBeInTheDocument()
     expect(within(updatedSidebar).getByRole('link', { name: /activity/i })).toBeInTheDocument()
     expect(within(updatedSidebar).getByRole('link', { name: /review/i })).toBeInTheDocument()
+  })
+
+  it('hides the Review entry when the team_review feature flag is off', () => {
+    mocks.usePreferences.mockReturnValue({ activeOrgId: 'org_123' })
+    mocks.useFeatureFlags.mockReturnValue({
+      explore: false,
+      reputation: false,
+      team_review: false,
+      realtime: false,
+    })
+    renderSidebar()
+
+    const sidebar = screen.getByTestId('desktop-sidebar')
+    expect(within(sidebar).getByRole('link', { name: /activity/i })).toBeInTheDocument()
+    expect(within(sidebar).queryByRole('link', { name: /review/i })).not.toBeInTheDocument()
   })
 
   it('renders a badge with the reviewCount on the Review item if present', () => {

--- a/packages/features/src/components/NavSidebar.tsx
+++ b/packages/features/src/components/NavSidebar.tsx
@@ -15,7 +15,7 @@ import {
   Shield 
 } from 'lucide-react'
 import { useLocation, Link, useNavigate } from 'react-router-dom'
-import { usePreferences, useMe } from '@devdeck/api-client'
+import { usePreferences, useMe, useFeatureFlags } from '@devdeck/api-client'
 import { useTranslation } from '@devdeck/i18n'
 import { UserAvatar } from './UserAvatar'
 
@@ -27,6 +27,7 @@ interface NavSidebarProps {
 
 export function NavSidebar({ isOpen, onClose, reviewCount }: NavSidebarProps) {
   const { t } = useTranslation()
+  const features = useFeatureFlags()
   const navigate = useNavigate()
   const location = useLocation()
   const { activeOrgId } = usePreferences()
@@ -153,14 +154,16 @@ export function NavSidebar({ isOpen, onClose, reviewCount }: NavSidebarProps) {
               active={isActive('/feed')}
               onClick={onClose}
             />
-            <NavItem
-              to="/review"
-              icon={Users}
-              label={t('nav.review')}
-              active={isActive('/review')}
-              badge={reviewCount}
-              onClick={onClose}
-            />
+            {features.team_review && (
+              <NavItem
+                to="/review"
+                icon={Users}
+                label={t('nav.review')}
+                active={isActive('/review')}
+                badge={reviewCount}
+                onClick={onClose}
+              />
+            )}
           </Section>
         )}
 

--- a/packages/features/src/components/NotesEditor.tsx
+++ b/packages/features/src/components/NotesEditor.tsx
@@ -4,6 +4,7 @@ import remarkGfm from 'remark-gfm'
 import { Edit3, Eye, Save, Users, X } from 'lucide-react'
 import { Button } from '@devdeck/ui'
 import { createRoom } from '@devdeck/realtime-client'
+import { useFeatureFlags } from '@devdeck/api-client'
 import { useTranslation } from '@devdeck/i18n'
 
 interface Props {
@@ -20,6 +21,7 @@ interface Props {
  */
 export function NotesEditor({ value, onSave, saving, roomID }: Props) {
   const { t } = useTranslation()
+  const features = useFeatureFlags()
   const [mode, setMode] = useState<'view' | 'edit'>('view')
   const [draft, setDraft] = useState(value)
   const [others, setOthers] = useState<number>(0)
@@ -33,7 +35,7 @@ export function NotesEditor({ value, onSave, saving, roomID }: Props) {
 
   // Real-time setup
   useEffect(() => {
-    if (!roomID || mode !== 'edit') return
+    if (!features.realtime || !roomID || mode !== 'edit') return
 
     const room = createRoom(roomID)
     roomRef.current = room
@@ -64,7 +66,7 @@ export function NotesEditor({ value, onSave, saving, roomID }: Props) {
       awareness.off('change', handleAwareness)
       room.destroy()
     }
-  }, [roomID, mode])
+  }, [roomID, mode, features.realtime])
 
   function handleDraftChange(val: string) {
     setDraft(val)

--- a/packages/features/src/pages/ExplorePage.tsx
+++ b/packages/features/src/pages/ExplorePage.tsx
@@ -2,17 +2,23 @@ import clsx from 'clsx'
 import { BookOpen, ChevronLeft, Search, Star } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useExploreCheatsheets } from '@devdeck/api-client'
+import { useExploreCheatsheets, useFeatureFlags } from '@devdeck/api-client'
 import type { Cheatsheet } from '@devdeck/api-client'
 import { useTranslation } from '@devdeck/i18n'
 import { AppShell } from '../components/AppShell'
+import { FeatureDisabledState } from '../components/FeatureDisabledState'
 
 export function ExplorePage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const features = useFeatureFlags()
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
   const [searchFilter, setSearchFilter] = useState('')
   const { data: cheatsheets = [], isLoading } = useExploreCheatsheets(selectedCategory ?? undefined)
+
+  if (!features.explore) {
+    return <FeatureDisabledState featureName={t('nav.explore')} />
+  }
 
   const categoryLabels: Record<string, string> = {
     vcs: t('cheatsheets.categories.vcs'),

--- a/packages/features/src/pages/ProfilePage.tsx
+++ b/packages/features/src/pages/ProfilePage.tsx
@@ -18,6 +18,7 @@ import {
   useDecks,
   useItems,
   useStats,
+  useFeatureFlags,
   logoutCurrentSession
 } from '@devdeck/api-client'
 import { Button, showToast } from '@devdeck/ui'
@@ -38,6 +39,7 @@ export function ProfilePage() {
   const { data: decks = [], isLoading: loadingDecks } = useDecks()
   const { data: itemsRes } = useItems({ limit: 10 })
   const { data: stats } = useStats()
+  const features = useFeatureFlags()
 
   // Edit Modal State
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -224,13 +226,15 @@ export function ProfilePage() {
 
           {/* RIGHT COLUMN: Stats, Tech Stack, Decks, Timeline */}
           <div className="lg:col-span-2 space-y-8">
-            <ReputationDashboard
-              totalItems={totalItemsCount}
-              decksCount={decks.length}
-              streakDays={stats?.streak_days || 0}
-              reputation={reputation}
-              achievements={achievements}
-            />
+            {features.reputation && (
+              <ReputationDashboard
+                totalItems={totalItemsCount}
+                decksCount={decks.length}
+                streakDays={stats?.streak_days || 0}
+                reputation={reputation}
+                achievements={achievements}
+              />
+            )}
 
             <TechStackSection
               stackTags={user.stack_tags}

--- a/packages/features/src/pages/TeamReviewPage.test.tsx
+++ b/packages/features/src/pages/TeamReviewPage.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   useItems: vi.fn(),
   useUpdateItem: vi.fn(),
   usePreferences: vi.fn(),
+  useFeatureFlags: vi.fn(),
 }))
 
 vi.mock('react-router-dom', () => ({
@@ -27,6 +28,7 @@ vi.mock('@devdeck/api-client', async () => {
     useItems: mocks.useItems,
     useUpdateItem: mocks.useUpdateItem,
     usePreferences: mocks.usePreferences,
+    useFeatureFlags: mocks.useFeatureFlags,
   }
 })
 
@@ -75,6 +77,12 @@ describe('<TeamReviewPage>', () => {
     mocks.useItems.mockReset()
     mocks.usePreferences.mockReset()
     mocks.usePreferences.mockReturnValue({ activeOrgId: 'org_123' })
+    mocks.useFeatureFlags.mockReturnValue({
+      explore: false,
+      reputation: false,
+      team_review: true,
+      realtime: false,
+    })
     mocks.useUpdateItem.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
   })
 
@@ -104,6 +112,25 @@ describe('<TeamReviewPage>', () => {
     renderPage()
     await user.click(screen.getByRole('heading', { name: 'ripgrep' }))
     expect(mocks.navigate).toHaveBeenCalledWith('/items/item-1')
+  })
+
+  it('renders a feature-disabled state when team_review flag is off', () => {
+    mocks.useFeatureFlags.mockReturnValue({
+      explore: false,
+      reputation: false,
+      team_review: false,
+      realtime: false,
+    })
+    mocks.useItems.mockReturnValue({
+      data: { total: 0, items: [] },
+      isLoading: false,
+      error: null,
+    })
+
+    renderPage()
+
+    expect(screen.getByText('Team Review is not enabled')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Back to my vault' })).toBeInTheDocument()
   })
 
   it('renders guided org-required state if there is no active org configured', async () => {

--- a/packages/features/src/pages/TeamReviewPage.tsx
+++ b/packages/features/src/pages/TeamReviewPage.tsx
@@ -1,16 +1,18 @@
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Box, CheckCircle2, Users } from 'lucide-react'
 import { Button } from '@devdeck/ui'
-import { useItems, usePreferences } from '@devdeck/api-client'
+import { useFeatureFlags, useItems, usePreferences } from '@devdeck/api-client'
 import { ItemCard } from '../components/ItemCard'
 import { detailPathForItem } from '../utils/itemRoutes'
 import { AppShell } from '../components/AppShell'
 import { OrgRequiredEmptyState } from '../components/OrgRequiredEmptyState'
+import { FeatureDisabledState } from '../components/FeatureDisabledState'
 import { useTranslation } from '@devdeck/i18n'
 
 export function TeamReviewPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const features = useFeatureFlags()
   const { activeOrgId } = usePreferences()
   const { data, isLoading, error } = useItems({
     tag: 'team-review',
@@ -18,6 +20,10 @@ export function TeamReviewPage() {
     sort: 'updated_desc',
   })
   const items = data?.items ?? []
+
+  if (!features.team_review) {
+    return <FeatureDisabledState featureName={t('review.title')} />
+  }
 
   if (!activeOrgId) {
     return <OrgRequiredEmptyState description={t('review.org_required_desc')} />

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -130,6 +130,11 @@
     "synced": "Synced",
     "cloud_mode": "Cloud Mode"
   },
+  "features": {
+    "disabled_title": "{{feature}} is not enabled",
+    "disabled_desc": "This feature is turned off on this server while it matures. A self-hosting admin can enable it with the matching FEATURE_* environment variable.",
+    "back_to_vault": "Back to my vault"
+  },
   "profile": {
     "title": "My Profile",
     "edit_profile": "Edit Profile",
@@ -783,6 +788,7 @@
     "repos": "Repos",
     "cheatsheets": "Cheatsheets",
     "runbooks": "Runbooks",
+    "explore": "Explore",
     "tools": "Tools",
     "workbench": "Workbench",
     "discovery": "Discovery",


### PR DESCRIPTION
Closes #123

Implements the May audit's progressive-disclosure plan for the surfaces that need a community/team to be useful: code stays in the repo, only default visibility changes.

## How it works

- **Backend:** four env-driven flags, all default off — `FEATURE_EXPLORE`, `FEATURE_REPUTATION`, `FEATURE_TEAM_REVIEW`, `FEATURE_REALTIME` — exposed through `GET /api/system/config` as a `features` object (`SystemFeatures`).
- **Frontend:** new `useFeatureFlags()` hook in `@devdeck/api-client` with safe defaults: anything unknown or not yet loaded is off.
- New shared `FeatureDisabledState` component: when a gated route is visited, it explains that the feature is off on this server and how a self-hosting admin enables it — honest instead of a dead page.

## Gated surfaces

| Flag | Effect when off (default) |
|------|--------------------------|
| `explore` | ExplorePage (trending/leaderboard) shows the disabled state |
| `reputation` | ReputationDashboard (stats + achievements gamification) hidden on Profile |
| `team_review` | Review entry hidden from the NavSidebar Team section; TeamReviewPage shows the disabled state. Org gating from #134 still applies when the flag is on |
| `realtime` | The `/api/realtime/{roomID}` websocket route is not registered server-side, and NotesEditor skips Yjs room creation — local notes editing is untouched |

Circles and Following stay visible: per the May audit review, Circles is the strategic community entry point, not a premature surface.

## Verification

- `pnpm typecheck` — all workspace projects pass.
- `vitest run` NavSidebar + TeamReviewPage — 11/11 tests pass, including two new flag-gating tests.
- `go build ./...` and `go vet` pass.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_