### PR TITLE
Backend (Go) quality pass: security hardening + golangci-lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Lint (golangci-lint)
+        run: "$(go env GOPATH)/bin/golangci-lint run ./..."
+
       - name: Build
         run: go build ./...
 

--- a/CONTRIBUTING.es.md
+++ b/CONTRIBUTING.es.md
@@ -69,6 +69,8 @@ Ver [docs/adr/0003-monorepo-pnpm-workspaces.md](docs/adr/0003-monorepo-pnpm-work
 ### Go
 - `gofmt` + `goimports`. El CI falla si el diff no está formateado.
 - `go vet ./...` limpio.
+- `golangci-lint run ./...` en `backend/` con **0 issues** (config en
+  `backend/.golangci.yml`: linters estándar + `gosec`). El CI lo corre.
 - Packages por dominio, no por capa. Ya está así, seguí el patrón.
 - Errors: `fmt.Errorf("contexto: %w", err)`. Nada de `errors.New` sin wrap cuando hay un error previo.
 - Tests al lado del código (`foo_test.go`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,9 @@ We use internal aliases: `@devdeck/ui`, `@devdeck/api-client`, and `@devdeck/fea
 
 ### Go
 - Use `gofmt` and `goimports`. The CI will fail if formatting is off.
+- Run `golangci-lint run ./...` in `backend/` before pushing — CI runs it
+  (config in `backend/.golangci.yml`; standard linters + `gosec`). It must
+  report **0 issues**.
 - Packages should be organized by **Domain**, not by layer.
 - Errors: Always wrap errors with context using `fmt.Errorf("context: %w", err)`.
 

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,27 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard # errcheck, govet, ineffassign, staticcheck, unused
+  enable:
+    - gosec # security-focused checks (the point of adding a linter here)
+    - bodyclose
+    - misspell
+  exclusions:
+    rules:
+      # Tests and tooling may ignore errors / use weaker constructs.
+      - path: _test\.go
+        linters:
+          - errcheck
+          - gosec
+      - path: internal/tools/
+        linters:
+          - errcheck
+          - gosec
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/backend/internal/ai/agent/agent.go
+++ b/backend/internal/ai/agent/agent.go
@@ -15,17 +15,17 @@ const (
 )
 
 type Message struct {
-	Role    Role    `json:"role"`
-	Content string  `json:"content"`
-	Name    string  `json:"name,omitempty"` // For tool messages
-	ToolID  string  `json:"tool_call_id,omitempty"`
+	Role    Role   `json:"role"`
+	Content string `json:"content"`
+	Name    string `json:"name,omitempty"` // For tool messages
+	ToolID  string `json:"tool_call_id,omitempty"`
 }
 
 type Tool struct {
-	Name         string                                                              `json:"name"`
-	Description  string                                                              `json:"description"`
-	Parameters   json.RawMessage                                                     `json:"parameters"` // JSON Schema
-	IsClientSide bool                                                                `json:"is_client_side"`
+	Name         string                                                                  `json:"name"`
+	Description  string                                                                  `json:"description"`
+	Parameters   json.RawMessage                                                         `json:"parameters"` // JSON Schema
+	IsClientSide bool                                                                    `json:"is_client_side"`
 	Execute      func(ctx context.Context, args map[string]any) (json.RawMessage, error) `json:"-"`
 }
 
@@ -40,9 +40,9 @@ type Response struct {
 }
 
 type ToolCall struct {
-	ID        string          `json:"id"`
-	Type      string          `json:"type"` // always "function"
-	Function  FunctionCall    `json:"function"`
+	ID       string       `json:"id"`
+	Type     string       `json:"type"` // always "function"
+	Function FunctionCall `json:"function"`
 }
 
 type FunctionCall struct {

--- a/backend/internal/ai/agent/orchestrator.go
+++ b/backend/internal/ai/agent/orchestrator.go
@@ -53,7 +53,7 @@ func (o *Orchestrator) Chat(ctx context.Context, history []Message, tools []Tool
 		hasClientSide := false
 		for _, tc := range resp.ToolCalls {
 			slog.Info("agent calling tool", "name", tc.Function.Name, "args", tc.Function.Arguments)
-			
+
 			var tool *Tool
 			for _, t := range tools {
 				if t.Name == tc.Function.Name {

--- a/backend/internal/ai/agent/tools_impl.go
+++ b/backend/internal/ai/agent/tools_impl.go
@@ -19,7 +19,7 @@ func DefaultTools(st *store.Store) []Tool {
 	return []Tool{
 		{
 			Name:        "search_vault",
-			Description: "Busca herramientas, repositorios y comandos en el vault personal o del equipo. Usala para encontrar información antes de actuar.",
+			Description: "Busca herramientas, repositorios y comandos en el vault personal o del equipo. Usala para encontrar información antes de actuar.", //nolint:misspell // Spanish text ("comandos"), not an English typo
 			Parameters: json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -60,7 +60,7 @@ func DefaultTools(st *store.Store) []Tool {
 				url, _ := args["url"].(string)
 				notes, _ := args["notes"].(string)
 				tagsRaw, _ := args["tags"].([]any)
-				
+
 				tags := []string{}
 				for _, t := range tagsRaw {
 					if ts, ok := t.(string); ok {
@@ -84,7 +84,7 @@ func DefaultTools(st *store.Store) []Tool {
 		},
 		{
 			Name:        "create_runbook",
-			Description: "Crea una lista de pasos operativos (runbook) vinculada a un item del vault.",
+			Description: "Crea una lista de pasos operativos (runbook) vinculada a un item del vault.", //nolint:misspell // Spanish text ("operativos"), not an English typo
 			Parameters: json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -125,8 +125,12 @@ func DefaultTools(st *store.Store) []Tool {
 					desc, _ := sm["description"].(string)
 
 					var pCmd, pDesc *string
-					if cmd != "" { pCmd = &cmd }
-					if desc != "" { pDesc = &desc }
+					if cmd != "" {
+						pCmd = &cmd
+					}
+					if desc != "" {
+						pDesc = &desc
+					}
 
 					_, _ = st.CreateRunbookStep(ctx, rb.ID, label, pCmd, pDesc)
 				}
@@ -136,8 +140,9 @@ func DefaultTools(st *store.Store) []Tool {
 		},
 		{
 			Name:         "execute_shell_command",
-			Description:  "Ejecuta un comando en la terminal local del usuario. Solo disponible en la Desktop App. Requiere aprobación manual del usuario.",
+			Description:  "Ejecuta un comando en la terminal local del usuario. Solo disponible en la Desktop App. Requiere aprobación manual del usuario.", //nolint:misspell // Spanish text ("comando"), not an English typo
 			IsClientSide: true,
+			//nolint:misspell // Spanish text ("comando") inside the JSON schema string, not an English typo
 			Parameters: json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -177,7 +182,7 @@ func DefaultTools(st *store.Store) []Tool {
 				if err != nil {
 					return nil, err
 				}
-				defer resp.Body.Close()
+				defer func() { _ = resp.Body.Close() }()
 
 				body, err := io.ReadAll(io.LimitReader(resp.Body, 50000))
 				if err != nil {

--- a/backend/internal/ai/agent_lmstudio.go
+++ b/backend/internal/ai/agent_lmstudio.go
@@ -87,7 +87,7 @@ func (a *AgentLMStudio) Chat(ctx context.Context, messages []agent.Message, tool
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/backend/internal/ai/agent_ollama.go
+++ b/backend/internal/ai/agent_ollama.go
@@ -86,7 +86,7 @@ func (a *AgentOllama) Chat(ctx context.Context, messages []agent.Message, tools 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/backend/internal/ai/agent_openai.go
+++ b/backend/internal/ai/agent_openai.go
@@ -42,9 +42,9 @@ func (a *AgentOpenAI) Chat(ctx context.Context, messages []agent.Message, tools 
 
 	// 1. Prepare request
 	type openAIRequest struct {
-		Model    string           `json:"model"`
-		Messages []agent.Message  `json:"messages"`
-		Tools    []any            `json:"tools,omitempty"`
+		Model    string          `json:"model"`
+		Messages []agent.Message `json:"messages"`
+		Tools    []any           `json:"tools,omitempty"`
 	}
 
 	reqBody := openAIRequest{
@@ -80,7 +80,7 @@ func (a *AgentOpenAI) Chat(ctx context.Context, messages []agent.Message, tools 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/backend/internal/ai/deepseek.go
+++ b/backend/internal/ai/deepseek.go
@@ -75,8 +75,8 @@ type deepSeekMessage struct {
 
 type deepSeekRequest struct {
 	Model       string            `json:"model"`
-	Temperature float64          `json:"temperature,omitempty"`
-	MaxTokens   int              `json:"max_tokens,omitempty"`
+	Temperature float64           `json:"temperature,omitempty"`
+	MaxTokens   int               `json:"max_tokens,omitempty"`
 	Messages    []deepSeekMessage `json:"messages"`
 }
 
@@ -97,7 +97,7 @@ func (p *deepSeekProvider) complete(ctx context.Context, messages []deepSeekMess
 		Model:       p.model,
 		Temperature: 0.2,
 		MaxTokens:   512,
-		Messages:   messages,
+		Messages:    messages,
 	})
 	if err != nil {
 		return "", err
@@ -113,7 +113,7 @@ func (p *deepSeekProvider) complete(ctx context.Context, messages []deepSeekMess
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err

--- a/backend/internal/ai/embeddings.go
+++ b/backend/internal/ai/embeddings.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	openAIEmbeddingsURL = "https://api.openai.com/v1/embeddings"
+	openAIEmbeddingsURL    = "https://api.openai.com/v1/embeddings"
 	dashScopeEmbeddingsURL = "https://dashscope.aliyuncs.com/api/v1/services/embeddings/text-embedding"
 )
 
@@ -41,7 +41,7 @@ func NewOpenAIEmbedder(apiKey string) *openAIEmbedder {
 	return &openAIEmbedder{
 		apiKey: strings.TrimSpace(apiKey),
 		dim:    1536, // text-embedding-3-small
-		httpc: &http.Client{Timeout: 30 * time.Second},
+		httpc:  &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -77,7 +77,7 @@ func (e *openAIEmbedder) Embed(ctx context.Context, text string) ([]float32, err
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -117,7 +117,7 @@ func NewQwenEmbedder(apiKey string) *qwenEmbedder {
 	return &qwenEmbedder{
 		apiKey: strings.TrimSpace(apiKey),
 		dim:    1024, // qwen-text-embedding
-		httpc: &http.Client{Timeout: 30 * time.Second},
+		httpc:  &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
@@ -130,15 +130,15 @@ func (e *qwenEmbedder) Dim() int {
 }
 
 type qwenEmbedRequest struct {
-	Model   string `json:"model"`
-	Input   string `json:"input"`
+	Model    string `json:"model"`
+	Input    string `json:"input"`
 	TextType string `json:"text_type"` // "query" or "document"
 }
 
 type qwenEmbedResponse struct {
-	Code     string `json:"code"`
-	Message  string `json:"message"`
-	Output   struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Output  struct {
 		Embeddings []struct {
 			TextIndex int       `json:"text_index"`
 			Embedding []float32 `json:"embedding"`
@@ -152,8 +152,8 @@ func (e *qwenEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 	}
 
 	body, err := json.Marshal(qwenEmbedRequest{
-		Model:   "text-embedding-3",
-		Input:   text,
+		Model:    "text-embedding-3",
+		Input:    text,
 		TextType: "document",
 	})
 	if err != nil {
@@ -172,7 +172,7 @@ func (e *qwenEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/backend/internal/ai/heuristic.go
+++ b/backend/internal/ai/heuristic.go
@@ -101,14 +101,10 @@ func (heuristicProvider) SuggestTags(_ context.Context, in Input) ([]string, err
 	}
 
 	// 2. Ecosistema por URL
-	for _, tag := range hostAndEcosystemTags(in.URL) {
-		tags = append(tags, tag)
-	}
+	tags = append(tags, hostAndEcosystemTags(in.URL)...)
 
 	// 3. Mapeo dinámico de palabras clave tecnológicas
-	for _, tag := range techKeywordTags(in.Title, in.Description) {
-		tags = append(tags, tag)
-	}
+	tags = append(tags, techKeywordTags(in.Title, in.Description)...)
 
 	// 4. Mapeos tradicionales basados en tipo de item
 	switch in.Type {
@@ -147,9 +143,7 @@ func (heuristicProvider) SuggestTags(_ context.Context, in Input) ([]string, err
 	}
 
 	// 5. Palabras clave adicionales del título
-	for _, word := range keywordTags(in.Type, in.Title) {
-		tags = append(tags, word)
-	}
+	tags = append(tags, keywordTags(in.Type, in.Title)...)
 
 	return uniqueTags(tags), nil
 }
@@ -196,24 +190,24 @@ func hostAndEcosystemTags(rawURL *string) []string {
 	var tags []string
 	host := strings.ToLower(strings.TrimPrefix(u.Hostname(), "www."))
 
-	switch {
-	case host == "github.com":
+	switch host {
+	case "github.com":
 		tags = append(tags, "github")
-	case host == "npmjs.com" || host == "yarnpkg.com":
+	case "npmjs.com", "yarnpkg.com":
 		tags = append(tags, "npm", "node", "javascript")
-	case host == "crates.io":
+	case "crates.io":
 		tags = append(tags, "rust", "cargo")
-	case host == "pypi.org" || host == "pypi.python.org":
+	case "pypi.org", "pypi.python.org":
 		tags = append(tags, "python", "pip")
-	case host == "pkg.go.dev":
+	case "pkg.go.dev":
 		tags = append(tags, "go", "golang")
-	case host == "hub.docker.com":
+	case "hub.docker.com":
 		tags = append(tags, "docker", "containers")
-	case host == "aws.amazon.com":
+	case "aws.amazon.com":
 		tags = append(tags, "aws", "cloud")
-	case host == "cloud.google.com":
+	case "cloud.google.com":
 		tags = append(tags, "gcp", "cloud")
-	case host == "kubernetes.io":
+	case "kubernetes.io":
 		tags = append(tags, "kubernetes", "k8s")
 	default:
 		parts := strings.Split(host, ".")
@@ -359,7 +353,7 @@ func keywordTags(itemType items.Type, title string) []string {
 		return nil
 	}
 	words := strings.FieldsFunc(strings.ToLower(title), func(r rune) bool {
-		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	})
 	stop := map[string]bool{
 		"the": true, "and": true, "for": true, "with": true, "from": true,

--- a/backend/internal/ai/lmstudio.go
+++ b/backend/internal/ai/lmstudio.go
@@ -120,7 +120,7 @@ func (p *lmStudioProvider) complete(ctx context.Context, messages []lmStudioMess
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/backend/internal/ai/ollama.go
+++ b/backend/internal/ai/ollama.go
@@ -50,7 +50,7 @@ func (p *ollamaProvider) SuggestTags(ctx context.Context, in Input) ([]string, e
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Clean the response in case Ollama adds markdown backticks
 	resp = strings.TrimPrefix(strings.TrimSpace(resp), "```json")
 	resp = strings.TrimPrefix(resp, "```")
@@ -102,7 +102,7 @@ func (p *ollamaProvider) generate(ctx context.Context, system, prompt string) (s
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		raw, _ := io.ReadAll(resp.Body)

--- a/backend/internal/ai/openai.go
+++ b/backend/internal/ai/openai.go
@@ -107,7 +107,7 @@ func (p *openAIProvider) complete(ctx context.Context, messages []openAIMessage)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err

--- a/backend/internal/ai/qwen.go
+++ b/backend/internal/ai/qwen.go
@@ -86,21 +86,21 @@ type qwenInput struct {
 
 type qwenParams struct {
 	ResultFormat string  `json:"result_format"`
-	MaxTokens  int     `json:"max_tokens,omitempty"`
-	Temperature float64 `json:"temperature,omitempty"`
+	MaxTokens    int     `json:"max_tokens,omitempty"`
+	Temperature  float64 `json:"temperature,omitempty"`
 }
 
 type qwenResponse struct {
-	Code      string `json:"code"`
-	Message  string `json:"message"`
-	Output   qwenOutput `json:"output"`
-	Usage    qwenUsage `json:"usage"`
+	Code    string     `json:"code"`
+	Message string     `json:"message"`
+	Output  qwenOutput `json:"output"`
+	Usage   qwenUsage  `json:"usage"`
 }
 
 type qwenOutput struct {
 	Choices []struct {
-		FinishReason string     `json:"finish_reason"`
-		Message   qwenMessage `json:"message"`
+		FinishReason string      `json:"finish_reason"`
+		Message      qwenMessage `json:"message"`
 	} `json:"choices"`
 }
 
@@ -118,8 +118,8 @@ func (p *qwenProvider) complete(ctx context.Context, messages []qwenMessage) (st
 		Input: qwenInput{Messages: messages},
 		Parameters: qwenParams{
 			ResultFormat: "message",
-			MaxTokens:   512,
-			Temperature: 0.2,
+			MaxTokens:    512,
+			Temperature:  0.2,
 		},
 	})
 	if err != nil {
@@ -137,7 +137,7 @@ func (p *qwenProvider) complete(ctx context.Context, messages []qwenMessage) (st
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -36,6 +36,10 @@ type Config struct {
 	// hit it in normal use.
 	RateLimitPerMinute int  `env:"RATE_LIMIT_PER_MINUTE" envDefault:"120"`
 	RateLimitDisabled  bool `env:"RATE_LIMIT_DISABLED" envDefault:"false"`
+	// AuthRateLimitPerMinute caps requests per IP on the unauthenticated
+	// /auth endpoints (login, register, refresh). Kept low to blunt
+	// brute-force / credential-stuffing without affecting normal users.
+	AuthRateLimitPerMinute int `env:"AUTH_RATE_LIMIT_PER_MINUTE" envDefault:"15"`
 
 	// ─── Feature flags (June 2026 review, issue #123) ───
 	// Premature social/enterprise surfaces ship default-off so solo users

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -11,16 +11,16 @@ import (
 // Config holds all environment-driven configuration for the API.
 // Wave 1 only uses the `token` AuthMode. JWT/OAuth fields land in Wave 4.
 type Config struct {
-	Port           string `env:"PORT" envDefault:"8080"`
-	DBURL          string `env:"DB_URL,required"`
-	DBURLReadOnly  string `env:"DB_READ_ONLY_URL"`
-	RedisURL       string `env:"REDIS_URL"`
-	AppRegion      string `env:"APP_REGION" envDefault:"us-east"`
-	AuthMode       string `env:"AUTH_MODE" envDefault:"token"`
-	APIToken    string `env:"API_TOKEN"`
-	GithubToken string `env:"GITHUB_TOKEN"`
-	LogLevel    string `env:"LOG_LEVEL" envDefault:"info"`
-	CORSOrigins string `env:"CORS_ORIGINS" envDefault:"app://.,http://localhost:5173"`
+	Port          string `env:"PORT" envDefault:"8080"`
+	DBURL         string `env:"DB_URL,required"`
+	DBURLReadOnly string `env:"DB_READ_ONLY_URL"`
+	RedisURL      string `env:"REDIS_URL"`
+	AppRegion     string `env:"APP_REGION" envDefault:"us-east"`
+	AuthMode      string `env:"AUTH_MODE" envDefault:"token"`
+	APIToken      string `env:"API_TOKEN"`
+	GithubToken   string `env:"GITHUB_TOKEN"`
+	LogLevel      string `env:"LOG_LEVEL" envDefault:"info"`
+	CORSOrigins   string `env:"CORS_ORIGINS" envDefault:"app://.,http://localhost:5173"`
 
 	// RefreshIntervalHours: a repo whose last_fetched_at is older than this
 	// gets re-enriched by the cron worker. Default 168h = 7 days.
@@ -73,18 +73,18 @@ type Config struct {
 	FrontendURL      string `env:"FRONTEND_URL" envDefault:"http://localhost:5173"`
 
 	// ─── Wave 5 Fase 18: local AI enrichment ───
-	AIProvider       string `env:"AI_PROVIDER" envDefault:"heuristic"`
+	AIProvider      string `env:"AI_PROVIDER" envDefault:"heuristic"`
 	OpenAIAPIKey    string `env:"OPENAI_API_KEY"`
-	OpenAIModel    string `env:"OPENAI_MODEL" envDefault:"gpt-4o-mini"`
-	OllamaBaseURL  string `env:"OLLAMA_BASE_URL" envDefault:"http://localhost:11434"`
-	OllamaModel    string `env:"OLLAMA_MODEL" envDefault:"llama3"`
-	QwenAPIKey     string `env:"QWEN_API_KEY"`     // Alibaba DashScope
-	QwenModel      string `env:"QWEN_MODEL" envDefault:"qwen-turbo"`
-	DeepSeekAPIKey string `env:"DEEPSEEK_API_KEY"`
-	DeepSeekModel  string `env:"DEEPSEEK_MODEL" envDefault:"deepseek-chat"`
+	OpenAIModel     string `env:"OPENAI_MODEL" envDefault:"gpt-4o-mini"`
+	OllamaBaseURL   string `env:"OLLAMA_BASE_URL" envDefault:"http://localhost:11434"`
+	OllamaModel     string `env:"OLLAMA_MODEL" envDefault:"llama3"`
+	QwenAPIKey      string `env:"QWEN_API_KEY"` // Alibaba DashScope
+	QwenModel       string `env:"QWEN_MODEL" envDefault:"qwen-turbo"`
+	DeepSeekAPIKey  string `env:"DEEPSEEK_API_KEY"`
+	DeepSeekModel   string `env:"DEEPSEEK_MODEL" envDefault:"deepseek-chat"`
 	LMStudioBaseURL string `env:"LM_STUDIO_BASE_URL" envDefault:"http://localhost:1234"`
 	LMStudioModel   string `env:"LM_STUDIO_MODEL" envDefault:""`
-	AIExternalOptIn bool  `env:"AI_EXTERNAL_OPT_IN" envDefault:"false"`
+	AIExternalOptIn bool   `env:"AI_EXTERNAL_OPT_IN" envDefault:"false"`
 }
 
 func (c Config) CORSOriginList() []string {

--- a/backend/internal/cron/digest.go
+++ b/backend/internal/cron/digest.go
@@ -108,7 +108,7 @@ func buildDigestSummary(itemNodes []*items.Item, total int) string {
 	}
 
 	if total > shown {
-		b.WriteString(fmt.Sprintf("…and %d more in your vault.\n", total-shown))
+		fmt.Fprintf(&b, "…and %d more in your vault.\n", total-shown)
 	}
 
 	b.WriteString("\nRevisit them before they fade.")

--- a/backend/internal/domain/auth/auth.go
+++ b/backend/internal/domain/auth/auth.go
@@ -8,14 +8,14 @@ import (
 
 // User represents an authenticated user (sourced from GitHub OAuth).
 type User struct {
-	ID          uuid.UUID `json:"id"`
-	GitHubID    *int64    `json:"github_id"`
-	Login       string    `json:"login"`
-	Username    *string   `json:"username,omitempty"`
-	Bio         *string   `json:"bio,omitempty"`
-	Plan        string    `json:"plan"`
-	AvatarURL   string    `json:"avatar_url"`
-	DisplayName string    `json:"display_name"`
+	ID                  uuid.UUID `json:"id"`
+	GitHubID            *int64    `json:"github_id"`
+	Login               string    `json:"login"`
+	Username            *string   `json:"username,omitempty"`
+	Bio                 *string   `json:"bio,omitempty"`
+	Plan                string    `json:"plan"`
+	AvatarURL           string    `json:"avatar_url"`
+	DisplayName         string    `json:"display_name"`
 	Role                string    `json:"role"`
 	Region              string    `json:"region"`
 	OnboardingCompleted bool      `json:"onboarding_completed"`

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -65,7 +65,7 @@ func (s *ResendSender) Send(ctx context.Context, to, subject, htmlBody string) e
 	if err != nil {
 		return fmt.Errorf("failed to send email: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("resend API returned status %d", resp.StatusCode)

--- a/backend/internal/enricher/external.go
+++ b/backend/internal/enricher/external.go
@@ -48,7 +48,7 @@ func (w *WebhookEnricher) Fetch(ctx context.Context, rawURL string) (*repos.Meta
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("webhook enricher %s returned status %d", w.name, resp.StatusCode)

--- a/backend/internal/enricher/generic.go
+++ b/backend/internal/enricher/generic.go
@@ -41,7 +41,7 @@ func (e *OpenGraphEnricher) Fetch(ctx context.Context, rawURL string) (*repos.Me
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("og fetch: %s", resp.Status)

--- a/backend/internal/enricher/github.go
+++ b/backend/internal/enricher/github.go
@@ -71,7 +71,7 @@ func (g *GitHubEnricher) Fetch(ctx context.Context, owner, repo string) (*repos.
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/backend/internal/enricher/package_scripts.go
+++ b/backend/internal/enricher/package_scripts.go
@@ -40,7 +40,7 @@ func (g *GitHubEnricher) FetchPackageScripts(ctx context.Context, owner, repo st
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/backend/internal/enricher/readme.go
+++ b/backend/internal/enricher/readme.go
@@ -36,7 +36,7 @@ func (g *GitHubEnricher) FetchReadme(ctx context.Context, owner, repo string) (s
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/backend/internal/enricher/stars.go
+++ b/backend/internal/enricher/stars.go
@@ -60,17 +60,17 @@ func (g *GitHubEnricher) listStarred(ctx context.Context, username string, maxRe
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("github user %q not found", username)
 		}
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil, fmt.Errorf("github starred request failed with status %d", resp.StatusCode)
 		}
 
 		var pageRepos []StarredRepo
 		err = json.NewDecoder(resp.Body).Decode(&pageRepos)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/http/handlers/agent.go
+++ b/backend/internal/http/handlers/agent.go
@@ -48,7 +48,7 @@ func (h *AgentHandler) Chat(w http.ResponseWriter, r *http.Request) {
 
 	sendEvent := func(data any) {
 		buf, _ := json.Marshal(data)
-		fmt.Fprintf(w, "data: %s\n\n", buf)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", buf)
 		flusher.Flush()
 	}
 

--- a/backend/internal/http/handlers/ask.go
+++ b/backend/internal/http/handlers/ask.go
@@ -56,12 +56,10 @@ func (h *AskHandler) Ask(w http.ResponseWriter, r *http.Request) {
 	var embedding []float32
 	if h.embeddings != nil && h.embeddings.Enabled() {
 		emb, err := h.embeddings.EmbedSearch(r.Context(), req.Question)
-		if err != nil {
-			// Log but continue with text search
-			emb = nil
-		} else {
+		if err == nil {
 			embedding = emb
 		}
+		// On error, fall back to text search with a nil embedding.
 	}
 
 	result, err := h.store.AskDevDeck(r.Context(), req.Question, embedding, 5)

--- a/backend/internal/http/handlers/auth.go
+++ b/backend/internal/http/handlers/auth.go
@@ -103,10 +103,13 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Clear the cookie
 	http.SetCookie(w, &http.Cookie{
-		Name:   "oauth_state",
-		Value:  "",
-		Path:   "/",
-		MaxAge: -1,
+		Name:     "oauth_state",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
 	})
 
 	code := r.FormValue("code")
@@ -184,7 +187,7 @@ func (h *AuthHandler) fetchGitHubUser(code string) (*auth.GitHubUser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var tokenResp struct {
 		AccessToken string `json:"access_token"`
@@ -205,7 +208,7 @@ func (h *AuthHandler) fetchGitHubUser(code string) (*auth.GitHubUser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var ghUser auth.GitHubUser
 	if err := json.NewDecoder(resp.Body).Decode(&ghUser); err != nil {
@@ -301,7 +304,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		writeInternal(w, err)
 		return
 	}
-	defer tx.Rollback(r.Context())
+	defer func() { _ = tx.Rollback(r.Context()) }()
 
 	user, err := h.store.CreateUserLocalTx(r.Context(), tx, body.Email, string(hash))
 	if err != nil {
@@ -428,6 +431,7 @@ func (h *AuthHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 
 	// Limit request size to 5MB
 	r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024)
+	// #nosec G120 -- request body is already bounded by MaxBytesReader above.
 	if err := r.ParseMultipartForm(5 * 1024 * 1024); err != nil {
 		writeError(w, http.StatusBadRequest, "FILE_TOO_LARGE", "file is too large (max 5MB)")
 		return
@@ -438,7 +442,7 @@ func (h *AuthHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "MISSING_FILE", "missing avatar file field")
 		return
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	// Read first 512 bytes to validate content type
 	buffer := make([]byte, 512)
@@ -461,7 +465,7 @@ func (h *AuthHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure uploads directory exists
 	uploadsDir := "./uploads"
-	if err := os.MkdirAll(uploadsDir, 0755); err != nil {
+	if err := os.MkdirAll(uploadsDir, 0750); err != nil {
 		writeInternal(w, err)
 		return
 	}
@@ -470,12 +474,13 @@ func (h *AuthHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 	filename := fmt.Sprintf("%s-%d.png", userID, time.Now().Unix())
 	filepath := filepath.Join(uploadsDir, filename)
 
+	// #nosec G304 -- filepath is built from a server-generated UUID and timestamp under a fixed uploads dir; not user-controlled.
 	out, err := os.Create(filepath)
 	if err != nil {
 		writeInternal(w, err)
 		return
 	}
-	defer out.Close()
+	defer func() { _ = out.Close() }()
 
 	if _, err = io.Copy(out, file); err != nil {
 		writeInternal(w, err)
@@ -492,7 +497,6 @@ func (h *AuthHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, map[string]string{"avatar_url": avatarURL})
 }
-
 
 // PATCH /api/auth/me/onboarding/complete
 func (h *AuthHandler) CompleteOnboarding(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/http/handlers/cheatsheets.go
+++ b/backend/internal/http/handlers/cheatsheets.go
@@ -351,27 +351,27 @@ func (h *CheatsheetsHandler) Export(w http.ResponseWriter, r *http.Request) {
 	if format == "json" {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.json\"", detail.Slug))
-		json.NewEncoder(w).Encode(detail)
+		_ = json.NewEncoder(w).Encode(detail)
 		return
 	}
 
 	// Default to markdown
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("# %s\n\n", detail.Title))
+	fmt.Fprintf(&sb, "# %s\n\n", detail.Title)
 	if detail.Description != "" {
 		sb.WriteString(detail.Description + "\n\n")
 	}
 	for _, e := range detail.Entries {
-		sb.WriteString(fmt.Sprintf("## %s\n", e.Label))
+		fmt.Fprintf(&sb, "## %s\n", e.Label)
 		if e.Description != "" {
 			sb.WriteString(e.Description + "\n\n")
 		}
-		sb.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", e.Command))
+		fmt.Fprintf(&sb, "```bash\n%s\n```\n\n", e.Command)
 	}
 
 	w.Header().Set("Content-Type", "text/markdown")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.md\"", detail.Slug))
-	w.Write([]byte(sb.String()))
+	_, _ = w.Write([]byte(sb.String()))
 }
 
 // GET /api/cheatsheets/{id}/badge
@@ -398,6 +398,7 @@ func (h *CheatsheetsHandler) Badge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	badgeURL := fmt.Sprintf("https://img.shields.io/badge/%s-%s-%s?logo=book", label, title, color)
+	// #nosec G710 -- redirect target is a fixed img.shields.io URL; user data is URL-escaped into path components only.
 	http.Redirect(w, r, badgeURL, http.StatusFound)
 }
 
@@ -433,7 +434,8 @@ func (h *CheatsheetsHandler) Card(w http.ResponseWriter, r *http.Request) {
 	`, html.EscapeString(detail.Title), html.EscapeString(detail.Category), len(detail.Entries))
 
 	w.Header().Set("Content-Type", "image/svg+xml")
-	w.Write([]byte(svg))
+	// #nosec G705 -- all dynamic values are escaped via html.EscapeString before being embedded in the SVG.
+	_, _ = w.Write([]byte(svg))
 }
 
 // ───── helpers ─────

--- a/backend/internal/http/handlers/circles_test.go
+++ b/backend/internal/http/handlers/circles_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"devdeck/internal/domain/circles"
+
 	"github.com/google/uuid"
 )
 

--- a/backend/internal/http/handlers/health.go
+++ b/backend/internal/http/handlers/health.go
@@ -1,8 +1,8 @@
 package handlers
 
 import (
-	"net/http"
 	"devdeck/internal/store"
+	"net/http"
 )
 
 type HealthHandler struct {
@@ -15,7 +15,7 @@ func NewHealthHandler(s *store.Store) *HealthHandler {
 
 func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	
+
 	if err := h.store.Ping(r.Context()); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"status":"error","details":"database unreachable"}`))

--- a/backend/internal/http/handlers/items.go
+++ b/backend/internal/http/handlers/items.go
@@ -53,9 +53,18 @@ func (h *ItemsHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	if v := q.Get("limit"); v != "" {
 		p.Limit, _ = strconv.Atoi(v)
+		if p.Limit > maxListLimit {
+			p.Limit = maxListLimit
+		}
+		if p.Limit < 0 {
+			p.Limit = 0
+		}
 	}
 	if v := q.Get("offset"); v != "" {
 		p.Offset, _ = strconv.Atoi(v)
+		if p.Offset < 0 {
+			p.Offset = 0
+		}
 	}
 
 	res, err := h.store.ListItems(r.Context(), p)

--- a/backend/internal/http/handlers/plugins.go
+++ b/backend/internal/http/handlers/plugins.go
@@ -5,17 +5,17 @@ import (
 )
 
 type PluginTemplate struct {
-	ID          string   `json:"id"`
-	Type        string   `json:"type"` // "enricher" or "webhook"
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Author      string   `json:"author"`
-	IconURL     string   `json:"icon_url"`
+	ID          string `json:"id"`
+	Type        string `json:"type"` // "enricher" or "webhook"
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Author      string `json:"author"`
+	IconURL     string `json:"icon_url"`
 	// For Enrichers
-	URLPattern  *string  `json:"url_pattern,omitempty"`
-	EndpointURL *string  `json:"endpoint_url,omitempty"`
+	URLPattern  *string `json:"url_pattern,omitempty"`
+	EndpointURL *string `json:"endpoint_url,omitempty"`
 	// For Webhooks
-	Events      []string `json:"events,omitempty"`
+	Events []string `json:"events,omitempty"`
 }
 
 var featuredPlugins = []PluginTemplate{

--- a/backend/internal/http/handlers/preview.go
+++ b/backend/internal/http/handlers/preview.go
@@ -21,11 +21,11 @@ type PreviewInput struct {
 }
 
 type PreviewResponse struct {
-	URL         string  `json:"url,omitempty"`
-	Title       string  `json:"title,omitempty"`
-	Description string  `json:"description,omitempty"`
-	Image       string  `json:"image,omitempty"`
-	Type        string  `json:"type"`
+	URL         string `json:"url,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Image       string `json:"image,omitempty"`
+	Type        string `json:"type"`
 }
 
 func NewPreviewHandler(en *enricher.Service) *PreviewHandler {

--- a/backend/internal/http/handlers/realtime.go
+++ b/backend/internal/http/handlers/realtime.go
@@ -31,7 +31,7 @@ func (r *Room) broadcast(msgType int, data []byte, sender *websocket.Conn) {
 		}
 		if err := client.WriteMessage(msgType, data); err != nil {
 			slog.Error("failed to broadcast message", "room", r.id, "err", err)
-			client.Close()
+			_ = client.Close()
 			delete(r.clients, client)
 		}
 	}
@@ -61,7 +61,7 @@ func (h *RealtimeHandler) Connect(w http.ResponseWriter, r *http.Request) {
 		slog.Error("failed to upgrade to websocket", "err", err)
 		return
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	h.mu.Lock()
 	room, ok := h.rooms[roomID]
@@ -99,6 +99,6 @@ func (h *RealtimeHandler) Connect(w http.ResponseWriter, r *http.Request) {
 	}
 	room.mu.Unlock()
 	h.mu.Unlock()
-	
+
 	slog.Info("client disconnected from room", "room", roomID)
 }

--- a/backend/internal/http/handlers/repos.go
+++ b/backend/internal/http/handlers/repos.go
@@ -94,12 +94,15 @@ func (h *ReposHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if v := q.Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			if n > maxListLimit {
+				n = maxListLimit
+			}
 			p.Limit = n
 		}
 	}
 	if v := q.Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			p.Offset = n
 		}
 	}

--- a/backend/internal/http/handlers/repos.go
+++ b/backend/internal/http/handlers/repos.go
@@ -284,7 +284,6 @@ func (h *ReposHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	}
 	md, err := h.enricher.Enrich(r.Context(), repo.URL, nil)
 
-
 	if err != nil {
 		writeError(w, http.StatusUnprocessableEntity, "ENRICH_FAILED", err.Error())
 		return

--- a/backend/internal/http/handlers/response.go
+++ b/backend/internal/http/handlers/response.go
@@ -37,8 +37,3 @@ func writeInternal(w http.ResponseWriter, err error) {
 	slog.Error("internal error", "err", err)
 	writeError(w, http.StatusInternalServerError, "INTERNAL", "internal server error")
 }
-
-func decodeJSON(r *http.Request, v any) error {
-	defer r.Body.Close()
-	return json.NewDecoder(r.Body).Decode(v)
-}

--- a/backend/internal/http/handlers/response.go
+++ b/backend/internal/http/handlers/response.go
@@ -6,6 +6,10 @@ import (
 	"net/http"
 )
 
+// maxListLimit caps user-supplied pagination "limit" values so a single
+// request can't ask for an unbounded number of rows (memory-exhaustion DoS).
+const maxListLimit = 500
+
 type errBody struct {
 	Error errPayload `json:"error"`
 }
@@ -28,15 +32,10 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 }
 
 func writeInternal(w http.ResponseWriter, err error) {
+	// Log the real error server-side; never leak internal/DB error text
+	// (constraint names, query fragments) to the client.
 	slog.Error("internal error", "err", err)
-	// Include actual error for debugging
-	writeJSON(w, http.StatusInternalServerError, map[string]any{
-		"error": map[string]string{
-			"code":    "INTERNAL",
-			"message": "internal server error: " + err.Error(),
-			"detail":  err.Error(),
-		},
-	})
+	writeError(w, http.StatusInternalServerError, "INTERNAL", "internal server error")
 }
 
 func decodeJSON(r *http.Request, v any) error {

--- a/backend/internal/http/handlers/saml.go
+++ b/backend/internal/http/handlers/saml.go
@@ -73,7 +73,7 @@ func (h *SAMLHandler) Metadata(w http.ResponseWriter, r *http.Request) {
 	sp := h.makeSP(nil) // Generic metadata
 	buf, _ := xml.Marshal(sp.Metadata())
 	w.Header().Set("Content-Type", "application/samlmetadata+xml")
-	w.Write(buf)
+	_, _ = w.Write(buf)
 }
 
 // GET /api/auth/saml/login
@@ -102,10 +102,10 @@ func (h *SAMLHandler) ACS(w http.ResponseWriter, r *http.Request) {
 
 func (h *SAMLHandler) makeSP(idpMetadata *saml.EntityDescriptor) *saml.ServiceProvider {
 	return &saml.ServiceProvider{
-		EntityID:          h.config.EntityID,
-		AcsURL:            h.makeURL("/api/auth/saml/acs"),
-		MetadataURL:       h.makeURL("/api/auth/saml/metadata"),
-		IDPMetadata:       idpMetadata,
+		EntityID:    h.config.EntityID,
+		AcsURL:      h.makeURL("/api/auth/saml/acs"),
+		MetadataURL: h.makeURL("/api/auth/saml/metadata"),
+		IDPMetadata: idpMetadata,
 	}
 }
 

--- a/backend/internal/http/handlers/scim.go
+++ b/backend/internal/http/handlers/scim.go
@@ -125,6 +125,6 @@ func (h *SCIMHandler) DeleteUser(w http.ResponseWriter, r *http.Request) {
 	// We need a Store method to remove org member.
 	_ = orgID
 	_ = userID
-	
+
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/http/handlers/stats.go
+++ b/backend/internal/http/handlers/stats.go
@@ -54,7 +54,7 @@ func (h *StatsHandler) GetGlobal(w http.ResponseWriter, r *http.Request) {
 	// Simple role check (if we had middleware for this it would be better,
 	// but let's do it here for now as requested in Phase 30 refactor).
 	// Actually, I'll assume it's protected by route group or check it.
-	
+
 	gs, err := h.store.GetGlobalStats(r.Context())
 	if err != nil {
 		writeInternal(w, err)

--- a/backend/internal/http/handlers/sync.go
+++ b/backend/internal/http/handlers/sync.go
@@ -26,12 +26,12 @@ type SyncResponse struct {
 
 // SyncDeltaResult describes a delta change from the server.
 type SyncDeltaResult struct {
-	OperationID uuid.UUID     `json:"operation_id"`
-	Operation  string       `json:"operation"`
-	EntityType string       `json:"entity_type"`
-	EntityID  uuid.UUID    `json:"entity_id"`
-	Payload   interface{} `json:"payload,omitempty"`
-	CreatedAt string       `json:"created_at"`
+	OperationID uuid.UUID   `json:"operation_id"`
+	Operation   string      `json:"operation"`
+	EntityType  string      `json:"entity_type"`
+	EntityID    uuid.UUID   `json:"entity_id"`
+	Payload     interface{} `json:"payload,omitempty"`
+	CreatedAt   string      `json:"created_at"`
 }
 
 // SyncHandler handles offline sync operations.
@@ -126,12 +126,12 @@ type SyncQueue struct {
 
 type PendingOperation struct {
 	OperationID uuid.UUID
-	Operation  string
-	EntityType string
-	EntityID  uuid.UUID
-	Payload   map[string]any
-	CreatedAt  int64
-	Retries   int
+	Operation   string
+	EntityType  string
+	EntityID    uuid.UUID
+	Payload     map[string]any
+	CreatedAt   int64
+	Retries     int
 }
 
 // NewSyncQueue creates a new sync queue.
@@ -177,10 +177,10 @@ func (q *SyncQueue) Count() int {
 type SyncStatus string
 
 const (
-	SyncStatusSynced   SyncStatus = "synced"
-	SyncStatusPending  SyncStatus = "pending"
+	SyncStatusSynced  SyncStatus = "synced"
+	SyncStatusPending SyncStatus = "pending"
 	SyncStatusOffline SyncStatus = "offline"
-	SyncStatusError  SyncStatus = "error"
+	SyncStatusError   SyncStatus = "error"
 )
 
 // NewSyncStatus returns initial sync status.
@@ -194,12 +194,12 @@ func NewSyncStatus() SyncStatus {
 type Device struct {
 	ID         uuid.UUID `json:"id"`
 	ClientID   uuid.UUID `json:"client_id"`
-	Name      string   `json:"name,omitempty"`
-	DeviceType string   `json:"device_type"`
-	LastSync  string   `json:"last_sync_at,omitempty"`
-	LastSeen  string   `json:"last_seen_at"`
-	CreatedAt string   `json:"created_at"`
-	IsActive  bool     `json:"is_active"`
+	Name       string    `json:"name,omitempty"`
+	DeviceType string    `json:"device_type"`
+	LastSync   string    `json:"last_sync_at,omitempty"`
+	LastSeen   string    `json:"last_seen_at"`
+	CreatedAt  string    `json:"created_at"`
+	IsActive   bool      `json:"is_active"`
 }
 
 // DevicesHandler manages user devices.
@@ -286,12 +286,4 @@ func (h *DevicesHandler) Register(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"registered": true,
 	})
-}
-
-// FormatTime formats a time for JSON response.
-func formatTime(t time.Time) string {
-	if t.IsZero() {
-		return ""
-	}
-	return t.Format(time.RFC3339)
 }

--- a/backend/internal/http/handlers/system_test.go
+++ b/backend/internal/http/handlers/system_test.go
@@ -19,7 +19,7 @@ func TestHandlers_SystemConfig_Get(t *testing.T) {
 	}
 
 	config := decodeJSON[systemConfig](t, rec)
-	
+
 	// ai_provider defaults to "heuristic" in newTestServer because it uses ai.NewHeuristic()
 	// actually, the config endpoint is wired up in router.go using:
 	// systemH := handlers.NewSystemConfigHandler(cfg.AIProvider, false)

--- a/backend/internal/http/middleware/auth.go
+++ b/backend/internal/http/middleware/auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"bytes"
 	"crypto/subtle"
 	"encoding/json"
 	"net/http"
@@ -93,7 +92,7 @@ func OptionalTokenAuth(cfg config.Config, authService *authservice.Service, st *
 				// Static token mode
 				if strings.HasPrefix(h, prefix) {
 					got := []byte(strings.TrimPrefix(h, prefix))
-					if bytes.Equal(got, expected) {
+					if subtle.ConstantTimeCompare(got, expected) == 1 {
 						testUserID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 						ctx := authctx.WithUserID(r.Context(), testUserID)
 						next.ServeHTTP(w, r.WithContext(ctx))

--- a/backend/internal/http/middleware/auth.go
+++ b/backend/internal/http/middleware/auth.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"crypto/subtle"
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -150,17 +149,6 @@ func unauthorized(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"error":{"code":"UNAUTHORIZED","message":"missing or invalid bearer token"}}`))
-}
-
-func writeError(w http.ResponseWriter, status int, code, msg string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"error": map[string]string{
-			"code":    code,
-			"message": msg,
-		},
-	})
 }
 
 // SCIMAuth validates a SCIM bearer token for an organization.

--- a/backend/internal/http/middleware/rate_limit.go
+++ b/backend/internal/http/middleware/rate_limit.go
@@ -9,44 +9,38 @@ import (
 	"github.com/go-chi/httprate"
 )
 
-// IARateLimit implements a multi-tier rate limit based on the user's plan.
+// IARateLimit implements a multi-tier per-hour rate limit based on the user's
+// plan. The two underlying limiters are constructed ONCE (when the middleware
+// is built) so their counters persist across requests; each request is then
+// dispatched to the pro or free limiter based on the plan in the context.
+// Keying is by user ID when authenticated, falling back to IP.
 func IARateLimit(proLimit, freeLimit int) func(http.Handler) http.Handler {
+	keyFunc := func(r *http.Request) (string, error) {
+		if userID, ok := authctx.UserID(r.Context()); ok {
+			return userID.String(), nil
+		}
+		return httprate.KeyByIP(r)
+	}
+
+	limitHandler := httprate.WithLimitHandler(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"AI_RATE_LIMITED","message":"cuota de IA agotada por esta hora"}}`))
+	})
+
+	proLimiter := httprate.Limit(proLimit, 1*time.Hour, httprate.WithKeyFuncs(keyFunc), limitHandler)
+	freeLimiter := httprate.Limit(freeLimit, 1*time.Hour, httprate.WithKeyFuncs(keyFunc), limitHandler)
+
 	return func(next http.Handler) http.Handler {
-		// We use httprate internally but with a custom key function
-		// and a limit handler that checks the user's plan from the context.
-		// Since chi middlewares are static, we'll implement a dynamic one here.
-		
+		proHandler := proLimiter(next)
+		freeHandler := freeLimiter(next)
+
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			plan, _ := authctx.UserPlan(r.Context())
-			
-			limit := freeLimit
-			if plan == "pro" {
-				limit = proLimit
+			if plan, _ := authctx.UserPlan(r.Context()); plan == "pro" {
+				proHandler.ServeHTTP(w, r)
+				return
 			}
-
-			// For Wave 7 / Phase 24, we'll keep it simple: 
-			// use httprate with UserID as key if logged in, IP otherwise.
-			keyFunc := func(r *http.Request) (string, error) {
-				if userID, ok := authctx.UserID(r.Context()); ok {
-					return userID.String(), nil
-				}
-				return httprate.KeyByIP(r)
-			}
-
-			// We need a way to apply the limit dynamically.
-			// Httprate doesn't easily support dynamic limits in one middleware instance.
-			// So we'll use a fixed conservative limit for now and improve in next waves.
-			
-			httprate.Limit(
-				limit,
-				1*time.Hour,
-				httprate.WithKeyFuncs(keyFunc),
-				httprate.WithLimitHandler(func(w http.ResponseWriter, _ *http.Request) {
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusTooManyRequests)
-					_, _ = w.Write([]byte(`{"error":{"code":"AI_RATE_LIMITED","message":"cuota de IA agotada por esta hora"}}`))
-				}),
-			)(next).ServeHTTP(w, r)
+			freeHandler.ServeHTTP(w, r)
 		})
 	}
 }

--- a/backend/internal/http/middleware/rbac.go
+++ b/backend/internal/http/middleware/rbac.go
@@ -50,7 +50,7 @@ func RequireOrgPermission(st *store.Store, permission string) func(http.Handler)
 
 			orgID, ok := authctx.OrgID(r.Context())
 			if !ok {
-				// If no active org, we assume it's personal vault. 
+				// If no active org, we assume it's personal vault.
 				// For now, if a route requires an org permission, it MUST have an active org.
 				forbidden(w, "organization context required")
 				return

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -169,23 +169,40 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 				r.Patch("/me/onboarding/complete", authH.CompleteOnboarding)
 			})
 
-			// OAuth/JWT only endpoints
+			// OAuth/JWT only endpoints. These are unauthenticated and must be
+			// rate-limited (per IP) to blunt brute-force / credential-stuffing
+			// against login/register/refresh.
 			if cfg.AuthMode == "jwt" {
-				r.Get("/providers", authH.Providers)
-				r.Post("/register", authH.Register)
-				r.Post("/login", authH.LoginLocal)
-				r.Post("/login-step1", samlH.LoginStep1)
-				r.Get("/github/login", authH.Login)
-				r.Get("/github/callback", authH.Callback)
+				r.Group(func(r chi.Router) {
+					if !cfg.RateLimitDisabled {
+						r.Use(httprate.Limit(
+							cfg.AuthRateLimitPerMinute,
+							1*time.Minute,
+							httprate.WithKeyFuncs(httprate.KeyByIP),
+							httprate.WithLimitHandler(func(w http.ResponseWriter, _ *http.Request) {
+								w.Header().Set("Content-Type", "application/json")
+								w.WriteHeader(http.StatusTooManyRequests)
+								_, _ = w.Write([]byte(`{"error":{"code":"RATE_LIMITED","message":"too many requests, slow down"}}`))
+							}),
+						))
+					}
 
-				r.Route("/saml", func(r chi.Router) {
-					r.Get("/metadata", samlH.Metadata)
-					r.Get("/login", samlH.Login)
-					r.Post("/acs", samlH.ACS)
+					r.Get("/providers", authH.Providers)
+					r.Post("/register", authH.Register)
+					r.Post("/login", authH.LoginLocal)
+					r.Post("/login-step1", samlH.LoginStep1)
+					r.Get("/github/login", authH.Login)
+					r.Get("/github/callback", authH.Callback)
+
+					r.Route("/saml", func(r chi.Router) {
+						r.Get("/metadata", samlH.Metadata)
+						r.Get("/login", samlH.Login)
+						r.Post("/acs", samlH.ACS)
+					})
+
+					r.Post("/refresh", authH.Refresh)
+					r.Post("/logout", authH.Logout)
 				})
-
-				r.Post("/refresh", authH.Refresh)
-				r.Post("/logout", authH.Logout)
 			}
 		})
 

--- a/backend/internal/store/activity.go
+++ b/backend/internal/store/activity.go
@@ -10,18 +10,18 @@ import (
 )
 
 type ActivityEntry struct {
-	ID         uuid.UUID       `json:"id"`
-	OrgID      uuid.UUID       `json:"org_id"`
-	UserID     uuid.UUID       `json:"user_id"`
-	Action     string          `json:"action"`
-	EntityType string          `json:"entity_type"`
-	EntityID   uuid.UUID       `json:"entity_id"`
-	Metadata   map[string]any  `json:"metadata,omitempty"`
-	CreatedAt  time.Time       `json:"created_at"`
-	
+	ID         uuid.UUID      `json:"id"`
+	OrgID      uuid.UUID      `json:"org_id"`
+	UserID     uuid.UUID      `json:"user_id"`
+	Action     string         `json:"action"`
+	EntityType string         `json:"entity_type"`
+	EntityID   uuid.UUID      `json:"entity_id"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	CreatedAt  time.Time      `json:"created_at"`
+
 	// JOINed data
-	UserDisplayName string  `json:"user_display_name,omitempty"`
-	UserAvatarURL   string  `json:"user_avatar_url,omitempty"`
+	UserDisplayName string `json:"user_display_name,omitempty"`
+	UserAvatarURL   string `json:"user_avatar_url,omitempty"`
 }
 
 // RecordActivity logs an event in the organization's audit log.

--- a/backend/internal/store/cheatsheets.go
+++ b/backend/internal/store/cheatsheets.go
@@ -2,12 +2,11 @@ package store
 
 import (
 	"context"
+	"devdeck/internal/domain/cheatsheets"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
-	"devdeck/internal/domain/cheatsheets"
-	domainitems "devdeck/internal/domain/items"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -218,13 +217,12 @@ func (s *Store) ExploreCheatsheets(ctx context.Context, category string, officia
 	idx := 1
 
 	if officialOnly {
-		q += fmt.Sprintf(` AND is_official = TRUE`)
+		q += ` AND is_official = TRUE`
 	}
 
 	if category != "" {
 		q += fmt.Sprintf(` AND category = $%d`, idx)
 		args = append(args, category)
-		idx++
 	}
 
 	q += ` ORDER BY is_official DESC, fork_count DESC, title ASC LIMIT 50`
@@ -309,7 +307,7 @@ func (s *Store) StarCheatsheet(ctx context.Context, id uuid.UUID) error {
 		return errors.New("unauthorized")
 	}
 
-	_, err := s.Writer().Exec(ctx, `
+	_, _ = s.Writer().Exec(ctx, `
 		INSERT INTO cheatsheet_stars (user_id, cheatsheet_id)
 		VALUES ($1, $2)
 		ON CONFLICT (user_id, cheatsheet_id) DO DELETE
@@ -317,6 +315,7 @@ func (s *Store) StarCheatsheet(ctx context.Context, id uuid.UUID) error {
 	// Wait, ON CONFLICT DO DELETE is not standard PG.
 
 	// Better toggle logic:
+	var err error
 	var exists bool
 	_ = s.Reader().QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM cheatsheet_stars WHERE user_id = $1 AND cheatsheet_id = $2)`, userID, id).Scan(&exists)
 
@@ -566,8 +565,8 @@ func (s *Store) Search(ctx context.Context, mode SearchMode, query string, query
 	}
 	for _, r := range itemResults {
 		out = append(out, SearchResult{
-			Type:        "item",
-			ID:          r.ID.String(),
+			Type:     "item",
+			ID:       r.ID.String(),
 			Title:    r.Title,
 			Subtitle: string(r.Type) + " · " + r.WhySaved,
 			Extra:    derefStr(r.URL),
@@ -683,25 +682,6 @@ func (s *Store) Search(ctx context.Context, mode SearchMode, query string, query
 	rows.Close()
 
 	return out, nil
-}
-
-func itemSearchSubtitle(itemType domainitems.Type, why, summary, desc string) string {
-	parts := []string{string(itemType)}
-	if why != "" {
-		parts = append(parts, why)
-	} else if summary != "" {
-		parts = append(parts, summary)
-	} else if desc != "" {
-		parts = append(parts, desc)
-	}
-	return strings.Join(parts, " · ")
-}
-
-func itemSearchExtra(url *string, notes string) string {
-	if url != nil && *url != "" {
-		return *url
-	}
-	return notes
 }
 
 // ───── Seed helpers ─────

--- a/backend/internal/store/custom_enrichers.go
+++ b/backend/internal/store/custom_enrichers.go
@@ -35,13 +35,13 @@ func (s *Store) CreateCustomEnricher(ctx context.Context, userID, orgID *uuid.UU
 func (s *Store) ListCustomEnrichers(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID) ([]CustomEnricher, error) {
 	var rows pgx.Rows
 	var err error
-	
+
 	if orgID != nil {
 		rows, err = s.Reader().Query(ctx, `SELECT id, org_id, user_id, name, url_pattern, endpoint_url, auth_header, created_at, updated_at FROM custom_enrichers WHERE org_id = $1`, *orgID)
 	} else {
 		rows, err = s.Reader().Query(ctx, `SELECT id, org_id, user_id, name, url_pattern, endpoint_url, auth_header, created_at, updated_at FROM custom_enrichers WHERE user_id = $1 AND org_id IS NULL`, userID)
 	}
-	
+
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/store/decks.go
+++ b/backend/internal/store/decks.go
@@ -315,7 +315,7 @@ func (s *Store) ImportDeckItems(ctx context.Context, userID, sourceDeckID uuid.U
 	if err != nil {
 		return 0, err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	count := 0
 	for _, it := range items {

--- a/backend/internal/store/orgs.go
+++ b/backend/internal/store/orgs.go
@@ -13,7 +13,7 @@ func (s *Store) CreateOrganization(ctx context.Context, userID uuid.UUID, name s
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	var org auth.Organization
 	err = tx.QueryRow(ctx, `
@@ -85,10 +85,10 @@ func (s *Store) AddOrgMember(ctx context.Context, orgID, userID uuid.UUID, role 
 }
 
 type OrgInsights struct {
-	TotalItems     int              `json:"total_items"`
-	TopLanguages   []LanguageStat   `json:"top_languages"`
-	TopCurators    []CuratorStat    `json:"top_curators"`
-	RecentActivity int              `json:"recent_activity"`
+	TotalItems     int            `json:"total_items"`
+	TopLanguages   []LanguageStat `json:"top_languages"`
+	TopCurators    []CuratorStat  `json:"top_curators"`
+	RecentActivity int            `json:"recent_activity"`
 }
 
 type LanguageStat struct {

--- a/backend/internal/store/runbooks.go
+++ b/backend/internal/store/runbooks.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Runbook struct {
-	ID          uuid.UUID      `json:"id"`
-	UserID      uuid.UUID      `json:"user_id"`
-	ItemID      uuid.UUID      `json:"item_id"`
-	Title       string         `json:"title"`
-	Description *string        `json:"description,omitempty"`
-	Steps       []RunbookStep  `json:"steps,omitempty"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
+	ID          uuid.UUID     `json:"id"`
+	UserID      uuid.UUID     `json:"user_id"`
+	ItemID      uuid.UUID     `json:"item_id"`
+	Title       string        `json:"title"`
+	Description *string       `json:"description,omitempty"`
+	Steps       []RunbookStep `json:"steps,omitempty"`
+	CreatedAt   time.Time     `json:"created_at"`
+	UpdatedAt   time.Time     `json:"updated_at"`
 }
 
 type RunbookStep struct {
@@ -90,14 +90,14 @@ func (s *Store) ListRunbooksByItem(ctx context.Context, itemID uuid.UUID) ([]Run
 		if err := rows.Scan(&rb.ID, &rb.UserID, &rb.ItemID, &rb.Title, &rb.Description, &rb.CreatedAt, &rb.UpdatedAt); err != nil {
 			return nil, err
 		}
-		
+
 		// Load steps for each runbook
 		steps, err := s.listRunbookSteps(ctx, rb.ID)
 		if err != nil {
 			return nil, err
 		}
 		rb.Steps = steps
-		
+
 		runbooks = append(runbooks, rb)
 	}
 	return runbooks, rows.Err()
@@ -210,7 +210,7 @@ func (s *Store) ReorderRunbookSteps(ctx context.Context, runbookID uuid.UUID, st
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	for i, id := range stepIDs {
 		_, err := tx.Exec(ctx, "UPDATE runbook_steps SET position = $1 WHERE id = $2 AND runbook_id = $3", i, id, runbookID)

--- a/backend/internal/store/stats.go
+++ b/backend/internal/store/stats.go
@@ -148,7 +148,7 @@ func (s *Store) GetGlobalStats(ctx context.Context) (map[string]any, error) {
 	}
 
 	return map[string]any{
-		"current_region": s.appRegion,
+		"current_region":    s.appRegion,
 		"user_distribution": userRegions,
 		"sync_distribution": opRegions,
 	}, nil

--- a/backend/internal/store/sync.go
+++ b/backend/internal/store/sync.go
@@ -32,7 +32,7 @@ func (s *Store) ProcessSyncBatch(ctx context.Context, userID, clientID uuid.UUID
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	for _, op := range ops {
 		res := SyncOperationResult{OperationID: op.OperationID, Status: "success"}
@@ -72,7 +72,8 @@ func (s *Store) ProcessSyncBatch(ctx context.Context, userID, clientID uuid.UUID
 
 		// 4. Apply to entity (LWW)
 		if op.EntityType == "item" {
-			if op.Operation == "create" {
+			switch op.Operation {
+			case "create":
 				// Simplified create from payload
 				itRaw, _ := json.Marshal(op.Payload)
 				var it struct {
@@ -95,7 +96,7 @@ func (s *Store) ProcessSyncBatch(ctx context.Context, userID, clientID uuid.UUID
 					res.Status = "error"
 					res.Error = fmt.Sprintf("create item: %v", err)
 				}
-			} else if op.Operation == "update" {
+			case "update":
 				// LWW: Update only if client_updated_at > current updated_at
 				// We use a single query with a WHERE clause for atomic LWW
 				_, err = tx.Exec(ctx, `
@@ -115,7 +116,7 @@ func (s *Store) ProcessSyncBatch(ctx context.Context, userID, clientID uuid.UUID
 					res.Status = "error"
 					res.Error = fmt.Sprintf("update item: %v", err)
 				}
-			} else if op.Operation == "delete" {
+			case "delete":
 				_, err = tx.Exec(ctx, `
 					UPDATE items SET archived = true, updated_at = $3 WHERE id = $1 AND user_id = $2 AND updated_at < $3
 				`, op.EntityID, userID, op.ClientUpdatedAt)
@@ -232,4 +233,3 @@ func (s *Store) GetSyncDelta(ctx context.Context, userID, excludeClientID uuid.U
 	}
 	return out, rows.Err()
 }
-

--- a/backend/internal/testutil/postgres.go
+++ b/backend/internal/testutil/postgres.go
@@ -136,8 +136,10 @@ func preflightDocker(_ context.Context) error {
 		}
 	}
 	for _, p := range candidates {
+		// #nosec G703 -- p comes from a fixed candidate list of well-known docker socket paths, not external input.
 		if _, err := os.Stat(p); err == nil {
 			// Try a quick connect to make sure the daemon is actually up.
+			// #nosec G704 -- p is a fixed local unix socket path, not a user/network-controlled address.
 			conn, derr := net.DialTimeout("unix", p, 2*time.Second)
 			if derr == nil {
 				_ = conn.Close()

--- a/backend/internal/testutil/postgres_shared.go
+++ b/backend/internal/testutil/postgres_shared.go
@@ -61,6 +61,7 @@ func applyMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 			}
 			sort.Strings(files)
 			for _, f := range files {
+				// #nosec G304 -- f is a .sql migration file discovered from a known local migrations directory, not user input.
 				data, err := os.ReadFile(f)
 				if err != nil {
 					migrationsErr = err

--- a/backend/internal/testutil/sqlsplit.go
+++ b/backend/internal/testutil/sqlsplit.go
@@ -132,7 +132,7 @@ func readDollarTag(s string) string {
 		if ch == '$' {
 			return s[:i+1]
 		}
-		if !(ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')) {
+		if ch != '_' && (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9') {
 			return ""
 		}
 	}

--- a/backend/internal/testutil/sqlsplit_test.go
+++ b/backend/internal/testutil/sqlsplit_test.go
@@ -114,12 +114,12 @@ func TestSplitRealProblemMigrations(t *testing.T) {
 	}
 
 	tests := []struct {
-		file         string
+		file          string
 		minStatements int
-		mustContain  []string
+		mustContain   []string
 	}{
 		{
-			file:         "0012_semantic_search.sql",
+			file:          "0012_semantic_search.sql",
 			minStatements: 5,
 			mustContain: []string{
 				"CREATE OR REPLACE FUNCTION compute_query_embedding",
@@ -127,7 +127,7 @@ func TestSplitRealProblemMigrations(t *testing.T) {
 			},
 		},
 		{
-			file:         "0013_offline_sync.sql",
+			file:          "0013_offline_sync.sql",
 			minStatements: 10,
 			mustContain: []string{
 				"CREATE TYPE operation_type AS ENUM",

--- a/backend/internal/tools/apply_0019.go
+++ b/backend/internal/tools/apply_0019.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/jackc/pgx/v5"
@@ -18,7 +17,7 @@ func Apply0019() {
 	}
 	defer conn.Close(context.Background())
 
-	sqlBytes, err := ioutil.ReadFile("migrations/0019_fix_local_auth.sql")
+	sqlBytes, err := os.ReadFile("migrations/0019_fix_local_auth.sql")
 	if err != nil {
 		panic(err)
 	}

--- a/backend/internal/tools/migrate_all.go
+++ b/backend/internal/tools/migrate_all.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,7 +26,7 @@ func MigrateAll() {
 	sort.Strings(files)
 
 	for _, file := range files {
-		sqlBytes, err := ioutil.ReadFile(file)
+		sqlBytes, err := os.ReadFile(file)
 		if err != nil {
 			panic(err)
 		}

--- a/backend/internal/webhooks/service.go
+++ b/backend/internal/webhooks/service.go
@@ -93,7 +93,7 @@ func (s *Service) send(hook WebhookData, body []byte) {
 		slog.Warn("webhooks: delivery failed", "hook_id", hook.ID, "url", hook.URL, "err", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		slog.Warn("webhooks: target returned error", "hook_id", hook.ID, "status", resp.StatusCode)


### PR DESCRIPTION
"Judgment day" for the Go backend. The security posture was already strong (SQL fully parameterized, bcrypt, JWT alg-confusion prevented, strong SSRF defense, restrictive CORS, no hardcoded secrets) — this PR closes the gaps that remained.

## 🔴 Critical
- **Rate-limit the `/auth` endpoints.** `login`/`register`/`refresh` lived in a route group with **no** limiter (the global one was on a different group), leaving them open to brute-force / credential-stuffing. Added a per-IP limiter (new `AUTH_RATE_LIMIT_PER_MINUTE`, default 15), gated by `RATE_LIMIT_DISABLED`.
- **Fix `IARateLimit`.** It built a fresh `httprate` limiter **inside the per-request handler**, so the counter reset every request and it never limited. Now the pro/free limiters are built once and dispatched by plan.

## 🟠 High
- **Stop leaking internal errors.** `writeInternal` returned raw `err.Error()` (pgx/DB details, constraint names) plus a `detail` field to clients; now it logs server-side and returns a generic message.
- **Constant-time token compare** in `OptionalTokenAuth` (`bytes.Equal` → `subtle.ConstantTimeCompare`; `TokenAuth` already did this).
- **Cap pagination.** `items`/`repos` accepted unbounded `limit` (`limit=999999999` → memory DoS). Capped at `maxListLimit=500`; negative limit/offset clamped.
- **Insecure logout cookie (found by gosec G124).** The clear-cookie now sets `HttpOnly/Secure/SameSite` matching the setter.

## 🛠️ Quality — golangci-lint gate
- Added **`backend/.golangci.yml`** (standard linters + `gosec`, `bodyclose`, `misspell`, gofmt/goimports formatters) and a **CI step** (pinned `v2.12.2`) in the backend job. CI ran only `go vet` before.
- Brought the tree to **0 golangci-lint issues**: errcheck (unchecked `resp.Body.Close`/`tx.Rollback`/`w.Write`/…), staticcheck (`io/ioutil`→`os`, tagged switches, De Morgan, needless `fmt.Sprintf`), ineffassign, and gofmt across the previously-unformatted files. Remaining gosec findings reviewed and annotated with **justified `#nosec`** (MaxBytesReader-capped form parse, server-generated upload paths, fixed shields.io badge URL, `html.EscapeString`'d SVG, known docker-socket paths in test utils).
- gosec G301: avatar upload dir perms `0755`→`0750`.
- Documented the gate in CONTRIBUTING (en + es).

## ✅ Verification
`go build ./...`, `go vet ./...`, and `golangci-lint run ./...` (0 issues) all pass locally. DB-backed tests run in CI.

## Follow-ups (not in this PR)
- **Tests for security-critical middleware** (`auth`, `rbac`, `rate_limit`, webhooks HMAC) — currently 0% coverage.
- **Input validation**: password strength, email format, JWT-secret minimum length, crypto-random OAuth `state`, batch-size caps. (Behavior-affecting — worth a focused PR.)
- Consider rejecting `CORS_ORIGINS=*` when `AllowCredentials` is on.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_