### PR TITLE
refactor(plugins): show compact Integrations list in Settings

### DIFF
--- a/packages/features/src/components/IntegrationsList.test.tsx
+++ b/packages/features/src/components/IntegrationsList.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { IntegrationsList } from './IntegrationsList'
+
+const mocks = vi.hoisted(() => ({
+  useFeaturedPlugins: vi.fn(),
+  useCustomEnrichers: vi.fn(),
+  useWebhooks: vi.fn(),
+  useCreateCustomEnricher: vi.fn(),
+  useCreateWebhook: vi.fn(),
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@devdeck/api-client')>('@devdeck/api-client')
+  return {
+    ...actual,
+    useFeaturedPlugins: mocks.useFeaturedPlugins,
+    useCustomEnrichers: mocks.useCustomEnrichers,
+    useWebhooks: mocks.useWebhooks,
+    useCreateCustomEnricher: mocks.useCreateCustomEnricher,
+    useCreateWebhook: mocks.useCreateWebhook,
+  }
+})
+
+const featured = [
+  {
+    id: 'npm-enricher',
+    type: 'enricher',
+    name: 'NPM Registry',
+    description: 'Extracts npm package metadata.',
+    author: 'DevDeck Team',
+    icon_url: 'npm.svg',
+    url_pattern: '^https://www\\.npmjs\\.com/package/([^/]+)',
+    endpoint_url: 'https://plugins.example.dev/npm',
+  },
+  {
+    id: 'slack-webhook',
+    type: 'webhook',
+    name: 'Slack Bridge',
+    description: 'Notifies a Slack channel on capture.',
+    author: 'DevDeck Team',
+    icon_url: 'slack.png',
+    events: ['item.created'],
+  },
+]
+
+describe('<IntegrationsList>', () => {
+  beforeEach(() => {
+    mocks.useFeaturedPlugins.mockReturnValue({ data: { plugins: featured }, isLoading: false })
+    mocks.useCustomEnrichers.mockReturnValue({ data: { enrichers: [] } })
+    mocks.useWebhooks.mockReturnValue({ data: { webhooks: [] } })
+    mocks.useCreateCustomEnricher.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useCreateWebhook.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+  })
+
+  it('renders one compact row per integration with install actions', () => {
+    render(<IntegrationsList />)
+
+    expect(screen.getByText('NPM Registry')).toBeInTheDocument()
+    expect(screen.getByText('Slack Bridge')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /install/i })).toHaveLength(2)
+  })
+
+  it('marks already-configured integrations as installed', () => {
+    mocks.useCustomEnrichers.mockReturnValue({
+      data: { enrichers: [{ url_pattern: '^https://www\\.npmjs\\.com/package/([^/]+)' }] },
+    })
+
+    render(<IntegrationsList />)
+
+    expect(screen.getByRole('button', { name: /installed/i })).toBeDisabled()
+    expect(screen.getAllByRole('button', { name: /install/i })).toHaveLength(2)
+  })
+})

--- a/packages/features/src/components/IntegrationsList.tsx
+++ b/packages/features/src/components/IntegrationsList.tsx
@@ -1,0 +1,116 @@
+import { Check, Download, Plug } from 'lucide-react'
+import {
+  useFeaturedPlugins,
+  useCreateCustomEnricher,
+  useCreateWebhook,
+  useCustomEnrichers,
+  useWebhooks,
+  type PluginTemplate,
+} from '@devdeck/api-client'
+import { Button, showToast } from '@devdeck/ui'
+import { useTranslation } from '@devdeck/i18n'
+
+/**
+ * Compact list of available enricher/webhook integrations.
+ * Replaces PluginGallery in Settings while the catalog is small
+ * (a "gallery" of three entries reads as inflated product surface);
+ * the gallery component stays in the codebase for when it grows.
+ */
+export function IntegrationsList() {
+  const { t } = useTranslation()
+  const { data: featuredRes, isLoading } = useFeaturedPlugins()
+  const { data: myEnrichersRes } = useCustomEnrichers()
+  const { data: myWebhooksRes } = useWebhooks()
+
+  const createEnricher = useCreateCustomEnricher()
+  const createWebhook = useCreateWebhook()
+
+  const featured = featuredRes?.plugins || []
+  const myEnrichers = myEnrichersRes?.enrichers || []
+  const myWebhooks = myWebhooksRes?.webhooks || []
+
+  async function handleInstall(p: PluginTemplate) {
+    try {
+      if (p.type === 'enricher') {
+        await createEnricher.mutateAsync({
+          name: p.name,
+          url_pattern: p.url_pattern!,
+          endpoint_url: p.endpoint_url!,
+        })
+      } else {
+        const url = window.prompt(t('plugins.enter_webhook_url', { name: p.name }))
+        if (!url) return
+        await createWebhook.mutateAsync({
+          name: p.name,
+          url,
+          events: p.events!,
+        })
+      }
+      showToast(t('plugins.install_success', { name: p.name }))
+    } catch (err) {
+      showToast((err as Error).message, 'error')
+    }
+  }
+
+  function isInstalled(p: PluginTemplate) {
+    if (p.type === 'enricher') {
+      return myEnrichers.some((e) => e.url_pattern === p.url_pattern)
+    }
+    return myWebhooks.some((w) => w.name === p.name)
+  }
+
+  if (isLoading) {
+    return (
+      <p className="p-6 text-center animate-pulse font-mono text-xs text-ink-soft">
+        {t('plugins.exploring')}
+      </p>
+    )
+  }
+
+  return (
+    <div className="grid gap-2">
+      {featured.map((p) => {
+        const installed = isInstalled(p)
+        return (
+          <div
+            key={p.id}
+            className="flex flex-wrap items-center gap-3 border-2 border-ink bg-bg-primary px-3 py-2"
+          >
+            <Plug size={16} strokeWidth={3} className="shrink-0 text-ink-soft" />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-display text-xs font-black uppercase tracking-tight truncate">
+                  {p.name}
+                </span>
+                <span
+                  className={`px-1.5 py-0.5 border-2 border-ink text-[8px] font-black uppercase ${
+                    p.type === 'enricher' ? 'bg-accent-lavender' : 'bg-accent-cyan'
+                  }`}
+                >
+                  {p.type}
+                </span>
+              </div>
+              <p className="font-mono text-[10px] text-ink-soft truncate">{p.description}</p>
+            </div>
+            <Button
+              onClick={() => handleInstall(p)}
+              disabled={installed || createEnricher.isPending || createWebhook.isPending}
+              variant={installed ? 'secondary' : 'primary'}
+              size="sm"
+            >
+              {installed ? (
+                <span className="flex items-center gap-1.5">
+                  <Check size={12} strokeWidth={4} /> {t('plugins.installed')}
+                </span>
+              ) : (
+                <span className="flex items-center gap-1.5">
+                  <Download size={12} strokeWidth={3} /> {t('plugins.install')}
+                </span>
+              )}
+            </Button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/features/src/components/PluginGallery.tsx
+++ b/packages/features/src/components/PluginGallery.tsx
@@ -10,6 +10,11 @@ import {
 import { Button, showToast } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
 
+/**
+ * Card-style plugin gallery. Currently unused in Settings — the catalog
+ * has three entries, so the compact IntegrationsList is shown instead.
+ * Bring this back when the catalog is large enough to deserve a gallery.
+ */
 export function PluginGallery() {
   const { t } = useTranslation()
   const { data: featuredRes, isLoading } = useFeaturedPlugins()

--- a/packages/features/src/pages/SettingsPage.tsx
+++ b/packages/features/src/pages/SettingsPage.tsx
@@ -29,7 +29,7 @@ import {
 import { showToast } from '@devdeck/ui'
 import { useTranslation } from '@devdeck/i18n'
 import { WebhookManager } from '../components/WebhookManager'
-import { PluginGallery } from '../components/PluginGallery'
+import { IntegrationsList } from '../components/IntegrationsList'
 import { OrgInsights } from '../components/OrgInsights'
 
 const APP_VERSION = '1.0.0'
@@ -128,8 +128,8 @@ export function SettingsPage() {
           <WebhookManager />
         </Section>
 
-        <Section title={`${t('settings.developer')}: ${t('settings.plugin_gallery')}`}>
-          <PluginGallery />
+        <Section title={`${t('settings.developer')}: ${t('settings.integrations')}`}>
+          <IntegrationsList />
         </Section>
 
         {/* Enterprise */}

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -89,6 +89,7 @@
     "output_webhooks": "Outgoing Webhooks",
     "output_webhooks_desc": "Subscribe to DevDeck events to notify external systems (e.g., Slack, Zapier).",
     "plugin_gallery": "Plugin Gallery",
+    "integrations": "Integrations",
     "enterprise": "Enterprise",
     "saml_title": "SSO Authentication (SAML)",
     "saml_desc": "Configure single sign-on for your organization.",


### PR DESCRIPTION
Closes #126

The plugin catalog has exactly three entries (NPM enricher, YouTube enricher, Slack webhook), so presenting it as a "gallery" of cards reads as inflated product surface (May audit).

## Changes

- New compact **`IntegrationsList`**: one row per enricher/webhook template — name, type badge, one-line description, and the same install action + installed detection the gallery had.
- **Settings** renders it under "Developer: Integrations" (new `settings.integrations` i18n key) instead of `PluginGallery`.
- **`PluginGallery` stays in the codebase**, annotated with when to bring it back: once the catalog is large enough to deserve a gallery.
- Tests for the list rendering and installed-state detection.

## Verification

- `tsc --noEmit -p packages/features` passes.
- `vitest run src/components/IntegrationsList.test.tsx` — 2/2 tests pass.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_