### PR TITLE
Extension quality pass: configurable server URL, dedup, lint coverage

### DIFF
--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -1,10 +1,9 @@
 /**
  * DevDeck Extension Background Script (MV3)
  */
+import { getBaseUrl } from '../lib/config'
 
 chrome.runtime.onInstalled.addListener(() => {
-  console.log('DevDeck Extension installed');
-  
   // Register context menus
   chrome.contextMenus.create({
     id: 'save-link',
@@ -32,7 +31,8 @@ async function handleCheckURL(url: string) {
     const { access } = await chrome.storage.local.get('access')
     if (!access) return { item: null }
 
-    const resp = await fetch('http://localhost:8080/api/items/check', {
+    const baseUrl = await getBaseUrl()
+    const resp = await fetch(`${baseUrl}/api/items/check`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -75,7 +75,15 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   }
 })
 
-async function handleCapture(payload: any) {
+interface CapturePayload {
+  url?: string
+  title_hint?: string
+  item_type?: string
+  notes?: string
+  source?: string
+}
+
+async function handleCapture(payload: CapturePayload) {
   try {
     const { access } = await chrome.storage.local.get('access')
     if (!access) {
@@ -83,7 +91,8 @@ async function handleCapture(payload: any) {
       return
     }
 
-    const resp = await fetch('http://localhost:8080/api/items/capture', {
+    const baseUrl = await getBaseUrl()
+    const resp = await fetch(`${baseUrl}/api/items/capture`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/extension/src/content/index.tsx
+++ b/apps/extension/src/content/index.tsx
@@ -1,18 +1,27 @@
 import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom/client'
 import { Sparkles, X, ExternalLink } from 'lucide-react'
+import { getBaseUrl, DEFAULT_BASE_URL } from '../lib/config'
+
+interface VaultItem {
+  id: string
+  title: string
+  notes?: string
+}
 
 function CopilotWidget() {
-  const [item, setItem] = useState<any>(null)
+  const [item, setItem] = useState<VaultItem | null>(null)
+  const [baseUrl, setBaseUrl] = useState(DEFAULT_BASE_URL)
   const [visible, setVisible] = useState(false)
   const [expanded, setExpanded] = useState(false)
 
   useEffect(() => {
+    void getBaseUrl().then(setBaseUrl)
     // Check if current URL is in DevDeck
     const url = window.location.href
     chrome.runtime.sendMessage({ type: 'CHECK_URL', url }, (response) => {
       if (response?.item) {
-        setItem(response.item)
+        setItem(response.item as VaultItem)
         setVisible(true)
         // Auto-show for a few seconds then collapse
         setExpanded(true)
@@ -47,9 +56,10 @@ function CopilotWidget() {
           )}
 
           <div className="flex gap-2">
-             <a 
-              href={`http://localhost:5173/items/${item.id}`} 
-              target="_blank" 
+             <a
+              href={`${baseUrl}/items/${item.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
               className="flex-1 bg-black text-white text-[10px] font-bold uppercase py-2 text-center hover:bg-gray-800 transition-colors flex items-center justify-center gap-1"
              >
                 Abrir <ExternalLink size={10} />

--- a/apps/extension/src/lib/config.ts
+++ b/apps/extension/src/lib/config.ts
@@ -1,0 +1,22 @@
+// Configurable DevDeck server URL. The published extension defaults to the
+// hosted instance; self-hosters and local devs can override it from the
+// options page (persisted in chrome.storage.local). This replaces the
+// previously hardcoded http://localhost:8080 that made the built extension
+// unusable against any non-local backend.
+export const DEFAULT_BASE_URL = 'https://devdeck.ai'
+
+const KEY = 'devdeck.base_url'
+
+export async function getBaseUrl(): Promise<string> {
+  try {
+    const res = await chrome.storage.local.get(KEY)
+    const url = res[KEY]
+    return typeof url === 'string' && url.trim() !== '' ? url : DEFAULT_BASE_URL
+  } catch {
+    return DEFAULT_BASE_URL
+  }
+}
+
+export async function setBaseUrl(url: string): Promise<void> {
+  await chrome.storage.local.set({ [KEY]: url.trim().replace(/\/+$/, '') })
+}

--- a/apps/extension/src/lib/storage.ts
+++ b/apps/extension/src/lib/storage.ts
@@ -1,0 +1,23 @@
+import type { TokenStorage } from '@devdeck/api-client'
+
+const ACCESS = 'devdeck.access_token'
+const REFRESH = 'devdeck.refresh_token'
+
+// Shared token storage for the popup and options pages. Tokens are kept in
+// localStorage (the sync TokenStorage API the api-client expects) and mirrored
+// into chrome.storage.local under `access`/`refresh` so the background service
+// worker — which has no localStorage — can read the access token.
+export const chromeStorageAdapter: TokenStorage = {
+  getAccess: () => localStorage.getItem(ACCESS),
+  getRefresh: () => localStorage.getItem(REFRESH),
+  setTokens: (access: string, refresh: string) => {
+    localStorage.setItem(ACCESS, access)
+    localStorage.setItem(REFRESH, refresh)
+    void chrome.storage.local.set({ access, refresh })
+  },
+  clear: () => {
+    localStorage.removeItem(ACCESS)
+    localStorage.removeItem(REFRESH)
+    void chrome.storage.local.remove(['access', 'refresh'])
+  },
+}

--- a/apps/extension/src/options/Options.tsx
+++ b/apps/extension/src/options/Options.tsx
@@ -1,13 +1,28 @@
-import { useState } from 'react'
-import { Settings, ShieldCheck, LogOut, ExternalLink } from 'lucide-react'
-import { isLoggedIn, logoutCurrentSession, loginLocal } from '@devdeck/api-client'
+import { useEffect, useState } from 'react'
+import { Settings, ShieldCheck, LogOut, ExternalLink, Server } from 'lucide-react'
+import { isLoggedIn, logoutCurrentSession, loginLocal, configureApiClient } from '@devdeck/api-client'
 import { Button, showToast, Toaster } from '@devdeck/ui'
+import { getBaseUrl, setBaseUrl, DEFAULT_BASE_URL } from '../lib/config'
 
 export function Options() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const [loggedIn, setLoggedIn] = useState(isLoggedIn())
+  const [serverUrl, setServerUrl] = useState(DEFAULT_BASE_URL)
+
+  useEffect(() => {
+    void getBaseUrl().then(setServerUrl)
+  }, [])
+
+  async function handleSaveServer(e: React.FormEvent) {
+    e.preventDefault()
+    const url = serverUrl.trim().replace(/\/+$/, '')
+    await setBaseUrl(url)
+    configureApiClient({ baseUrl: url, authMode: 'jwt' })
+    setServerUrl(url)
+    showToast('Servidor guardado', 'success')
+  }
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -16,8 +31,8 @@ export function Options() {
       await loginLocal(email, password)
       setLoggedIn(true)
       showToast('Sesión iniciada correctamente', 'success')
-    } catch (err: any) {
-      showToast(err.message || 'Error al iniciar sesión', 'error')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Error al iniciar sesión', 'error')
     } finally {
       setLoading(false)
     }
@@ -39,6 +54,29 @@ export function Options() {
       </header>
 
       <main className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <section className="bg-bg-card border-3 border-ink shadow-hard p-6 space-y-6 md:col-span-2">
+          <h2 className="font-display font-black uppercase text-xl tracking-widest flex items-center gap-2">
+            <Server size={24} strokeWidth={3} className="text-accent-cyan" />
+            Servidor
+          </h2>
+          <form onSubmit={handleSaveServer} className="space-y-3">
+            <p className="font-mono text-xs text-ink-soft">
+              URL del servidor DevDeck (cambialo si te self-hosteás o usás un backend local).
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="url"
+                value={serverUrl}
+                onChange={(e) => setServerUrl(e.target.value)}
+                placeholder={DEFAULT_BASE_URL}
+                className="flex-1 border-2 border-ink p-2 font-mono text-xs focus:bg-accent-yellow/5 outline-none"
+                required
+              />
+              <Button type="submit" variant="secondary">Guardar</Button>
+            </div>
+          </form>
+        </section>
+
         <section className="bg-bg-card border-3 border-ink shadow-hard p-6 space-y-6">
           <h2 className="font-display font-black uppercase text-xl tracking-widest flex items-center gap-2">
             <ShieldCheck size={24} strokeWidth={3} className="text-accent-lime" />
@@ -57,8 +95,9 @@ export function Options() {
           ) : (
             <form onSubmit={handleLogin} className="space-y-4">
               <div className="space-y-1">
-                <label className="block font-display font-bold uppercase text-[10px]">Email</label>
+                <label htmlFor="devdeck-email" className="block font-display font-bold uppercase text-[10px]">Email</label>
                 <input
+                  id="devdeck-email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -67,8 +106,9 @@ export function Options() {
                 />
               </div>
               <div className="space-y-1">
-                <label className="block font-display font-bold uppercase text-[10px]">Contraseña</label>
+                <label htmlFor="devdeck-password" className="block font-display font-bold uppercase text-[10px]">Contraseña</label>
                 <input
+                  id="devdeck-password"
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
@@ -111,7 +151,7 @@ export function Options() {
 
       <footer className="text-center pt-12 border-t-2 border-ink/10">
         <p className="font-mono text-[10px] text-ink-soft uppercase tracking-widest">
-          DevDeck Extension v2.0.0
+          DevDeck Extension v0.5.0
         </p>
       </footer>
       

--- a/apps/extension/src/options/main.tsx
+++ b/apps/extension/src/options/main.tsx
@@ -1,35 +1,21 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import {
-  configureApiClient,
-  setTokenStorage,
-} from '@devdeck/api-client'
+import { configureApiClient, setTokenStorage } from '@devdeck/api-client'
 import { Options } from './Options'
+import { chromeStorageAdapter } from '../lib/storage'
+import { getBaseUrl } from '../lib/config'
 import '../../src/index.css'
-
-const chromeStorageAdapter = {
-  getAccess: () => localStorage.getItem('devdeck.access_token'),
-  getRefresh: () => localStorage.getItem('devdeck.refresh_token'),
-  setTokens: (access: string, refresh: string) => {
-    localStorage.setItem('devdeck.access_token', access)
-    localStorage.setItem('devdeck.refresh_token', refresh)
-    chrome.storage.local.set({ access, refresh })
-  },
-  clear: () => {
-    localStorage.clear()
-    chrome.storage.local.remove(['access', 'refresh'])
-  },
-}
 
 setTokenStorage(chromeStorageAdapter)
 
-configureApiClient({
-  baseUrl: 'http://localhost:8080',
-  authMode: 'jwt',
-})
+async function bootstrap() {
+  configureApiClient({ baseUrl: await getBaseUrl(), authMode: 'jwt' })
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <Options />
-  </React.StrictMode>,
-)
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <Options />
+    </React.StrictMode>,
+  )
+}
+
+void bootstrap()

--- a/apps/extension/src/popup/main.tsx
+++ b/apps/extension/src/popup/main.tsx
@@ -1,45 +1,22 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import {
-  configureApiClient,
-  setTokenStorage,
-  startSyncEngine,
-} from '@devdeck/api-client'
+import { configureApiClient, setTokenStorage, startSyncEngine } from '@devdeck/api-client'
 import { Popup } from './Popup'
-import '../../src/index.css' // We'll need a tailwind entry
-
-/**
- * Storage adapter for Chrome Extension storage.
- */
-const chromeStorageAdapter = {
-  getAccess: () => {
-    // Note: async storage needs to be handled carefully with the current sync api-client
-    // For now, we'll try to use a cached version or refactor api-client to support async storage.
-    return localStorage.getItem('devdeck.access_token')
-  },
-  getRefresh: () => localStorage.getItem('devdeck.refresh_token'),
-  setTokens: (access: string, refresh: string) => {
-    localStorage.setItem('devdeck.access_token', access)
-    localStorage.setItem('devdeck.refresh_token', refresh)
-    chrome.storage.local.set({ access, refresh })
-  },
-  clear: () => {
-    localStorage.clear()
-    chrome.storage.local.remove(['access', 'refresh'])
-  },
-}
+import { chromeStorageAdapter } from '../lib/storage'
+import { getBaseUrl } from '../lib/config'
+import '../../src/index.css'
 
 setTokenStorage(chromeStorageAdapter)
 
-configureApiClient({
-  baseUrl: 'http://localhost:8080', // Default for dev
-  authMode: 'jwt',
-})
+async function bootstrap() {
+  configureApiClient({ baseUrl: await getBaseUrl(), authMode: 'jwt' })
+  startSyncEngine().catch((err) => console.error('sync engine failed:', err))
 
-startSyncEngine().catch(console.error)
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <Popup />
+    </React.StrictMode>,
+  )
+}
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <Popup />
-  </React.StrictMode>,
-)
+void bootstrap()

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,6 @@ export default tseslint.config(
       '**/vite-env.d.ts',
       '**/env.d.ts',
       // Out of frontend lint scope — these have their own pipelines.
-      'apps/extension/**',
       'apps/landing/**',
       'backend/**',
       'cli/**',


### PR DESCRIPTION
"Judgment day" for the browser extension (MV3 + React/Vite).

## 🔴 Headline bug — hardcoded localhost
The built extension hardcoded `http://localhost:8080` (API, in popup/options/background) and `http://localhost:5173` (the content-script "open" link), so a published/installed build **could not talk to any non-local backend**.

- New shared, persisted **server URL** (`src/lib/config.ts`, default `https://devdeck.ai`, overridable from the options page via `chrome.storage.local`), used by the popup, options, background `check`/`capture` fetches, and the content-script open link.
- Added an **"API server" field** to the options page so users/self-hosters can point it anywhere.

## 🧹 Cleanup
- Extracted the **duplicated** chrome token-storage adapter (it was copy-pasted in popup + options) into `src/lib/storage.ts`, typed as `TokenStorage`; it now clears only the DevDeck keys instead of `localStorage.clear()`.
- **Brought `apps/extension` into the shared ESLint config** (it was excluded) → now linted by `pnpm lint` / CI. Fixed every surfaced issue: typed the content `VaultItem` and background `CapturePayload` (removed `any`), associated the login form labels, added `rel="noopener noreferrer"` to the external link, removed a debug `console.log`.
- Fixed a version string (footer said `v2.0.0`; now `v0.5.0`).

## ✅ Verification
`pnpm -F @devdeck/extension typecheck`, `pnpm lint` (0 errors / 0 warnings, extension included), and the extension build all pass.

## Follow-ups (not in this PR)
- The content widget loads **Tailwind from a CDN** (`cdn.jsdelivr.net/...tailwindcss@2.2.19`) into every page; bundling the CSS into the shadow DOM is a separate change (and removes a runtime CDN/supply-chain dependency).
- `host_permissions: <all_urls>` is broad (needed for capture-anywhere, but worth documenting for store review).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_