### PR TITLE
chore(deps): coordinated i18next 23→26 + react-i18next 15→17 (closes #174)

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -10,8 +10,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "i18next": "^23.15.1",
-    "react-i18next": "^15.0.2"
+    "i18next": "^26.3.1",
+    "react-i18next": "^17.0.8"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,14 +459,14 @@ importers:
   packages/i18n:
     dependencies:
       i18next:
-        specifier: ^23.15.1
-        version: 23.16.8
+        specifier: ^26.3.1
+        version: 26.3.1(typescript@5.9.3)
       react:
         specifier: '>=18'
         version: 18.3.1
       react-i18next:
-        specifier: ^15.0.2
-        version: 15.7.4(i18next@23.16.8)(react@18.3.1)(typescript@5.9.3)
+        specifier: ^17.0.8
+        version: 17.0.8(i18next@26.3.1(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3)
 
   packages/realtime-client:
     dependencies:
@@ -4137,8 +4137,13 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  i18next@23.16.8:
-    resolution: {integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==}
+  i18next@26.3.1:
+    resolution: {integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-corefoundation@1.1.7:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
@@ -5467,14 +5472,14 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-i18next@15.7.4:
-    resolution: {integrity: sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==}
+  react-i18next@17.0.8:
+    resolution: {integrity: sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==}
     peerDependencies:
-      i18next: '>= 23.4.0'
+      i18next: '>= 26.2.0'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -6470,6 +6475,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -11072,9 +11082,9 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next@23.16.8:
-    dependencies:
-      '@babel/runtime': 7.29.2
+  i18next@26.3.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   iconv-corefoundation@1.1.7:
     dependencies:
@@ -12536,12 +12546,13 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-i18next@15.7.4(i18next@23.16.8)(react@18.3.1)(typescript@5.9.3):
+  react-i18next@17.0.8(i18next@26.3.1(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 23.16.8
+      i18next: 26.3.1(typescript@5.9.3)
       react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -13694,6 +13705,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.28
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   utf8-byte-length@1.0.5: {}
 


### PR DESCRIPTION
Supersedes **#174**. That dependabot PR bumped only `react-i18next` to 17, but `react-i18next@17` **requires `i18next >= 26.2.0`** while the project pinned `i18next ^23` — a peer mismatch (CI passed there only because pnpm doesn't fail on peer warnings). This does the **coordinated** upgrade.

## Changes
- `packages/i18n`: `i18next` `^23.15.1` → `^26.3.1`, `react-i18next` `^15.0.2` → `^17.0.8` (the only place either is declared).

## Verification
- `pnpm why i18next` → single version (26.3.1).
- Full `pnpm typecheck` ✅, `pnpm lint` 0/0 ✅, **124 `features` unit tests** (which exercise `t()` / `Trans` / rendering) ✅, and **web + desktop builds** ✅.
- The i18n bootstrap (`initReactI18next` + `resources` + `interpolation`/`react` options + the inline language detection added in 0.6.0) is unchanged and compatible with the new majors.

Closes #174.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_