### PR TITLE
Landing quality pass: fix broken OG image, SEO meta & CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Build web
         run: pnpm -F @devdeck/web build
 
+      - name: Build landing
+        run: pnpm -F @devdeck/landing build
+
   desktop:
     name: Desktop (Vitest + typecheck + build)
     runs-on: ubuntu-latest

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -3,6 +3,8 @@ import tailwind from '@astrojs/tailwind';
 
 // https://astro.build/config
 export default defineConfig({
+  // Used to build absolute canonical / Open Graph URLs.
+  site: 'https://devdeck.ai',
   integrations: [
     tailwind({
       applyBaseStyles: false, // Use our own shared globals.css

--- a/apps/landing/public/og-image.svg
+++ b/apps/landing/public/og-image.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" font-family="'Space Grotesk', system-ui, sans-serif">
+  <rect width="1200" height="630" fill="#FFFBF0"/>
+  <rect x="20" y="20" width="1160" height="590" fill="none" stroke="#0A0A0A" stroke-width="6"/>
+
+  <!-- Deck mark -->
+  <g transform="translate(90, 150)">
+    <rect x="24" y="24" width="150" height="190" rx="16" fill="#FFD23F" stroke="#0A0A0A" stroke-width="6"/>
+    <rect x="0" y="0" width="150" height="190" rx="16" fill="#0A0A0A"/>
+    <text x="75" y="112" font-size="150" font-weight="800" fill="#FFFFFF" text-anchor="middle" dominant-baseline="middle">D</text>
+  </g>
+
+  <!-- Wordmark -->
+  <text x="320" y="250" font-size="120" font-weight="800" fill="#0A0A0A">Dev<tspan fill="#FF5C8A">Deck</tspan></text>
+
+  <!-- Tagline -->
+  <text x="324" y="330" font-size="40" font-weight="600" fill="#4A4A4A">The developer memory layer.</text>
+
+  <!-- Sub-tagline -->
+  <text x="90" y="470" font-size="34" font-weight="500" fill="#0A0A0A">Capture repos, CLIs, snippets, prompts &amp; workflows —</text>
+  <text x="90" y="516" font-size="34" font-weight="500" fill="#0A0A0A">retrieve them by intent, not by exact name.</text>
+
+  <!-- Footer chips -->
+  <g font-size="26" font-weight="700">
+    <rect x="90" y="556" width="200" height="44" fill="#7CFF6B" stroke="#0A0A0A" stroke-width="4"/>
+    <text x="190" y="585" fill="#0A0A0A" text-anchor="middle">OPEN SOURCE</text>
+    <rect x="306" y="556" width="150" height="44" fill="#4DD0E1" stroke="#0A0A0A" stroke-width="4"/>
+    <text x="381" y="585" fill="#0A0A0A" text-anchor="middle">WEB</text>
+    <rect x="472" y="556" width="190" height="44" fill="#B388FF" stroke="#0A0A0A" stroke-width="4"/>
+    <text x="567" y="585" fill="#0A0A0A" text-anchor="middle">DESKTOP</text>
+  </g>
+
+  <text x="1110" y="585" font-size="28" font-weight="700" fill="#0A0A0A" text-anchor="end">devdeck.ai</text>
+</svg>

--- a/apps/landing/src/layouts/Layout.astro
+++ b/apps/landing/src/layouts/Layout.astro
@@ -8,31 +8,44 @@ interface Props {
 }
 
 const { title, description, lang = 'en' } = Astro.props;
+
+// Absolute URLs (Open Graph / canonical require absolute URLs to work on
+// social platforms and search engines). Astro.site is set in astro.config.
+const siteUrl = Astro.site ?? new URL('https://devdeck.ai');
+const canonical = new URL(Astro.url.pathname, siteUrl);
+const ogImage = new URL('/og-image.svg', siteUrl);
+const enUrl = new URL('/', siteUrl);
+const esUrl = new URL('/es', siteUrl);
 ---
 
 <!doctype html>
 <html lang={lang} class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    
+
     <!-- SEO Meta Tags -->
     <title>{title}</title>
     <meta name="description" content={description} />
-    
+    <link rel="canonical" href={canonical} />
+    <link rel="alternate" hreflang="en" href={enUrl} />
+    <link rel="alternate" hreflang="es" href={esUrl} />
+    <link rel="alternate" hreflang="x-default" href={enUrl} />
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonical} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:image" content={ogImage} />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:title" content={title} />
     <meta property="twitter:description" content={description} />
-    <meta property="twitter:image" content="/og-image.png" />
+    <meta property="twitter:image" content={ogImage} />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
"Judgment day" for the Astro landing site (`apps/landing`, en + es).

## 🐛 Broken social sharing (Open Graph)
- `og:image` / `twitter:image` pointed at **`/og-image.png` which doesn't exist** (only favicons are in `public/`) → broken social-card previews. They also used a **relative URL**, which OG/Twitter require to be absolute.
- Added a **branded 1200×630 `og-image.svg`** (neo-brutalist, on-palette) and emit **absolute** image URLs via `Astro.site`.

## 🔎 SEO
- Set `site: https://devdeck.ai` in `astro.config.mjs` so canonical/OG URLs resolve.
- Added `<link rel="canonical">`, `og:url`, and **hreflang alternates** (`en` / `es` / `x-default`) so the two language versions don't compete in search.
- Fixed the viewport meta (`initial-scale=1`).

## 🤖 CI
- The landing was **not built in CI** (it could break silently). Added a `Build landing` step to the workspace job.

## ✅ Verification
`astro build` passes; the built HTML now emits absolute `canonical` + `og:image` and the hreflang alternates (verified in `dist/index.html`).

## Follow-up
- Export `og-image.svg` → a **PNG** for maximum social-platform compatibility (some platforms don't render SVG OG images). The SVG is a correct, non-404 stopgap and renders fine when fetched directly.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_