### PR TITLE
feat(ux): add repo cheatsheet empty states

### DIFF
--- a/packages/features/src/pages/CheatsheetsListPage.test.tsx
+++ b/packages/features/src/pages/CheatsheetsListPage.test.tsx
@@ -81,6 +81,7 @@ describe('CheatsheetsListPage empty state', () => {
     const { CheatsheetsListPage } = await import('./CheatsheetsListPage')
     renderWithProviders(<CheatsheetsListPage />)
 
+    expect(screen.getByText('cheatsheets.empty_state_title')).toBeInTheDocument()
     expect(screen.getByText('cheatsheets.empty_state')).toBeInTheDocument()
     expect(screen.getByText('cheatsheets.empty_state_hint')).toBeInTheDocument()
 
@@ -97,6 +98,7 @@ describe('CheatsheetsListPage empty state', () => {
 
     await user.click(screen.getByText('cheatsheets.categories.vcs'))
 
+    expect(screen.getByText('cheatsheets.empty_state_category_title')).toBeInTheDocument()
     expect(screen.getByText('cheatsheets.empty_state_category')).toBeInTheDocument()
   })
 })

--- a/packages/features/src/pages/CheatsheetsListPage.tsx
+++ b/packages/features/src/pages/CheatsheetsListPage.tsx
@@ -117,6 +117,9 @@ export function CheatsheetsListPage() {
         {cheatsheets.length === 0 ? (
           <div className="text-center py-20 space-y-4">
             <BookOpen size={64} strokeWidth={2} className="mx-auto mb-4 text-ink-soft" />
+            <h2 className="font-display font-black text-2xl uppercase">
+              {selectedCategory ? t('cheatsheets.empty_state_category_title') : t('cheatsheets.empty_state_title')}
+            </h2>
             <p className="font-mono text-ink-soft max-w-md mx-auto">
               {selectedCategory ? t('cheatsheets.empty_state_category') : t('cheatsheets.empty_state')}
             </p>

--- a/packages/features/src/pages/HomePage.test.tsx
+++ b/packages/features/src/pages/HomePage.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { HomePage } from './HomePage'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  useItems: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+}))
+
+vi.mock('../components/AppShell', () => ({
+  AppShell: ({
+    children,
+    query,
+    onQueryChange,
+  }: {
+    children: ReactNode
+    query?: string
+    onQueryChange?: (value: string) => void
+  }) => (
+    <div data-testid="app-shell">
+      <input
+        id="topbar-search"
+        aria-label="Search"
+        value={query ?? ''}
+        onChange={(event) => onQueryChange?.(event.target.value)}
+      />
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('../components/Sidebar', () => ({
+  Sidebar: () => <aside data-testid="sidebar" />,
+}))
+
+vi.mock('../components/Mascot/Mascot', () => ({
+  Mascot: () => <div data-testid="mascot" />,
+}))
+
+vi.mock('../components/ItemGrid', () => ({
+  ItemGrid: () => <div data-testid="item-grid" />,
+}))
+
+vi.mock('@devdeck/api-client', async () => {
+  const actual = await vi.importActual<object>('@devdeck/api-client')
+  return {
+    ...actual,
+    useItems: mocks.useItems,
+  }
+})
+
+describe('<HomePage>', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useItems.mockReturnValue({
+      data: { total: 0, items: [] },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it('shows actionable guidance for an empty repos list', async () => {
+    const user = userEvent.setup()
+    const captureListener = vi.fn()
+    window.addEventListener('devdeck:open-capture', captureListener)
+
+    render(<HomePage />)
+
+    expect(screen.getByText('No repos saved yet')).toBeInTheDocument()
+    expect(screen.getByText(/paste a github url/i)).toBeInTheDocument()
+    expect(screen.getByText(/import github stars/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /capture your first repo/i }))
+    expect(captureListener).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener('devdeck:open-capture', captureListener)
+  })
+})

--- a/packages/features/src/pages/HomePage.tsx
+++ b/packages/features/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { EmptyState } from '@devdeck/ui'
+import { Button } from '@devdeck/ui'
+import { Github, Plus } from 'lucide-react'
 import { detailPathForItem } from '../utils/itemRoutes'
 import { Mascot } from '../components/Mascot/Mascot'
 import { ItemGrid } from '../components/ItemGrid'
@@ -52,6 +53,10 @@ export function HomePage() {
   const items = data?.items ?? []
   const hasFilters = Boolean(query || tag || lang)
 
+  function openCapture() {
+    window.dispatchEvent(new CustomEvent('devdeck:open-capture'))
+  }
+
   return (
     <AppShell
       query={query}
@@ -86,7 +91,24 @@ export function HomePage() {
         )}
 
         {!isLoading && !error && items.length === 0 && !hasFilters && (
-          <EmptyState onAdd={() => window.dispatchEvent(new CustomEvent('devdeck:open-capture'))} />
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <Github size={72} strokeWidth={2} className="mb-6 text-ink-soft" />
+            <h2 className="font-display font-black text-4xl uppercase mb-3">
+              {t('repos.empty_state_title')}
+            </h2>
+            <p className="font-mono text-ink-soft mb-3 max-w-md">
+              {t('repos.empty_state_desc')}
+            </p>
+            <p className="font-mono text-xs text-ink-soft/70 mb-8 max-w-md">
+              {t('repos.empty_state_hint')}
+            </p>
+            <Button onClick={openCapture} size="lg">
+              <span className="flex items-center gap-2">
+                <Plus size={16} strokeWidth={3} />
+                {t('repos.empty_state_action')}
+              </span>
+            </Button>
+          </div>
         )}
 
         {!isLoading && !error && items.length === 0 && hasFilters && (

--- a/packages/features/src/pages/ItemDetailPage.test.tsx
+++ b/packages/features/src/pages/ItemDetailPage.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
 	useCapture: vi.fn(),
 	useCircles: vi.fn(),
 	useShareToCircle: vi.fn(),
+	useFeatureFlags: vi.fn(),
 	showToast: vi.fn(),
 	confirm: vi.fn(),
 }))
@@ -53,6 +54,7 @@ vi.mock('@devdeck/api-client', async () => {
 		useCapture: mocks.useCapture,
 		useCircles: mocks.useCircles,
 		useShareToCircle: mocks.useShareToCircle,
+		useFeatureFlags: mocks.useFeatureFlags,
 	}
 })
 
@@ -112,6 +114,7 @@ describe('<ItemDetailPage>', () => {
 		mocks.useCapture.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
 		mocks.useCircles.mockReturnValue({ data: [], isLoading: false })
 		mocks.useShareToCircle.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
+		mocks.useFeatureFlags.mockReturnValue({ realtime: false })
 	})
 
 	it('renders AI summary and suggested tags', () => {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -590,6 +590,10 @@
     "no_results_filters": "No results for current filters."
   },
   "repos": {
+    "empty_state_title": "No repos saved yet",
+    "empty_state_desc": "Paste a GitHub URL to capture a repo and enrich it with stars, language, topics, and description automatically.",
+    "empty_state_hint": "Want a faster start? Settings → Import GitHub Stars can fill your vault from your public starred repos.",
+    "empty_state_action": "Capture your first repo",
     "not_found_title": "Repo not found or deleted",
     "not_found_desc": "The repo no longer exists in your vault, or was deleted while this screen was open.",
     "back_to_items": "Back to items",
@@ -1054,6 +1058,8 @@
     "new_cheatsheet": "New cheatsheet",
     "create_success": "Cheatsheet created",
     "delete_success": "Cheatsheet deleted",
+    "empty_state_title": "No cheatsheets yet",
+    "empty_state_category_title": "No cheatsheets in this category",
     "empty_state": "There are no cheatsheets yet.",
     "empty_state_category": "There are no cheatsheets in this category.",
     "delete_confirm": "Are you sure you want to delete this cheatsheet?",
@@ -1087,7 +1093,7 @@
       "cloud": "Cloud / DevOps",
       "other": "Other"
     },
-    "empty_state_hint": "A cheatsheet is a curated collection of tools and commands. Create your first one to start organizing your vault.",
+    "empty_state_hint": "Explore seeded examples when they are available, or create your first cheatsheet to start organizing reusable commands.",
     "empty_state_action": "Create your first cheatsheet"
   },
   "paste": {


### PR DESCRIPTION
Closes #144

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Replace the generic repos empty state with repo-specific guidance and a capture action.
- Add clearer Cheatsheets empty-state headings while keeping the create action intact.
- Cover Repos and Cheatsheets empty-state actions with focused tests.
- Include the current ItemDetailPage test harness mock for `useFeatureFlags`, matching the NotesEditor dependency.

## Changes
| File | Change |
|------|--------|
| `packages/features/src/pages/HomePage.tsx` | Adds repo-specific empty-state guidance and capture CTA. |
| `packages/features/src/pages/HomePage.test.tsx` | Verifies repo empty-state guidance and capture event. |
| `packages/features/src/pages/CheatsheetsListPage.tsx` | Adds explicit empty-state headings for all/category-empty states. |
| `packages/features/src/pages/CheatsheetsListPage.test.tsx` | Verifies the Cheatsheets empty-state headings. |
| `packages/i18n/src/locales/en.json` | Adds/updates English UI copy. |
| `packages/features/src/pages/ItemDetailPage.test.tsx` | Mocks `useFeatureFlags` so the package suite stays green. |

## Test Plan
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features exec vitest run src/pages/HomePage.test.tsx src/pages/CheatsheetsListPage.test.tsx`
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features exec vitest run src/pages/ItemDetailPage.test.tsx`
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features test`
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features typecheck`
- [ ] I manually verified the affected flow, if applicable.
- [ ] I included screenshots/GIFs for user-facing UI changes, if applicable.

## Contributor Checklist
- [x] Linked an approved issue with `Closes #144`
- [x] Added exactly one `type:*` label
- [x] Kept the PR small and focused
- [x] Included tests or a clear verification note
- [ ] Updated docs if behavior changed
- [ ] If I changed a doc with a language counterpart (`*.es.md`), I updated it too or flagged it as translation-pending
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` or AI attribution trailers