### PR TITLE
docs(limitations): vault export shipped in #146

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -10,7 +10,7 @@
 
 - **There is no offline-first sync yet.** DevDeck runs in honest cloud mode: the app needs to reach the API to read and write your vault. Offline sync (local SQLite + conflict resolution) is intentionally deferred until after `1.0.0` (see [FEATURE_REVIEW_2026_06.md](archive/FEATURE_REVIEW_2026_06.md), decision A5).
 - **Workbench utilities do run fully local.** JSON formatter, JWT decoder, Base64/URL tools, UUID/timestamp, hashes, regex tester, and the secret scanner work in-app without network access.
-- **Full vault export is not available yet.** Today only cheatsheets and decks can be exported; a complete vault export/backup (JSON + Markdown) is tracked in #122.
+- **Your data has an exit door:** Settings → Export My Vault downloads everything as JSON (full fidelity) or Markdown (#146). Import of vault exports back into DevDeck is not built yet.
 
 ## AI features
 


### PR DESCRIPTION
Follow-up to #146.

One-line truth fix: `docs/LIMITATIONS.md` still claimed "full vault export is not available yet (tracked in #122)" — #146 shipped it. The bullet now states the current capability (Settings → Export My Vault, JSON/Markdown) and the remaining honest gap: re-importing a vault export back into DevDeck is not built yet.

Docs-only, no code changes.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_