### PR TITLE
test(cheatsheets): fix broken empty-state tests that turned main red

### DIFF
--- a/packages/features/src/pages/CheatsheetsListPage.test.tsx
+++ b/packages/features/src/pages/CheatsheetsListPage.test.tsx
@@ -72,32 +72,30 @@ describe('CheatsheetsListPage empty state', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.useCheatsheets.mockReturnValue({ data: [], isLoading: false })
+    mocks.useCreateCheatsheet.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+    mocks.useDeleteCheatsheet.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
   })
 
-  it('shows guided empty state with explanation and action button when no cheatsheets exist', async () => {
-    const { user } = await import('@testing-library/react')
+  it('shows guided empty state and opens the create modal from its action', async () => {
+    const user = userEvent.setup()
     const { CheatsheetsListPage } = await import('./CheatsheetsListPage')
     renderWithProviders(<CheatsheetsListPage />)
 
-    // Should show the explanation hint text
+    expect(screen.getByText('cheatsheets.empty_state')).toBeInTheDocument()
     expect(screen.getByText('cheatsheets.empty_state_hint')).toBeInTheDocument()
 
-    // Should show the action button
-    const button = screen.getByTestId('button')
-    expect(button).toBeInTheDocument()
-
-    // Clicking the button should call navigate (handled by the modal)
-    await user.click(button)
-    expect(mocks.navigate).not.toHaveBeenCalled() // navigate is mocked but the modal opens instead
+    // No form inputs until the create modal opens.
+    expect(screen.queryAllByRole('textbox')).toHaveLength(0)
+    await user.click(screen.getByText('cheatsheets.empty_state_action'))
+    expect(screen.queryAllByRole('textbox').length).toBeGreaterThan(0)
   })
 
-  it('shows category-specific hint when a category filter is active', async () => {
-    mocks.useCheatsheets.mockReturnValue({
-      data: [],
-      isLoading: false,
-    })
+  it('shows the category-specific hint when a category filter is active', async () => {
+    const user = userEvent.setup()
     const { CheatsheetsListPage } = await import('./CheatsheetsListPage')
     renderWithProviders(<CheatsheetsListPage />)
+
+    await user.click(screen.getByText('cheatsheets.categories.vcs'))
 
     expect(screen.getByText('cheatsheets.empty_state_category')).toBeInTheDocument()
   })


### PR DESCRIPTION
**`main` is currently red**: the cheatsheets empty-state tests merged with #148 break workspace typecheck and fail at runtime. This restores green.

## What was broken

- `const { user } = await import('@testing-library/react')` — there is no `user` export, so `tsc --noEmit` fails across the workspace and the test throws at runtime.
- `screen.getByTestId('button')` matched **two** buttons (header "New cheatsheet" + the empty-state action) → `getMultipleElementsFoundError`.
- The second test asserted `cheatsheets.empty_state_category` without ever activating a category filter — that branch is unreachable with `selectedCategory === null`.
- The mutation hooks (`useCreateCheatsheet`/`useDeleteCheatsheet`) weren't mocked, so opening the modal would crash on `.isPending`.

## The fix

- `userEvent.setup()` for interactions.
- Assertions target the real empty-state copy (`empty_state`, `empty_state_hint`); the create action is verified by the modal's form inputs appearing after the click.
- The category test clicks an actual category button first, then asserts the category-specific hint.
- Mutation hooks mocked in `beforeEach`.

## Verification

- `tsc --noEmit -p packages/features` — passes again (was failing on main).
- `vitest run src/pages/CheatsheetsListPage.test.tsx` — 2/2 pass.

No production code touched — the page's empty state itself works fine.

https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1dVsEvYUxXGwJMxQXTGT9)_