### PR TITLE
docs(adr): design for HttpOnly-cookie auth tokens (token-storage follow-up)

### DIFF
--- a/docs/adr/0004-auth-token-storage-httponly-cookies.es.md
+++ b/docs/adr/0004-auth-token-storage-httponly-cookies.es.md
@@ -1,0 +1,146 @@
+# ADR 0004 — Sacar los tokens de auth web de `localStorage` a cookies HttpOnly
+
+- Estado: **Propuesto** (solo diseño — todavía no implementado)
+- Fecha: 2026-06-14
+- Relacionado: follow-up de seguridad señalado en el pase de hardening 0.6.0
+
+## Contexto
+
+Hoy el cliente **web** guarda el access token y el refresh token en
+`localStorage`:
+
+- `packages/api-client/src/auth/storage/localStorage.ts` guarda
+  `devdeck_access_token` y `devdeck_refresh_token`.
+- `packages/api-client/src/api-client.ts` lee el access token
+  (`getBearerToken()`) y lo manda como `Authorization: Bearer <jwt>`.
+- El backend Go autentica `/api` con el middleware `TokenAuth` leyendo ese
+  header. El login (`POST /api/auth/login`) y el callback de OAuth devuelven el
+  par de tokens al cliente (body JSON / params del redirect); `POST
+  /api/auth/refresh` recibe `{ refresh_token }` en el body y lo rota (los
+  refresh tokens se guardan server-side como hashes SHA-256, de un solo uso).
+
+**Problema:** todo lo que está en `localStorage` es legible por cualquier
+JavaScript de la página. Un solo XSS (acabamos de cerrar uno almacenado en el
+visor de README) = **robo total de la sesión**, incluido el refresh token de
+larga vida. Es el ítem de seguridad pendiente de mayor valor para la web.
+
+El **desktop** ya guarda los tokens en el keychain del SO vía Electron
+`safeStorage` (no legible por JS) y la **extensión** usa `chrome.storage`;
+ninguno comparte la exposición de `localStorage` de la web. Por eso este cambio
+es **específico de web** y no debe romper desktop/extensión.
+
+## Decisión
+
+Adoptar un **modelo híbrido de tokens en web** (recomendado por sobre auth
+totalmente por cookies):
+
+1. **Access token** — corto, devuelto en el **body** de login/refresh, mantenido
+   **solo en memoria** (variable JS, nunca `localStorage`). Se envía como
+   `Authorization: Bearer` igual que hoy.
+2. **Refresh token** — seteado por el backend como cookie **`HttpOnly; Secure;
+   SameSite=Lax`**, con scope al path de refresh (`Path=/api/auth`). Nunca
+   legible por JS.
+
+Al cargar la página se hace un **refresh silencioso** (`POST /api/auth/refresh`
+con `credentials: 'include'`, sin body); la cookie lo autentica, el backend rota
+la cookie de refresh y devuelve un access token nuevo a memoria. Los reloads ya
+no necesitan un token persistente legible por JS.
+
+### Por qué híbrido (no cookies para todo)
+
+- **Mínimo radio de impacto**: el access token sigue por header, así que solo el
+  endpoint `/api/auth/refresh` pasa a basarse en cookie y necesita manejo de
+  CSRF. Todos los demás endpoints `/api` quedan iguales (Bearer header).
+- **Elimina el riesgo real**: no sobrevive ningún token persistente legible por
+  JS. El access en memoria muere en el reload y es corto; el refresh nunca se
+  expone a JS. Un XSS ya no puede robar una sesión durable.
+- **Multi-superficie**: desktop/extensión mantienen el flujo body+Bearer.
+
+Auth totalmente por cookies (access también en cookie, leído por el middleware)
+empujaría la protección CSRF a **todos** los endpoints mutadores y complicaría
+la extensión cross-origin — más superficie, más riesgo, poco beneficio extra.
+
+## Cambios en el backend (Go)
+
+Todo detrás de un flag para rollout seguro: `AUTH_COOKIE_MODE` (default
+`false`).
+
+- **Handlers de login / callback OAuth** (`internal/http/handlers/auth.go`): en
+  modo cookie, además `Set-Cookie` del refresh como `HttpOnly; Secure;
+  SameSite=Lax; Path=/api/auth; Max-Age=<TTL refresh>`. Dejar de poner el
+  refresh en la **URL de redirect** de OAuth (hoy queda en el historial) — setear
+  la cookie en la navegación top-level del callback (SameSite=Lax lo permite) y
+  redirigir limpio.
+- **`POST /api/auth/refresh`**: leer el refresh de la cookie **primero**, con
+  fallback al body (para que desktop/extensión sigan funcionando). Rotar como
+  hoy, `Set-Cookie` del nuevo refresh, devolver el nuevo access en el body.
+- **`POST /api/auth/logout`**: además limpiar la cookie (`Set-Cookie` expirada
+  con los mismos atributos) y borrar la sesión server-side.
+- **CSRF**: el endpoint de refresh pasa a autenticarse por cookie, así que sumar
+  una defensa CSRF liviana — `SameSite=Lax` ya bloquea POST cross-site en
+  navegadores modernos; además verificar que `Origin`/`Referer` coincida con un
+  origen permitido en `/api/auth/refresh`. (No hace falta double-submit token
+  porque solo ese endpoint usa cookie y devuelve un token corto al mismo
+  origen.)
+- **CORS** (`internal/http/router.go`): `AllowCredentials` ya es `true`;
+  asegurar que la lista de orígenes nunca contenga `*` con credenciales activas
+  (guard al arranque — también notado en la auditoría del backend).
+- **Dev**: las cookies `Secure` no viajan por `http://` plano. Desarrollar sobre
+  `https`/`localhost` (los navegadores tratan `localhost` como seguro) o quitar
+  `Secure` solo cuando la config indique local/dev.
+
+## Cambios en el frontend (web)
+
+- **`TokenStorage`**: agregar un adapter de access token **en memoria** para web;
+  dejar de escribir access/refresh en `localStorage`. (La abstracción
+  `TokenStorage` ya existe — `setTokenStorage()` — así que es un swap de adapter
+  en `apps/web/src/main.tsx`.)
+- **`api-client.ts`**: el refresh usa `credentials: 'include'` y no manda body de
+  refresh en modo cookie; al arrancar, intentar un refresh silencioso para
+  re-hidratar el access en memoria.
+- **`isLoggedIn()`**: derivar de la presencia del token en memoria + el
+  resultado del refresh de arranque, en vez de leer `localStorage`.
+- **Página de callback OAuth**: ya no parsear tokens de la URL en modo cookie (la
+  cookie ya está seteada); solo disparar refresh silencioso + navegar.
+
+## Impacto multi-superficie
+
+- **Desktop (Electron)**: sin cambios — mantiene `safeStorage` + refresh
+  body/Bearer (no expuesto a XSS). El modo cookie solo lo pide el cliente web.
+- **Extensión**: mantiene `chrome.storage` + body/Bearer. Sus fetches son
+  cross-origin a la API; cookies ahí requerirían `SameSite=None` (más débil) y
+  permisos de host — no vale la pena. El refresh cookie-primero/body-fallback del
+  backend lo soporta de forma transparente.
+
+## Plan de rollout
+
+1. **Backend, aditivo + con flag**: soportar refresh por cookie
+   (`AUTH_COOKIE_MODE`) sin dejar de aceptar refresh por body. Mergear y
+   verificar que con el flag apagado nada cambia.
+2. **Web opt-in**: pasar web a access en memoria + refresh por cookie bajo el
+   mismo flag; QA del flujo completo login/reload/expiración/logout.
+3. **Default on para web; dejar de persistir tokens en `localStorage`.**
+
+## Riesgos y rollback
+
+- **No verificable en CI**: la suite e2e es solo de desktop (modo token), así que
+  no ejercita el auth por cookies de web. Este cambio **requiere QA manual de
+  web** (login, reload→refresh silencioso, expiración del access→refresh, logout,
+  ida y vuelta de OAuth) en al menos Chrome + Firefox + Safari antes de activarlo
+  por default. Es la razón principal para tratarlo como un esfuerzo aparte y por
+  etapas.
+- **Errores en los atributos de cookie** son el modo de fallo clásico: `Secure`
+  sobre `http` dev, `SameSite=Strict` rompiendo el redirect de OAuth, `Path`
+  equivocado. Mitigado por el flag y el rollout por etapas.
+- **Rollback**: apagar `AUTH_COOKIE_MODE` → los clientes vuelven al flujo
+  body/Bearer actual. Sin migración de datos (los refresh ya son hashes
+  server-side).
+
+## Testing
+
+- **Backend (CI-able)**: tests unitarios/integración de set/rotate/clear de
+  cookie, refresh cookie-primero vs body-fallback, y el chequeo de Origin en
+  `/api/auth/refresh`.
+- **Web (manual)**: la matriz de QA de arriba. Opcional: agregar un e2e web
+  (nuevo) con Playwright que corra el flujo real login→reload→logout contra el
+  backend vivo para hacerlo verificable en CI a futuro.

--- a/docs/adr/0004-auth-token-storage-httponly-cookies.md
+++ b/docs/adr/0004-auth-token-storage-httponly-cookies.md
@@ -1,0 +1,147 @@
+# ADR 0004 — Move web auth tokens out of `localStorage` into HttpOnly cookies
+
+- Status: **Proposed** (design only — not yet implemented)
+- Date: 2026-06-14
+- Supersedes/relates: security follow-up flagged in the 0.6.0 hardening pass
+
+## Context
+
+Today the **web** client stores both the access token and the refresh token in
+`localStorage`:
+
+- `packages/api-client/src/auth/storage/localStorage.ts` keeps
+  `devdeck_access_token` and `devdeck_refresh_token`.
+- `packages/api-client/src/api-client.ts` reads the access token
+  (`getBearerToken()`) and sends it as `Authorization: Bearer <jwt>`.
+- The Go backend authenticates `/api` via the `TokenAuth` middleware reading
+  that `Authorization: Bearer` header. Login (`POST /api/auth/login`) and the
+  OAuth callback return the token pair to the client (JSON body / redirect
+  params); `POST /api/auth/refresh` takes `{ refresh_token }` in the body and
+  rotates it (refresh tokens are stored server-side as SHA-256 hashes,
+  single-use).
+
+**Problem:** anything in `localStorage` is readable by any JavaScript running
+on the page. A single XSS bug (we just closed a stored-XSS in the README
+viewer) therefore means **full session theft**, including the long-lived
+refresh token. This is the highest-value remaining security item for the web
+surface.
+
+The **desktop** app already stores tokens in the OS keychain via Electron
+`safeStorage` (not JS-readable) and the **extension** uses `chrome.storage`;
+neither shares the web's `localStorage` exposure. So this change is
+**web-specific** and must not break desktop/extension.
+
+## Decision
+
+Adopt a **hybrid token model on web** (recommended over full cookie auth):
+
+1. **Access token** — short-lived, returned in the login/refresh **response
+   body**, held **in memory only** (a JS variable, never `localStorage`). Sent
+   as `Authorization: Bearer` exactly as today.
+2. **Refresh token** — set by the backend as an **`HttpOnly; Secure;
+   SameSite=Lax` cookie**, scoped to the refresh path (`Path=/api/auth`). Never
+   readable by JS.
+
+On page load the app performs a **silent refresh** (`POST /api/auth/refresh`
+with `credentials: 'include'`, no body); the cookie authenticates it, the
+backend rotates the refresh cookie and returns a fresh access token into
+memory. Reloads no longer need a JS-readable persistent token.
+
+### Why hybrid (not full cookie auth)
+
+- **Smallest blast radius**: the access token stays header-based, so only the
+  single `/api/auth/refresh` endpoint becomes cookie-based and needs CSRF
+  handling. Every other `/api` endpoint is unchanged (still Bearer header).
+- **Eliminates the actual risk**: no persistent, JS-readable token survives.
+  An in-memory access token dies on reload and is short-lived; the refresh
+  token is never exposed to JS. XSS can no longer steal a durable session.
+- **Multi-surface friendly**: desktop/extension keep the body+Bearer flow.
+
+Full cookie auth (access token also in a cookie, middleware reads it) would
+push CSRF protection onto **every** mutating endpoint and complicate the
+cross-origin extension — more surface, more risk, little extra benefit.
+
+## Backend changes (Go)
+
+Gate everything behind a config flag for safe rollout: `AUTH_COOKIE_MODE`
+(default `false`).
+
+- **Login / OAuth callback handlers** (`internal/http/handlers/auth.go`): when
+  the request opts into cookie mode, additionally `Set-Cookie` the refresh
+  token as `HttpOnly; Secure; SameSite=Lax; Path=/api/auth; Max-Age=<refresh
+  TTL>`. Stop putting the refresh token in the OAuth **redirect URL** (it
+  currently lands in browser history) — set the cookie on the callback's
+  top-level navigation (SameSite=Lax permits this) and redirect clean.
+- **`POST /api/auth/refresh`**: read the refresh token from the cookie
+  **first**, falling back to the request body (so desktop/extension keep
+  working). Rotate as today, `Set-Cookie` the new refresh token, return the new
+  access token in the body.
+- **`POST /api/auth/logout`**: also clear the cookie (`Set-Cookie` expired with
+  the same attributes) in addition to deleting the server-side session.
+- **CSRF**: the refresh endpoint becomes cookie-authenticated, so add a
+  lightweight CSRF defense — `SameSite=Lax` already blocks cross-site POSTs in
+  modern browsers; additionally verify the `Origin`/`Referer` matches an
+  allowed origin on `/api/auth/refresh`. (No double-submit token needed because
+  only this one endpoint is cookie-driven and it returns a short-lived token to
+  the same origin.)
+- **CORS** (`internal/http/router.go`): `AllowCredentials` is already `true`;
+  ensure the origin list never contains `*` when credentials are on (add a
+  startup guard — also noted in the backend audit).
+- **Dev ergonomics**: `Secure` cookies don't flow over plain `http://`. Either
+  develop over `https`/`localhost` (browsers treat `localhost` as secure) or
+  drop `Secure` only when `cfg` indicates local/dev.
+
+## Frontend changes (web)
+
+- **`TokenStorage`**: add an **in-memory** access-token adapter for web; stop
+  writing access/refresh to `localStorage`. (The `TokenStorage` abstraction
+  already exists — `setTokenStorage()` — so this is an adapter swap in
+  `apps/web/src/main.tsx`.)
+- **`api-client.ts`**: the refresh call uses `credentials: 'include'` and sends
+  no refresh body in cookie mode; on boot, attempt one silent refresh to
+  re-hydrate the in-memory access token.
+- **`isLoggedIn()`**: derive from in-memory token presence + the boot-refresh
+  result instead of reading `localStorage`.
+- **OAuth callback page**: no longer parse tokens from the URL in cookie mode
+  (the cookie is already set); just trigger a silent refresh + navigate.
+
+## Multi-surface impact
+
+- **Desktop (Electron)**: unchanged — keeps `safeStorage` + body/Bearer refresh
+  (not XSS-exposed). Cookie mode is requested only by the web client.
+- **Extension**: keep `chrome.storage` + body/Bearer. Extension fetches are
+  cross-origin to the API; cookie auth there would require `SameSite=None`
+  (weaker) and host permissions — not worth it. The backend's cookie-first,
+  body-fallback refresh supports this transparently.
+
+## Rollout plan
+
+1. **Backend, additive + flagged**: support cookie refresh (`AUTH_COOKIE_MODE`)
+   while still accepting body refresh. Ship + verify nothing changes with the
+   flag off.
+2. **Web opt-in**: switch web to in-memory access + cookie refresh behind the
+   same flag; QA the full login/reload/expiry/logout flow.
+3. **Default on for web; stop persisting tokens in `localStorage`.**
+
+## Risks & rollback
+
+- **Cannot be verified in CI**: the e2e suite is desktop-only (token mode), so
+  it will not exercise web cookie auth. This change **requires manual web QA**
+  (login, reload→silent refresh, access-token expiry→refresh, logout, OAuth
+  round-trip) across at least Chrome + Firefox + Safari before enabling by
+  default. This is the main reason it is a separate, deliberately-staged effort.
+- **Cookie attribute mistakes** are the classic failure mode: `Secure` over
+  `http` dev, `SameSite=Strict` breaking the OAuth redirect, wrong `Path`.
+  Mitigated by the flag and staged rollout.
+- **Rollback**: turn `AUTH_COOKIE_MODE` off → clients fall back to the existing
+  body/Bearer flow. No data migration involved (refresh tokens are already
+  server-side hashes).
+
+## Testing
+
+- **Backend (CI-able)**: unit/integration tests for cookie set/rotate/clear,
+  cookie-first vs body-fallback refresh, and the Origin check on
+  `/api/auth/refresh`.
+- **Web (manual)**: the QA matrix above. Optionally add a Playwright web e2e
+  (new) that runs the real login→reload→logout flow against the live backend to
+  make this CI-verifiable in the future.


### PR DESCRIPTION
Design-only PR (no code) for the remaining security follow-up: moving **web** auth tokens out of `localStorage` (XSS-exposed) into HttpOnly cookies. You asked for the design/plan first.

**ADR 0004** (`docs/adr/0004-auth-token-storage-httponly-cookies.md` + `.es.md`) proposes a **hybrid model**:
- **Access token** → short-lived, kept **in memory** (JS var, not `localStorage`), still sent as `Authorization: Bearer`.
- **Refresh token** → backend-set **`HttpOnly; Secure; SameSite=Lax`** cookie scoped to `/api/auth`, never JS-readable. Page load does a silent `credentials:'include'` refresh.

Why hybrid over full cookie auth: smallest blast radius (only `/api/auth/refresh` becomes cookie-based + needs CSRF; every other endpoint unchanged), it still removes the actual risk (no durable JS-readable token), and desktop/extension keep the body+Bearer flow untouched.

The ADR covers concrete backend (Go) + frontend changes, the `AUTH_COOKIE_MODE` flagged staged rollout, CSRF/CORS handling, multi-surface impact, risks/rollback, and the **manual-QA requirement** — CI's e2e is desktop/token-mode, so it can't verify web cookie auth, which is exactly why we kept this as a design step before implementing.

No production code changes; safe to review/merge as documentation. Implementation would follow once you approve the approach.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGcawXeUjrK9w62eSFQtG1)_