### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.0] - 2026-06-14
+
+Quality & security hardening pass across the whole monorepo (web, desktop,
+extension, backend, landing) to make DevDeck contribution-ready as an
+open-source project.
+
+### Added
+
+- **Spanish (es) runtime locale**: complete `es` translation (full key parity
+  with `en`) with automatic language detection and a language switcher in
+  Settings. The app previously shipped only English at runtime.
+- **ESLint + Prettier** for the whole web frontend (shared flat config); the
+  root `lint` script was previously a no-op. `pnpm lint` reports 0 errors.
+- **golangci-lint** gate for the Go backend (config + CI step, includes
+  `gosec`); CI previously ran only `go vet`.
+- **Tests for `apps/web`** (Vitest: router reachability + page smoke tests);
+  it had none before.
+- **CI now runs the frontend unit tests, lint, and the web/landing builds**,
+  plus backend `golangci-lint` — none of which ran before.
+- **Configurable server URL for the browser extension** (options page,
+  persisted) replacing hardcoded localhost.
+- **Desktop 404 page** + catch-all route (unknown routes rendered blank).
+- Project scaffolding: `.github/dependabot.yml`, `CODEOWNERS`,
+  `apps/web/.env.example`, and `AUTH_RATE_LIMIT_PER_MINUTE` config.
+
+### Changed
+
+- **Web bundle is code-split** (vendor chunks); the main chunk dropped from
+  ~1.57 MB to ~440 KB.
+- **Dependency updates**: Go modules (pgx, x/net, x/crypto, testcontainers,
+  …), JS dev/prod groups (TanStack Query, Playwright, …) and framer-motion 12.
+  CI Go toolchain bumped to 1.25.
+- Replaced 48 `any` usages in the data layer with accurate types; removed dead
+  code; `gofmt`'d the backend tree.
+
+### Fixed
+
+- **Stored XSS** in the README viewer (remote markdown was rendered with
+  `rehype-raw` and no sanitizer) — added `rehype-sanitize`.
+- Silent failures surfaced to users (waitlist submit, workspace switch); a
+  conditional-`useEffect` hooks bug in the mascot; the extension's hardcoded
+  `localhost` API/web URLs; the landing's broken (404) Open Graph image.
+- Backend: internal/DB error text leaked to clients; unbounded pagination
+  (memory-exhaustion DoS); insecure logout cookie.
+- ~190 lint warnings and keyboard-accessibility gaps across the frontend.
+
+### Security
+
+- **Removed a tracked `deploy/.env`** (committed secrets) and rotated its
+  local values.
+- **Rate-limited the unauthenticated `/auth` endpoints** (login/register/
+  refresh) — they had no limiter, allowing brute-force.
+- Fixed a non-functional AI rate limiter; constant-time static-token compare;
+  sanitized remote README (see Fixed); pagination caps; insecure-cookie fix.
+- Hardened the desktop Electron shell (validate external-URL schemes,
+  `will-navigate` guard).
+- _Known follow-up_: web/extension auth tokens still live in `localStorage`
+  (XSS-exposed); migrating to HttpOnly cookies needs coordinated backend work.
+
+---
+
 ## [0.5.0] - 2026-06-04
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -87,7 +87,7 @@ Ambas apps importan pages y componentes del package `@devdeck/features` — solo
 | [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) | Guía paso a paso para self-host |
 | [docs/CAPTURE.md](docs/CAPTURE.md) | Spec de canales de captura (extensión, CLI, paste, share) |
 | [docs/TESTING_STRATEGY.md](docs/TESTING_STRATEGY.md) | Plan de tests y CI |
-| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | Limitaciones conocidas de la 0.5.0 Public Beta |
+| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | Limitaciones conocidas de la 0.6.0 Public Beta |
 | [docs/ARCHITECTURE_MAP.md](docs/ARCHITECTURE_MAP.md) | Mapa de arquitectura en una página para contribuidores |
 | [docs/archive/REVIEW_2026_04.md](docs/archive/REVIEW_2026_04.md) | **Review técnico de abril 2026** — motiva Ola 4.5 |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Cómo contribuir |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It turns scattered discoveries into a searchable engineering memory: capture use
 
 Domain: **[devdeck.ai](https://devdeck.ai)**
 
-Current version: **0.5.0 Public Beta** — functional, useful, and actively being polished before a stable 1.0 release.
+Current version: **0.6.0 Public Beta** — functional, useful, and actively being polished before a stable 1.0 release.
 
 ---
 
@@ -181,7 +181,7 @@ Possible future sustainability paths include hosted community Circles, paid setu
 | Doc | Content |
 |-----|---------|
 | [docs/CIRCLES_COMMUNITY.md](docs/CIRCLES_COMMUNITY.md) | Circles as private collective memory for developer communities |
-| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | Known limitations of the 0.5.0 Public Beta, stated honestly |
+| [docs/LIMITATIONS.md](docs/LIMITATIONS.md) | Known limitations of the 0.6.0 Public Beta, stated honestly |
 | [docs/FIRST_CONTRIBUTION.md](docs/FIRST_CONTRIBUTION.md) | Short path for a first issue-backed PR |
 | [docs/ARCHITECTURE_MAP.md](docs/ARCHITECTURE_MAP.md) | One-page architecture orientation for new contributors |
 | [docs/DEV_WORKBENCH.md](docs/DEV_WORKBENCH.md) | Developer Workbench direction and workflows |

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "DevDeck \u2014 your personal dev multi-tool. Desktop app.",
   "main": "./out/main/index.js",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/extension",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "DevDeck \u2014 browser extension (React/Vite).",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -2,7 +2,7 @@
   "name": "@devdeck/landing",
   "private": true,
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "DevDeck — web client (React).",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devdeck",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "DevDeck monorepo — desktop, web, shared packages.",
   "scripts": {
     "dev:desktop": "pnpm -F @devdeck/desktop dev",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/api-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/features",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/i18n",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/realtime-client/package.json
+++ b/packages/realtime-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/realtime-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdeck/ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
Release **0.6.0** — the quality & security hardening pass across the whole monorepo (web, desktop, extension, backend, landing), shipped this session via #157, #176, #177, #181, #182, #183.

## Changes
- Bump all 10 workspace `package.json` files `0.5.0` → `0.6.0`.
- Update README (en + es) version references.
- Add the `[0.6.0]` CHANGELOG entry (Added / Changed / Fixed / Security).

## Highlights captured in the CHANGELOG
- **Added**: Spanish runtime locale + language switcher; ESLint/Prettier (web) and golangci-lint (backend) gates; `apps/web` tests; CI now runs frontend tests/lint + web/landing builds + backend lint; configurable extension server URL; desktop 404 route; dependabot/CODEOWNERS/.env.example.
- **Changed**: web bundle code-splitting (1.57 MB → 440 KB); dependency updates + Go 1.25; 48 `any` → real types; backend `gofmt`.
- **Fixed**: README stored-XSS, silent UX failures, mascot hooks bug, extension hardcoded localhost, landing broken OG image, ~190 lint warnings + a11y gaps, backend error leakage / pagination DoS / insecure logout cookie.
- **Security**: untracked+rotated `deploy/.env`, `/auth` rate limiting, AI rate-limiter fix, constant-time token compare, README sanitization, Electron hardening. Known follow-up: tokens in `localStorage` → HttpOnly cookies (needs backend work).

Verification: `pnpm install --frozen-lockfile` passes (no lockfile change); version is a metadata/docs-only change on top of already-merged, CI-green work.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_