### PR TITLE
feat(ux): add actionable item search empty states

### DIFF
--- a/packages/features/src/components/GlobalSearchModal.test.tsx
+++ b/packages/features/src/components/GlobalSearchModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { GlobalSearchModal } from './GlobalSearchModal'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
@@ -77,5 +78,23 @@ describe('<GlobalSearchModal>', () => {
     expect(screen.queryByText('Text')).not.toBeInTheDocument()
     expect(screen.queryByText('AI (Semantic)')).not.toBeInTheDocument()
     expect(screen.queryByText('Hybrid')).not.toBeInTheDocument()
+  })
+
+  it('shows actionable guidance when a search has no matches', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const captureListener = vi.fn()
+    window.addEventListener('devdeck:open-capture', captureListener)
+
+    renderModal(true, onClose)
+    await user.type(screen.getByPlaceholderText(/search anything/i), 'docker')
+
+    expect(screen.getByText('No matches found')).toBeInTheDocument()
+    expect(screen.getByText(/search checks items, repos, cheatsheets, and commands/i)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /capture it instead/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(captureListener).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener('devdeck:open-capture', captureListener)
   })
 })

--- a/packages/features/src/components/GlobalSearchModal.tsx
+++ b/packages/features/src/components/GlobalSearchModal.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Boxes, Code2, Search, X } from 'lucide-react'
+import { BookOpen, Boxes, Code2, Plus, Search, X } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useGlobalSearch, useSystemConfig } from '@devdeck/api-client'
@@ -44,6 +44,11 @@ export function GlobalSearchModal({ open, onClose }: Props) {
     else if (r.type === 'repo') navigate(`/repo/${r.id}`)
     else if (r.type === 'cheatsheet') navigate(`/cheatsheets/${r.id}`)
     // entries navigate to their parent cheatsheet (we don't have cheatsheet id in SearchResult)
+  }
+
+  function openCaptureInstead() {
+    onClose()
+    window.dispatchEvent(new CustomEvent('devdeck:open-capture'))
   }
 
   // Group results by type.
@@ -112,8 +117,19 @@ export function GlobalSearchModal({ open, onClose }: Props) {
               {t('search.min_chars')}
             </div>
           ) : results.length === 0 && !isLoading ? (
-            <div className="p-8 text-center font-mono text-sm text-ink-soft">
-              {t('common.no_results_found')} "{query}"
+            <div className="p-8 text-center">
+              <p className="font-display text-lg font-black uppercase">{t('search.no_results_title')}</p>
+              <p className="mx-auto mt-2 max-w-md font-mono text-sm text-ink-soft">
+                {t('search.no_results_desc', { query })}
+              </p>
+              <button
+                type="button"
+                onClick={openCaptureInstead}
+                className="mt-5 border-3 border-ink bg-accent-lime px-4 py-2 font-display font-bold uppercase shadow-hard"
+              >
+                <Plus size={16} strokeWidth={3} className="mr-2 inline-block" />
+                {t('search.capture_instead')}
+              </button>
             </div>
           ) : (
             <div className="py-2">

--- a/packages/features/src/pages/ItemDetailPage.test.tsx
+++ b/packages/features/src/pages/ItemDetailPage.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 	useCapture: vi.fn(),
 	useCircles: vi.fn(),
 	useShareToCircle: vi.fn(),
+	useFeatureFlags: vi.fn(),
 	showToast: vi.fn(),
 	confirm: vi.fn(),
 }))
@@ -53,6 +54,7 @@ vi.mock('@devdeck/api-client', async () => {
 		useCapture: mocks.useCapture,
 		useCircles: mocks.useCircles,
 		useShareToCircle: mocks.useShareToCircle,
+		useFeatureFlags: mocks.useFeatureFlags,
 	}
 })
 
@@ -112,6 +114,7 @@ describe('<ItemDetailPage>', () => {
 		mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
 		mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
 		mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useFeatureFlags.mockReturnValue({ realtime: false })
 	})
 
 	it('renders AI summary and suggested tags', () => {

--- a/packages/features/src/pages/ItemsPage.test.tsx
+++ b/packages/features/src/pages/ItemsPage.test.tsx
@@ -94,12 +94,22 @@ describe('<ItemsPage>', () => {
     expect(mocks.navigate).toHaveBeenCalledWith('/review')
   })
 
-  it('shows a useful empty state instead of staying on loading forever', () => {
+  it('shows a useful empty state instead of staying on loading forever', async () => {
+    const user = userEvent.setup()
+    const captureListener = vi.fn()
+    window.addEventListener('devdeck:open-capture', captureListener)
+
     renderPage()
+
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument()
     expect(screen.getByText('Nothing here yet')).toBeInTheDocument()
+    expect(screen.getByText(/start building your personal developer vault/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /save command/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /open cheatsheets/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /discover/i })).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /capture your first item/i }))
+    expect(captureListener).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener('devdeck:open-capture', captureListener)
   })
 })

--- a/packages/features/src/pages/ItemsPage.tsx
+++ b/packages/features/src/pages/ItemsPage.tsx
@@ -189,53 +189,53 @@ export function ItemsPage() {
             <p className="text-sm font-mono">{(error as Error).message}</p>
           </div>
         )}
-                {!isLoading && !error && items.length === 0 && (
-                  <div className="flex flex-col items-center justify-center py-12 text-center gap-8">
-                    <div>
-                        <Box size={64} strokeWidth={2} className="mb-4 opacity-50 mx-auto" />
-                        <p className="font-display font-bold text-xl mb-2">{t('items.empty_state_title')}</p>
-                        <p className="font-mono text-sm text-ink-soft max-w-sm">
-                        {t('items.empty_state_desc')}
-                        </p>
-                    </div>
+        {!isLoading && !error && items.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 text-center gap-8">
+            <div>
+              <Box size={64} strokeWidth={2} className="mb-4 opacity-50 mx-auto" />
+              <p className="font-display font-bold text-xl mb-2">{t('items.empty_state_title')}</p>
+              <p className="font-mono text-sm text-ink-soft max-w-sm">
+                {hasFilters ? t('items.no_results_filters') : t('items.empty_state_desc')}
+              </p>
+            </div>
 
-                    {!hasFilters && (
-                      <div className="w-full max-w-4xl space-y-6">
-                        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-left">
-                          <UtilityAction
-                            icon={<TerminalSquare size={18} strokeWidth={3} />}
-                            title={t('items.utility_save_cmd_title')}
-                            desc={t('items.utility_save_cmd_desc')}
-                            onClick={openCapture}
-                          />
-                          <UtilityAction
-                            icon={<BookOpen size={18} strokeWidth={3} />}
-                            title={t('items.utility_cheats_title')}
-                            desc={t('items.utility_cheats_desc')}
-                            onClick={() => navigate('/cheatsheets')}
-                          />
-                          <UtilityAction
-                            icon={<Compass size={18} strokeWidth={3} />}
-                            title={t('items.utility_discover_title')}
-                            desc={t('items.utility_discover_desc')}
-                            onClick={() => navigate('/discovery')}
-                          />
-                        </div>
-                        <OnboardingChecklist />
-                      </div>
-                    )}
+            {!hasFilters && (
+              <div className="w-full max-w-4xl space-y-6">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-left">
+                  <UtilityAction
+                    icon={<TerminalSquare size={18} strokeWidth={3} />}
+                    title={t('items.utility_save_cmd_title')}
+                    desc={t('items.utility_save_cmd_desc')}
+                    onClick={openCapture}
+                  />
+                  <UtilityAction
+                    icon={<BookOpen size={18} strokeWidth={3} />}
+                    title={t('items.utility_cheats_title')}
+                    desc={t('items.utility_cheats_desc')}
+                    onClick={() => navigate('/cheatsheets')}
+                  />
+                  <UtilityAction
+                    icon={<Compass size={18} strokeWidth={3} />}
+                    title={t('items.utility_discover_title')}
+                    desc={t('items.utility_discover_desc')}
+                    onClick={() => navigate('/discovery')}
+                  />
+                </div>
+                <OnboardingChecklist />
+              </div>
+            )}
 
-                    <button
-                      type="button"
-                      onClick={openCapture}
-                      className="border-3 border-ink px-4 py-2 bg-accent-lime shadow-hard
-                                 font-display font-bold uppercase"
-                    >
-                      <Plus size={16} strokeWidth={3} className="inline-block mr-2" />
-                      {t('items.capture_something')}
-                    </button>
-                  </div>
-                )}
+            <button
+              type="button"
+              onClick={openCapture}
+              className="border-3 border-ink px-4 py-2 bg-accent-lime shadow-hard
+                         font-display font-bold uppercase"
+            >
+              <Plus size={16} strokeWidth={3} className="inline-block mr-2" />
+              {hasFilters ? t('items.capture_something') : t('items.capture_first_item')}
+            </button>
+          </div>
+        )}
 
 
         {items.length > 0 && (

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -489,7 +489,10 @@
     "ai_semantic": "AI (Semantic)",
     "hybrid": "Hybrid",
     "min_chars": "Type at least 2 characters to search...",
-    "results_count": "{{count}} results found"
+    "results_count": "{{count}} results found",
+    "no_results_title": "No matches found",
+    "no_results_desc": "Search checks items, repos, cheatsheets, and commands. Try intent words, or capture \"{{query}}\" instead.",
+    "capture_instead": "Capture it instead"
   },
   "notifications": {
     "title": "Notifications",
@@ -571,7 +574,7 @@
   "items": {
     "all": "All",
     "empty_state_title": "Nothing here yet",
-    "empty_state_desc": "Capture a URL, command, shortcut or note with the button above.",
+    "empty_state_desc": "Capture a URL, command, shortcut, or note to start building your personal developer vault.",
     "utility_save_cmd_title": "Save command",
     "utility_save_cmd_desc": "CLI, scripts, flags and quick recipes.",
     "utility_cheats_title": "Open cheatsheets",
@@ -579,6 +582,7 @@
     "utility_discover_title": "Discover",
     "utility_discover_desc": "Find new tools and references.",
     "capture_something": "Capture something",
+    "capture_first_item": "Capture your first item",
     "items_count": "{{count}} item",
     "items_count_plural": "{{count}} items",
     "type_filter": "type",


### PR DESCRIPTION
Closes #143

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add actionable guidance to the Items empty state with a primary capture action.
- Replace the global search no-match dead end with guidance plus a capture action.
- Cover both surfaces with focused tests.
- Update the ItemDetailPage test harness to mock `useFeatureFlags`, matching the current NotesEditor dependency.

## Changes
| File | Change |
|------|--------|
| `packages/features/src/pages/ItemsPage.tsx` | Adds guided empty-state copy and "Capture your first item" action. |
| `packages/features/src/components/GlobalSearchModal.tsx` | Adds no-match guidance and "Capture it instead" action. |
| `packages/i18n/src/locales/en.json` | Adds/updates English UI copy. |
| `*.test.tsx` | Covers empty-state actions and fixes current ItemDetailPage harness mock. |

## Test Plan
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features exec vitest run src/pages/ItemsPage.test.tsx src/components/GlobalSearchModal.test.tsx`
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features test`
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features typecheck`
- [ ] I manually verified the affected flow, if applicable.
- [ ] I included screenshots/GIFs for user-facing UI changes, if applicable.

## Contributor Checklist
- [x] Linked an approved issue with `Closes #143`
- [x] Added exactly one `type:*` label
- [x] Kept the PR small and focused
- [x] Included tests or a clear verification note
- [ ] Updated docs if behavior changed
- [ ] If I changed a doc with a language counterpart (`*.es.md`), I updated it too or flagged it as translation-pending
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` or AI attribution trailers