### PR TITLE
Desktop (Electron) quality pass: security hardening, 404 route, lint & types

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,6 +38,17 @@ interface ApiTesterResponse {
   body: string
 }
 
+// Only ever hand http(s) URLs to the OS browser. Blocks file://, and other
+// schemes that could be abused if a malicious URL reaches the open handler.
+function isSafeExternalURL(rawURL: string): boolean {
+  try {
+    const { protocol } = new URL(rawURL)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 let mainWindow: BrowserWindow | null = null
 let pendingAuthCallbackURL: string | null = null
 let shortcutStatus: Record<string, { accelerator: string; registered: boolean }> = {}
@@ -117,7 +128,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.on('auth:open-external', (_event, url: string) => {
-    void shell.openExternal(url)
+    if (isSafeExternalURL(url)) void shell.openExternal(url)
   })
 
   ipcMain.on('auth:get-pending-url', (event) => {
@@ -296,10 +307,23 @@ function createWindow(): void {
     }
   })
 
-  // External links → system browser, never inside the app.
+  // External links → system browser, never inside the app. Validate the
+  // scheme so only http(s) is handed to the OS.
   win.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url)
+    if (isSafeExternalURL(url)) shell.openExternal(url)
     return { action: 'deny' }
+  })
+
+  // Block the renderer from navigating the top frame away from the app
+  // (defense-in-depth against any injected content). In-app routing uses a
+  // HashRouter, so legitimate navigation never triggers this.
+  win.webContents.on('will-navigate', (event, url) => {
+    const devURL = process.env.ELECTRON_RENDERER_URL
+    const isAppURL = url.startsWith('file://') || (devURL ? url.startsWith(devURL) : false)
+    if (!isAppURL) {
+      event.preventDefault()
+      if (isSafeExternalURL(url)) void shell.openExternal(url)
+    }
   })
 
   if (process.env.ELECTRON_RENDERER_URL) {

--- a/apps/desktop/src/renderer/src/App.routes.test.ts
+++ b/apps/desktop/src/renderer/src/App.routes.test.ts
@@ -15,4 +15,9 @@ describe('desktop route parity', () => {
     expect(appSource).toContain('path="/circles/:id"')
     expect(appSource).toContain('path="/circles/join/:inviteCode"')
   })
+
+  it('has a catch-all 404 route so unknown paths never render blank', () => {
+    expect(appSource).toContain('path="*"')
+    expect(appSource).toContain('NotFoundPage')
+  })
 })

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ import { RegisterPage } from './pages/RegisterPage'
 import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
 import { AuthCallbackPage } from './pages/AuthCallbackPage'
+import { NotFoundPage } from './pages/NotFoundPage'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -129,11 +130,11 @@ function AuthBridge(): null {
   const navigate = useNavigate()
 
   useEffect(() => {
-    const pending = (window as any).electronAPI?.auth.getPendingCallbackURL()
+    const pending = window.electronAPI?.auth.getPendingCallbackURL()
     if (pending) {
       navigate(desktopCallbackPath(pending), { replace: true })
     }
-    return (window as any).electronAPI?.auth.onCallbackURL((url: string) => {
+    return window.electronAPI?.auth.onCallbackURL((url: string) => {
       navigate(desktopCallbackPath(url), { replace: true })
     })
   }, [navigate])
@@ -159,9 +160,10 @@ function AnimatedRoutes() {
   })
 
   useEffect(() => {
-    const onOpenCapture = (e: any) => {
-      if (e.detail) {
-        setInitialCaptureData({ url: e.detail.url, title: e.detail.title })
+    const onOpenCapture = (e: Event) => {
+      const detail = (e as CustomEvent<{ url?: string; title?: string }>).detail
+      if (detail) {
+        setInitialCaptureData({ url: detail.url, title: detail.title })
       } else {
         setInitialCaptureData(null)
       }
@@ -179,11 +181,7 @@ function AnimatedRoutes() {
   }, [])
 
   useEffect(() => {
-    const api = (window as unknown as {
-      electronAPI?: {
-        onShortcut: (callback: (name: string) => void) => () => void
-      }
-    }).electronAPI
+    const api = window.electronAPI
     if (!api) return
 
     return api.onShortcut((name) => {
@@ -327,6 +325,7 @@ function AnimatedRoutes() {
           />
           <Route path="/deck/:slug" element={withTransition(<PublicDeckPage />)} />
           <Route path="/u/:username" element={withTransition(<PublicProfilePage />)} />
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </AnimatePresence>
       <UnifiedCommandPalette open={globalSearchOpen} onClose={() => setGlobalSearchOpen(false)} />

--- a/apps/desktop/src/renderer/src/pages/ForgotPasswordPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/ForgotPasswordPage.tsx
@@ -18,8 +18,8 @@ export function ForgotPasswordPage() {
     try {
       await forgotPassword(email)
       setSuccess(true)
-    } catch (err: any) {
-      setError(err.message || t('common.error'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('common.error'))
     } finally {
       setLoading(false)
     }

--- a/apps/desktop/src/renderer/src/pages/LoginPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/LoginPage.tsx
@@ -14,7 +14,7 @@ export function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [step, setStep] = useState<1 | 2>(1)
-  const [loginType, setLoginType] = useState<'password' | 'saml'>('password')
+  const [, setLoginType] = useState<'password' | 'saml'>('password')
   const [loginError, setLoginError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
@@ -52,8 +52,8 @@ export function LoginPage() {
       }
       setLoginType(res.type)
       setStep(2)
-    } catch (err: any) {
-      setLoginError(err.message || t('auth.validate_email_error'))
+    } catch (err) {
+      setLoginError(err instanceof Error ? err.message : t('auth.validate_email_error'))
     } finally {
       setLoading(false)
     }
@@ -66,8 +66,8 @@ export function LoginPage() {
     try {
       await loginLocal(email, password)
       navigate('/', { replace: true })
-    } catch (err: any) {
-      setLoginError(err.message || t('auth.login_error'))
+    } catch (err) {
+      setLoginError(err instanceof Error ? err.message : t('auth.login_error'))
     } finally {
       setLoading(false)
     }

--- a/apps/desktop/src/renderer/src/pages/NotFoundPage.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { NotFoundPage } from './NotFoundPage'
+
+describe('<NotFoundPage> (desktop)', () => {
+  it('renders the 404 heading and a link back home', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: '404' })).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/')
+  })
+})

--- a/apps/desktop/src/renderer/src/pages/NotFoundPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/NotFoundPage.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from '@devdeck/i18n'
+
+export function NotFoundPage() {
+  const { t } = useTranslation()
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-bg-primary p-8">
+      <div className="bg-bg-card border-5 border-ink shadow-hard-xl p-10 max-w-md w-full text-center">
+        <div className="w-20 h-20 mx-auto mb-6 border-3 border-ink bg-accent-yellow flex items-center justify-center text-4xl">
+          🦎
+        </div>
+        <h1 className="font-display font-black text-5xl uppercase tracking-tight mb-2">404</h1>
+        <p className="font-mono text-sm text-ink-soft mb-2 uppercase font-bold">
+          {t('not_found.title')}
+        </p>
+        <p className="font-mono text-sm text-ink-soft mb-6">{t('not_found.desc')}</p>
+        <Link
+          to="/"
+          className="inline-block border-3 border-ink bg-accent-pink text-ink
+                     font-display font-bold uppercase py-3 px-6 shadow-hard
+                     hover:-translate-x-1 hover:-translate-y-1 hover:shadow-hard-lg
+                     active:translate-x-1 active:translate-y-1 active:shadow-hard-sm
+                     transition-all duration-150"
+        >
+          {t('not_found.back')}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/pages/RegisterPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/RegisterPage.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
-import { useNavigate, Link } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 import { registerUser } from '@devdeck/api-client'
 import { useTranslation } from '@devdeck/i18n'
 
 export function RegisterPage() {
   const { t } = useTranslation()
-  const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -31,8 +30,8 @@ export function RegisterPage() {
     try {
       await registerUser(email, password, inviteCode)
       setSuccess(true)
-    } catch (err: any) {
-      setError(err.message || t('auth.register_error'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('auth.register_error'))
     } finally {
       setLoading(false)
     }

--- a/apps/desktop/src/renderer/src/pages/ResetPasswordPage.tsx
+++ b/apps/desktop/src/renderer/src/pages/ResetPasswordPage.tsx
@@ -35,8 +35,8 @@ export function ResetPasswordPage() {
     try {
       await resetPassword(token, password)
       navigate('/login?reset=success', { replace: true })
-    } catch (err: any) {
-      setError(err.message || t('common.error'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('common.error'))
     } finally {
       setLoading(false)
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,14 +14,14 @@ export default tseslint.config(
     ignores: [
       '**/dist/**',
       '**/build/**',
+      '**/out/**',
       '**/node_modules/**',
       '**/coverage/**',
       '**/*.config.{js,ts,cjs,mjs}',
       '**/*.cjs',
       '**/vite-env.d.ts',
       '**/env.d.ts',
-      // Out of web scope — these have their own pipelines.
-      'apps/desktop/**',
+      // Out of frontend lint scope — these have their own pipelines.
       'apps/extension/**',
       'apps/landing/**',
       'backend/**',

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -351,6 +351,11 @@
     "terms_desc": "By joining, you agree that we will send you an email (and only one) when your invitation is ready.",
     "error": "Something went wrong. Please check your email and try again."
   },
+  "not_found": {
+    "title": "Page not found",
+    "desc": "This page doesn't exist — or it went to the freezer.",
+    "back": "Back to home"
+  },
   "feed": {
     "title": "Network Feed",
     "seeing_captures": "You are seeing captures from the curators you follow",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -351,6 +351,11 @@
     "terms_desc": "Al unirte, aceptas que te enviemos un email (y solo uno) cuando tu invitación esté lista.",
     "error": "Algo salió mal. Revisa tu email e inténtalo de nuevo."
   },
+  "not_found": {
+    "title": "Página no encontrada",
+    "desc": "Esta página no existe — o se fue al freezer.",
+    "back": "Volver al inicio"
+  },
   "feed": {
     "title": "Feed de la red",
     "seeing_captures": "Estás viendo capturas de los curadores que sigues",


### PR DESCRIPTION
Follow-up to the web quality pass (#157), bringing the **desktop (Electron)** app to the same bar. The desktop app is a thin shell over the shared `packages/*`, so it already inherited the web hardening; this PR covers the desktop-specific surface (`main`, `preload`, `renderer`).

The Electron security baseline was already solid (`contextIsolation`, `sandbox`, `nodeIntegration: false`, `safeStorage`, external links routed to the OS browser).

## 🔒 Electron security (main process)
- **Validate URL scheme** (http/https only) before handing anything to `shell.openExternal` — both in the window-open handler and the `auth:open-external` IPC. Blocks `file://` and other schemes.
- **Add a `will-navigate` guard** so the renderer can't navigate the top frame to an external origin (defense-in-depth; in-app routing uses a `HashRouter`, so legitimate navigation never triggers it).

## 🐛 Renderer
- **Add a `NotFoundPage` + catch-all `*` route.** Unknown hash routes previously rendered a **blank screen** (web already had this). The page is i18n'd via `t()`.
- **Type safety:** type `window.electronAPI` via the existing `electron.d.ts` and `CustomEvent`s instead of `any`; type caught errors (`err instanceof Error`); drop unused vars.

## 🛠️ Tooling
- **Bring `apps/desktop` into the shared ESLint config** (it was excluded), so it's linted by `pnpm lint` and CI. Also ignore `**/out/**` (electron-vite build output). Desktop lint is clean — **0 errors, 0 warnings**.
- **i18n:** new `not_found` keys in `en` + `es` (full 908/908 parity).
- **Tests:** add a `NotFoundPage` render test + a catch-all route-parity check (desktop suite **6 → 8**).

## ✅ Verification
`typecheck` ✅ · `pnpm lint` 0/0 ✅ · desktop tests 8 ✅ · `electron-vite build` ✅

## Follow-ups (need a runtime Electron smoke test — intentionally left out)
- **`shell:run`** executes arbitrary commands from the renderer with no main-process guardrails (allowlist/confirmation). It's a runbook/agent feature (the renderer confirms in-UI), but worth defense-in-depth. Product + security decision.
- **Renderer CSP** — fiddly because of `file://` (prod) vs the dev server; needs a real smoke test.
- Renderer bundle (~3.1 MB) isn't code-split like web — low priority since desktop loads from local disk.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_