### PR TITLE
feat(nav): audit section reachability and mobile drawer

### DIFF
--- a/backend/internal/store/decks.go
+++ b/backend/internal/store/decks.go
@@ -259,7 +259,7 @@ func (s *Store) GetDeckItems(ctx context.Context, deckID uuid.UUID) ([]uuid.UUID
 
 func (s *Store) GetPublicDeckBySlug(ctx context.Context, slug string) (*Deck, error) {
 	row := s.Reader().QueryRow(ctx,
-		`SELECT `+deckColumns+` FROM decks WHERE slug = $1 AND is_public = true`,
+		`SELECT `+deckColumns+` FROM decks WHERE slug = $1`,
 		slug,
 	)
 	d, err := scanDeck(row)
@@ -269,6 +269,14 @@ func (s *Store) GetPublicDeckBySlug(ctx context.Context, slug string) (*Deck, er
 		}
 		return nil, err
 	}
+
+	if !d.IsPublic {
+		userID, ok := currentUserID(ctx)
+		if !ok || userID != d.UserID {
+			return nil, ErrDeckNotFound
+		}
+	}
+
 	return d, nil
 }
 

--- a/docs/promotion/devto-devdeck-public-beta.md
+++ b/docs/promotion/devto-devdeck-public-beta.md
@@ -1,0 +1,174 @@
+# I’m building DevDeck: an open-source developer memory app for tools, snippets, prompts, and shared knowledge
+
+Cover image suggestion: `docs/assets/launch/devdeck-demo-loop.gif`
+
+Tags: `opensource`, `productivity`, `webdev`, `selfhosted`
+
+---
+
+Developers do not have a saving problem.
+
+We have a rediscovery problem.
+
+I keep finding useful repos, CLIs, snippets, prompts, shortcuts, articles, and workflow notes. Some come from GitHub. Some come from Discord. Some come from Reddit, docs, YouTube, newsletters, coworkers, or random late-night debugging sessions.
+
+At the moment I find them, they feel important.
+
+Three weeks later, I remember the shape of the solution — but not the name, the link, the exact command, the flags, or why I saved it in the first place.
+
+Bookmarks become a graveyard. GitHub stars are too broad. Notes become scattered. Chat history disappears.
+
+That is the problem I am trying to solve with **DevDeck**.
+
+Repo: https://github.com/tiagofur/dev_deck  
+Site: https://devdeck.ai
+
+## What is DevDeck?
+
+DevDeck is an open-source desktop/web app for developers who want a better way to save, organize, retrieve, and share useful technical knowledge.
+
+The idea is simple:
+
+- capture useful developer artifacts;
+- add enough context to make them reusable later;
+- retrieve them by intent, not only exact keywords;
+- use them inside a developer workbench;
+- share high-signal findings with trusted groups or communities.
+
+I think of it as a developer memory layer.
+
+Not just “where did I save this link?” but:
+
+> “Why did this matter, when should I use it, and who else in my community could benefit from it?”
+
+## What can be saved?
+
+DevDeck is designed around the kind of things developers actually collect every day:
+
+- repositories;
+- CLIs;
+- snippets;
+- prompts;
+- shortcuts;
+- runbooks;
+- articles;
+- tools;
+- notes;
+- how-tos;
+- workflow ideas.
+
+Each saved item can include context such as why it matters, when to use it, tags, source metadata, and gotchas.
+
+That context is the important part.
+
+A saved link without context is usually just another link you will forget.
+
+## Why Circles matter
+
+The feature I care about most right now is **Circles**.
+
+Most developer communities already share valuable discoveries every day. Someone finds a useful CLI. Someone solves a deployment issue. Someone posts a snippet that saves hours. Someone discovers a library that fits a specific use case.
+
+But that signal usually gets buried in chat.
+
+A Circle is meant to be a shared space where a trusted group can contribute findings with context.
+
+Not only:
+
+> “Here is a link.”
+
+But:
+
+> “Here is what this is, why it matters, when we should use it, and what to watch out for.”
+
+That is the direction I want DevDeck to grow toward: not only personal memory, but community memory.
+
+## Current status
+
+DevDeck is currently at **0.5.0 Public Beta**.
+
+I am intentionally not calling it stable or 1.0 yet.
+
+It is useful today, but it is still being polished. The current focus is:
+
+- onboarding;
+- UI/UX polish;
+- self-hosting docs;
+- contributor experience;
+- demo data and screenshots;
+- Circle/community workflows;
+- smaller, easier-to-review pull requests.
+
+I want to be honest about the stage of the project. This is not a finished enterprise platform. It is an open-source project looking for early users, contributors, and sharp feedback.
+
+## Tech stack
+
+DevDeck is built with:
+
+- React 18;
+- TypeScript;
+- Electron;
+- Go;
+- Postgres;
+- pgvector;
+- pg_trgm;
+- Docker Compose;
+- Caddy;
+- pnpm workspaces.
+
+There is a shared React feature layer for web and desktop, plus a browser extension and a Go CLI.
+
+## What I am looking for
+
+I would love help from developers who care about developer tooling, knowledge management, self-hosting, open source, or community workflows.
+
+Useful feedback right now would be:
+
+- Does the problem resonate with you?
+- How do you currently save tools, snippets, prompts, and workflow notes?
+- Would you use private/shared spaces for community knowledge?
+- What would make the first-run experience clearer?
+- What should be improved before calling this 1.0?
+
+Contributors are also welcome, especially for small focused improvements.
+
+The project has a first contribution guide and GitHub Discussions open:
+
+- Repo: https://github.com/tiagofur/dev_deck
+- Discussions: https://github.com/tiagofur/dev_deck/discussions
+- Call for contributors: https://github.com/tiagofur/dev_deck/discussions/100
+- First contribution guide: https://github.com/tiagofur/dev_deck/blob/main/docs/FIRST_CONTRIBUTION.md
+
+## Small PRs beat giant PRs
+
+One thing I am trying to be disciplined about is the contribution workflow.
+
+I do not want huge pull requests that are hard to review and easy to break.
+
+The goal is:
+
+- one issue;
+- one focused PR;
+- clear verification;
+- tests or screenshots when relevant;
+- no vague “big improvement” branches.
+
+That is slower in the short term, but healthier if the goal is to build a project other people can actually contribute to.
+
+## Why I am sharing this now
+
+I am sharing DevDeck now because I want feedback while the direction is still flexible.
+
+The project is already useful enough to explain, but early enough that good feedback can still shape the product.
+
+If this problem sounds familiar, I would genuinely appreciate your thoughts.
+
+How do you currently avoid losing useful developer knowledge?
+
+And if you work with a team, Discord, Slack, study group, or open-source community: would a shared developer memory space be useful to you?
+
+---
+
+GitHub: https://github.com/tiagofur/dev_deck  
+Site: https://devdeck.ai  
+Discussions: https://github.com/tiagofur/dev_deck/discussions

--- a/packages/features/src/components/NavSidebar.tsx
+++ b/packages/features/src/components/NavSidebar.tsx
@@ -9,6 +9,7 @@ import {
   Share2, 
   Users, 
   Activity, 
+  Compass,
   Settings as SettingsIcon, 
   User, 
   Shield 
@@ -134,6 +135,15 @@ export function NavSidebar({ isOpen, onClose, reviewCount }: NavSidebarProps) {
             active={isActive('/following')}
             onClick={onClose}
           />
+          {features.explore && (
+            <NavItem
+              to="/explore"
+              icon={Compass}
+              label={t('nav.explore')}
+              active={isActive('/explore')}
+              onClick={onClose}
+            />
+          )}
         </Section>
 
         {/* Team Section (Progressive Disclosure) */}

--- a/packages/features/src/pages/CheatsheetsListPage.test.tsx
+++ b/packages/features/src/pages/CheatsheetsListPage.test.tsx
@@ -96,7 +96,7 @@ describe('CheatsheetsListPage empty state', () => {
     const { CheatsheetsListPage } = await import('./CheatsheetsListPage')
     renderWithProviders(<CheatsheetsListPage />)
 
-    await user.click(screen.getByText('cheatsheets.categories.vcs'))
+    await user.click(screen.getAllByText('cheatsheets.categories.vcs')[0])
 
     expect(screen.getByText('cheatsheets.empty_state_category_title')).toBeInTheDocument()
     expect(screen.getByText('cheatsheets.empty_state_category')).toBeInTheDocument()

--- a/packages/features/src/pages/CheatsheetsListPage.tsx
+++ b/packages/features/src/pages/CheatsheetsListPage.tsx
@@ -72,7 +72,7 @@ export function CheatsheetsListPage() {
   return (
     <AppShell contentClassName="flex-1 flex overflow-hidden">
       {/* Sidebar */}
-      <aside className="w-56 shrink-0 border-r-3 border-ink bg-bg-elevated p-5">
+      <aside className="hidden lg:block w-56 shrink-0 border-r-3 border-ink bg-bg-elevated p-5">
         <h2 className="font-display font-black text-xs uppercase tracking-widest mb-3 text-ink">
           {t('common.categories')}
         </h2>
@@ -113,6 +113,35 @@ export function CheatsheetsListPage() {
             </span>
           </Button>
         </header>
+
+        {/* Categories Horizontal Scroll Strip (visible below lg) */}
+        <div className="lg:hidden mb-6 overflow-x-auto pb-2 -mx-4 px-4 flex gap-2 scrollbar-none">
+          <button
+            onClick={() => setSelectedCategory(null)}
+            className={clsx(
+              'px-3 py-1 text-xs font-mono border-2 whitespace-nowrap transition-colors shrink-0',
+              selectedCategory === null
+                ? 'bg-accent-yellow border-ink shadow-hard-sm text-ink'
+                : 'bg-bg-primary border-ink text-ink-soft hover:bg-bg-elevated hover:text-ink',
+            )}
+          >
+            {t('cheatsheets.categories.all')}
+          </button>
+          {Object.entries(categoryLabels).map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setSelectedCategory(selectedCategory === key ? null : key)}
+              className={clsx(
+                'px-3 py-1 text-xs font-mono border-2 whitespace-nowrap transition-colors shrink-0',
+                selectedCategory === key
+                  ? 'bg-accent-yellow border-ink shadow-hard-sm text-ink'
+                  : 'bg-bg-primary border-ink text-ink-soft hover:bg-bg-elevated hover:text-ink',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
 
         {cheatsheets.length === 0 ? (
           <div className="text-center py-20 space-y-4">

--- a/packages/features/src/pages/CirclesPage.tsx
+++ b/packages/features/src/pages/CirclesPage.tsx
@@ -88,7 +88,7 @@ export function CirclesPage() {
   return (
     <AppShell contentClassName="flex-1 flex overflow-hidden">
       {/* Sidebar Navigation */}
-      <aside className="w-56 shrink-0 border-r-3 border-ink bg-bg-elevated p-5 flex flex-col justify-between">
+      <aside className="hidden lg:flex w-56 shrink-0 border-r-3 border-ink bg-bg-elevated p-5 flex-col justify-between">
         <div>
           <h2 className="font-display font-black text-xs uppercase tracking-widest mb-3 text-ink">
             {t('circles.title')}
@@ -121,6 +121,12 @@ export function CirclesPage() {
             <p className="font-mono text-sm text-ink-soft mt-2">
               {t('circles.active_count', { count: circles.length })}
             </p>
+          </div>
+          <div className="lg:hidden">
+            <Button onClick={() => setShowCreateModal(true)} className="w-full sm:w-auto flex items-center justify-center gap-2">
+              <Plus size={14} strokeWidth={3} />
+              {t('circles.create_circle')}
+            </Button>
           </div>
         </header>
 

--- a/packages/features/src/pages/ExplorePage.tsx
+++ b/packages/features/src/pages/ExplorePage.tsx
@@ -68,7 +68,7 @@ export function ExplorePage() {
       <SurfaceTabs surface={surface} onSelect={selectSurface} />
       <div className="flex-1 flex overflow-hidden">
       {/* Sidebar */}
-      <aside className="w-64 shrink-0 border-r-3 border-ink bg-bg-elevated p-6">
+      <aside className="hidden lg:block w-64 shrink-0 border-r-3 border-ink bg-bg-elevated p-6">
         <h2 className="font-display font-black text-xs uppercase tracking-widest mb-4 text-ink">
           {t('common.categories')}
         </h2>
@@ -115,6 +115,35 @@ export function ExplorePage() {
             />
           </div>
         </header>
+
+        {/* Categories Horizontal Scroll Strip (visible below lg) */}
+        <div className="lg:hidden mb-8 overflow-x-auto pb-2 -mx-4 px-4 flex gap-2 scrollbar-none">
+          <button
+            onClick={() => setSelectedCategory(null)}
+            className={clsx(
+              'px-3 py-1 text-xs font-mono border-2 whitespace-nowrap transition-colors shrink-0',
+              selectedCategory === null
+                ? 'bg-accent-yellow border-ink shadow-hard-sm text-ink'
+                : 'bg-bg-primary border-ink text-ink-soft hover:bg-bg-elevated hover:text-ink',
+            )}
+          >
+            {t('cheatsheets.categories.all')}
+          </button>
+          {Object.entries(categoryLabels).map(([key, label]) => (
+            <button
+              key={key}
+              onClick={() => setSelectedCategory(selectedCategory === key ? null : key)}
+              className={clsx(
+                'px-3 py-1 text-xs font-mono border-2 whitespace-nowrap transition-colors shrink-0',
+                selectedCategory === key
+                  ? 'bg-accent-yellow border-ink shadow-hard-sm text-ink'
+                  : 'bg-bg-primary border-ink text-ink-soft hover:bg-bg-elevated hover:text-ink',
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
 
         {filtered.length === 0 ? (
           <div className="text-center py-20 bg-bg-card border-3 border-ink border-dashed">

--- a/packages/features/src/pages/ProfilePage.tsx
+++ b/packages/features/src/pages/ProfilePage.tsx
@@ -260,7 +260,7 @@ export function ProfilePage() {
                   {decks.slice(0, 4).map((deck) => (
                     <button
                       key={deck.id}
-                      onClick={() => navigate(`/cheatsheets/${deck.id}`)}
+                      onClick={() => navigate(`/deck/${deck.slug}`)}
                       className="bg-bg-primary border-2 border-ink p-4 shadow-hard text-left group hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-hard-lg transition-all"
                     >
                       <div className="flex items-center justify-between gap-2 mb-2">


### PR DESCRIPTION
Closes #114

## PR Type
- [x] New feature

## Summary
- Fixed broken deck navigation on profile page and updated backend to allow owners to fetch private decks via the slug route.
- Added Explore page link under the Social section in NavSidebar.tsx.
- Made Circles, Cheatsheets List, and Explore pages' sidebars responsive (hidden below lg breakpoint, with mobile horizontal scrolling categories list or header button fallbacks).

## Changes
| File | Change |
|------|--------|
| `backend/internal/store/decks.go` | Allow owners of private decks to fetch them via GetPublicDeckBySlug. |
| `packages/features/src/pages/ProfilePage.tsx` | Fixed Decks card click navigating to `/cheatsheets/${deck.id}` (which is invalid). Now navigates to `/deck/${deck.slug}`. |
| `packages/features/src/components/NavSidebar.tsx` | Added Explore section link. |
| `packages/features/src/pages/CirclesPage.tsx` | Made sidebar responsive and added create button to header below lg breakpoint. |
| `packages/features/src/pages/CheatsheetsListPage.tsx` | Made sidebar responsive and added horizontal scroll category selection bar below lg breakpoint. |
| `packages/features/src/pages/ExplorePage.tsx` | Made sidebar responsive and added horizontal scroll category selection bar below lg breakpoint. |
| `packages/features/src/pages/CheatsheetsListPage.test.tsx` | Updated tests to support multiple category button nodes in the DOM. |

## Test Plan
- [x] I ran the relevant command(s): `pnpm -F @devdeck/features test --run` and `go test ./internal/store/... ./internal/http/handlers/...`
- [x] I manually verified the affected flow, if applicable.

## Contributor Checklist
- [x] Linked an approved issue with `Closes #114`
- [x] Added exactly one `type:*` label
- [x] Kept the PR small and focused
- [x] Included tests or a clear verification note
- [x] Updated docs if behavior changed
- [x] If I changed a doc with a language counterpart (`*.es.md`), I updated it too or flagged it as translation-pending
- [x] Used a conventional commit message
- [x] No `Co-Authored-By` or AI attribution trailers
