### PR TITLE
feat(workbench): one-click preloaded examples per tool

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -16,7 +16,6 @@
 
 - **AI enrichment requires a configured provider.** Summaries, smart tags, semantic search, and Ask DevDeck need OpenAI, Ollama, or another supported provider. Without one, DevDeck uses a built-in heuristic tagger and text/fuzzy search, and the interactive AI surfaces are hidden rather than shown as dead buttons.
 - **Heuristic tagging is more limited** than provider-backed enrichment: it works from URL patterns, metadata, and keywords, not from understanding content.
-- **The weekly digest currently depends on an AI provider** for its summary. A no-AI fallback is tracked in #115.
 
 ## Search
 

--- a/packages/features/src/components/Workbench/ApiTool.tsx
+++ b/packages/features/src/components/Workbench/ApiTool.tsx
@@ -8,7 +8,7 @@ import {
   requestConfigToCurl,
   parseCurlCommand,
 } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 const API_REQUEST_HISTORY_STORAGE_KEY = 'devdeck.workbench.apiRequests.v1'
 
@@ -256,6 +256,13 @@ export function ApiTool() {
           <TextArea label="Body" value={body} onChange={setBody} placeholder='{"hello":"devdeck"}' />
         )}
         <div className="grid gap-3 border-3 border-ink bg-bg-elevated p-4">
+          <ExampleButton
+            onLoad={() =>
+              setCurlImport(
+                "curl -X GET 'https://api.github.com/repos/golang/go' -H 'Accept: application/vnd.github+json'"
+              )
+            }
+          />
           <TextArea
             label="Import cURL"
             value={curlImport}

--- a/packages/features/src/components/Workbench/HashTool.tsx
+++ b/packages/features/src/components/Workbench/HashTool.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from 'react'
 import { Button } from '@devdeck/ui'
 import { hashText } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function HashTool() {
   const [input, setInput] = useState('')
@@ -15,6 +15,7 @@ export function HashTool() {
 
   return (
     <ToolFrame title="Hash generator">
+      <ExampleButton onLoad={() => setInput('devdeck demo input — hash me')} />
       <form onSubmit={submit} className="grid gap-5">
         <div className="flex gap-2">
           {(['SHA-256', 'SHA-1'] as const).map((nextAlgorithm) => (

--- a/packages/features/src/components/Workbench/JsonTool.tsx
+++ b/packages/features/src/components/Workbench/JsonTool.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { formatJson } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function JsonTool() {
   const [input, setInput] = useState('')
@@ -8,6 +8,11 @@ export function JsonTool() {
 
   return (
     <ToolFrame title="JSON formatter">
+      <ExampleButton
+        onLoad={() =>
+          setInput('{ "name":"devdeck","tags":["cli","vault"], "stars": 1234,"nested":{"ok":true,"version":"0.5.0"}}')
+        }
+      />
       <TextArea label="Input" value={input} onChange={setInput} placeholder='{"hello":"devdeck"}' />
       {result.error && input.trim() && (
         <p className="border-2 border-ink bg-accent-pink px-3 py-2 font-mono text-sm">

--- a/packages/features/src/components/Workbench/JwtTool.tsx
+++ b/packages/features/src/components/Workbench/JwtTool.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { decodeJwt } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function JwtTool() {
   const [input, setInput] = useState('')
@@ -11,6 +11,13 @@ export function JwtTool() {
 
   return (
     <ToolFrame title="JWT decoder">
+      <ExampleButton
+        onLoad={() =>
+          setInput(
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+          )
+        }
+      />
       <TextArea label="Token" value={input} onChange={setInput} placeholder="eyJ..." />
       {result.error && input.trim() && (
         <p className="border-2 border-ink bg-accent-pink px-3 py-2 font-mono text-sm">

--- a/packages/features/src/components/Workbench/RegexTool.tsx
+++ b/packages/features/src/components/Workbench/RegexTool.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { testRegex } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function RegexTool() {
   const [pattern, setPattern] = useState('')
@@ -13,6 +13,13 @@ export function RegexTool() {
 
   return (
     <ToolFrame title="Regex tester">
+      <ExampleButton
+        onLoad={() => {
+          setPattern('(\\w+)@(\\w+)\\.dev')
+          setFlags('gi')
+          setSample('Contact ana@devdeck.dev or leo@example.dev for demo access.')
+        }}
+      />
       <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_140px]">
         <label className="grid gap-2">
           <span className="font-display text-xs font-black uppercase tracking-widest">Pattern</span>

--- a/packages/features/src/components/Workbench/SecretScannerTool.tsx
+++ b/packages/features/src/components/Workbench/SecretScannerTool.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { ShieldAlert } from 'lucide-react'
 import { scanSecrets } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function SecretScannerTool() {
   const [input, setInput] = useState('')
@@ -14,6 +14,19 @@ export function SecretScannerTool() {
 
   return (
     <ToolFrame title="Secret scanner">
+      <ExampleButton
+        onLoad={() =>
+          setInput(
+            [
+              '# demo .env — every value here is fake',
+              'API_URL=https://api.example.dev',
+              'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',
+              'GITHUB_TOKEN=ghp_1234567890abcdefghijklmnopqrstuvwxyz12',
+              'DB_PASSWORD=correct-horse-battery-staple',
+            ].join('\n')
+          )
+        }
+      />
       <TextArea
         label="Input"
         value={input}

--- a/packages/features/src/components/Workbench/TimestampTool.tsx
+++ b/packages/features/src/components/Workbench/TimestampTool.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { Button } from '@devdeck/ui'
 import { timestampToDate, dateToUnixTimestamp } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function TimestampTool() {
   const [input, setInput] = useState('')
@@ -17,6 +17,12 @@ export function TimestampTool() {
 
   return (
     <ToolFrame title="Timestamp converter">
+      <ExampleButton
+        onLoad={() => {
+          setMode('to-date')
+          setInput('1716249600')
+        }}
+      />
       <div className="flex gap-2">
         <Button
           type="button"

--- a/packages/features/src/components/Workbench/TransformTool.tsx
+++ b/packages/features/src/components/Workbench/TransformTool.tsx
@@ -6,7 +6,7 @@ import {
   encodeUrl,
   decodeUrl,
 } from '../../workbench/utils'
-import { ToolFrame, TextArea, ResultActions } from './shared'
+import { ToolFrame, TextArea, ResultActions, ExampleButton } from './shared'
 
 export function TransformTool({ tool }: { tool: 'base64' | 'url' }) {
   const [input, setInput] = useState('')
@@ -24,6 +24,16 @@ export function TransformTool({ tool }: { tool: 'base64' | 'url' }) {
 
   return (
     <ToolFrame title={tool === 'base64' ? 'Base64' : 'URL encoding'}>
+      <ExampleButton
+        onLoad={() => {
+          setMode('encode')
+          setInput(
+            tool === 'base64'
+              ? 'DevDeck saves your best finds.'
+              : 'https://example.dev/search?q=developer memory&lang=es'
+          )
+        }}
+      />
       <div className="flex gap-2">
         {(['encode', 'decode'] as const).map((nextMode) => (
           <Button

--- a/packages/features/src/components/Workbench/examples.test.tsx
+++ b/packages/features/src/components/Workbench/examples.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { JsonTool } from './JsonTool'
+import { RegexTool } from './RegexTool'
+
+const mocks = vi.hoisted(() => ({
+  useCapture: vi.fn(),
+  useCircles: vi.fn(),
+  useShareToCircle: vi.fn(),
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useCapture: mocks.useCapture,
+    useCircles: mocks.useCircles,
+    useShareToCircle: mocks.useShareToCircle,
+  }
+})
+
+describe('Workbench tool examples', () => {
+  beforeEach(() => {
+    mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCircles.mockReturnValue({ data: [] })
+    mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
+  it('loads and formats the JSON example with one click', async () => {
+    const user = userEvent.setup()
+    render(<JsonTool />)
+
+    await user.click(screen.getByRole('button', { name: /try an example/i }))
+
+    const [input, output] = screen.getAllByRole('textbox') as HTMLTextAreaElement[]
+    expect(input.value).toContain('"name":"devdeck"')
+    expect(output.value).toContain('"name": "devdeck"')
+  })
+
+  it('loads the regex example and shows matches immediately', async () => {
+    const user = userEvent.setup()
+    render(<RegexTool />)
+
+    await user.click(screen.getByRole('button', { name: /try an example/i }))
+
+    expect(screen.getByDisplayValue('(\\w+)@(\\w+)\\.dev')).toBeInTheDocument()
+    const matches = screen.getAllByRole('textbox').at(-1) as HTMLTextAreaElement
+    expect(matches.value).toContain('"count": 2')
+    expect(matches.value).toContain('ana@devdeck.dev')
+  })
+})

--- a/packages/features/src/components/Workbench/shared.tsx
+++ b/packages/features/src/components/Workbench/shared.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Clipboard, Save, Share2 } from 'lucide-react'
+import { Clipboard, Save, Share2, Sparkles } from 'lucide-react'
 import { Button, showToast } from '@devdeck/ui'
 import { useCapture, useCircles, useShareToCircle } from '@devdeck/api-client'
 import { ShareToCirclePanel } from '../ShareToCirclePanel'
@@ -46,6 +46,23 @@ export function TextArea({
         className="min-h-48 w-full resize-y border-3 border-ink bg-bg-primary p-3 font-mono text-sm outline-none focus:bg-accent-yellow/10"
       />
     </label>
+  )
+}
+
+/**
+ * One-click sample loader so a first-time user sees what the tool does
+ * without bringing their own data. Sample data must be obviously fake.
+ */
+export function ExampleButton({ onLoad }: { onLoad: () => void }) {
+  return (
+    <div>
+      <Button type="button" size="sm" variant="secondary" onClick={onLoad}>
+        <span className="flex items-center gap-2">
+          <Sparkles size={15} strokeWidth={3} />
+          Try an example
+        </span>
+      </Button>
+    </div>
   )
 }
 


### PR DESCRIPTION
Closes #120

Each Workbench tool previously opened empty — a first-time user had to bring their own JWT/JSON/curl to see what the tool does. This adds a one-click "Try an example" action (new shared `ExampleButton`) that fills the tool with obviously fake/safe sample data and shows a result immediately.

## Examples wired

| Tool | Sample |
|------|--------|
| JSON formatter | Messy sample object, formats instantly |
| JWT decoder | The canonical public jwt.io demo token (fake payload) |
| Base64 / URL encoding | Sample sentence / sample URL with query params |
| Timestamp converter | Sample UNIX epoch, switches to "to date" mode |
| Hash generator | Sample input text |
| Regex tester | Email-like pattern + sample text producing two matches instantly |
| Secret scanner | Fake `.env` using AWS's documented `AKIAIOSFODNN7EXAMPLE` key and an obviously fake `ghp_…` token — demonstrates findings + masking |
| API tester | Sample GitHub API `curl` for the import flow |

**Intentionally without examples:** UUID (pure generator, nothing to load), Project Context (environment-dependent), Snippet Expander (stateful and off by default).

Also includes a one-line truth fix in `docs/LIMITATIONS.md`: drops the "weekly digest depends on an AI provider" bullet, which #137 made obsolete.

## Verification

- `tsc --noEmit -p packages/features` passes.
- `vitest run` Workbench examples + WorkbenchPage — 11/11 tests pass, including two new tests asserting the JSON and Regex examples load and produce output in one click.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_