### PR TITLE
fix(test): use seeded devdeck-test user for self-follow assertion

### DIFF
--- a/backend/internal/http/handlers/social_test.go
+++ b/backend/internal/http/handlers/social_test.go
@@ -30,16 +30,10 @@ type feedResp struct {
 func TestSocial_FollowUnfollowAndFeed(t *testing.T) {
 	ts := newTestServer(t)
 
-	// Create a well-known test user in the DB (matching middleware's testUserID)
+	// The test user (UUID 00000000-0000-0000-0000-000000000001, login "devdeck-test") is
+	// inserted by truncateAll and matches the UUID that the static-token middleware
+	// hard-codes into the request context.
 	testUserID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	_, err := ts.store.UpsertUser(context.Background(), auth.GitHubUser{
-		ID:    1,
-		Login: "testuser",
-		Name:  "Test User",
-	})
-	if err != nil {
-		t.Fatalf("failed to create test user: %v", err)
-	}
 
 	// Create a curator user that we will follow
 	curator, err := ts.store.UpsertUser(context.Background(), auth.GitHubUser{
@@ -67,8 +61,10 @@ func TestSocial_FollowUnfollowAndFeed(t *testing.T) {
 		t.Errorf("expected testUserID to follow curator")
 	}
 
-	// 2. Try to follow yourself -> should return 400 Bad Request
-	selfFollowRec := ts.do(t, http.MethodPost, "/api/users/testuser/follow", nil)
+	// 2. Try to follow yourself -> should return 400 Bad Request.
+	// The authenticated user is "devdeck-test" (UUID 00000000-0000-0000-0000-000000000001)
+	// as injected by the static-token middleware. Following that same username must be rejected.
+	selfFollowRec := ts.do(t, http.MethodPost, "/api/users/devdeck-test/follow", nil)
 	if selfFollowRec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 on self-follow, got %d, body: %s", selfFollowRec.Code, selfFollowRec.Body.String())
 	}

--- a/backend/internal/testutil/postgres_shared.go
+++ b/backend/internal/testutil/postgres_shared.go
@@ -118,8 +118,8 @@ func truncateAll(ctx context.Context, pool *pgxpool.Pool) error {
 	}
 
 	_, err := pool.Exec(ctx, `
-		INSERT INTO users (id, github_id, login, display_name)
-		VALUES ('00000000-0000-0000-0000-000000000001', -1, 'devdeck-test', 'Test User')
+		INSERT INTO users (id, github_id, login, username, display_name)
+		VALUES ('00000000-0000-0000-0000-000000000001', -1, 'devdeck-test', 'devdeck-test', 'Test User')
 		ON CONFLICT DO NOTHING
 	`)
 	return err


### PR DESCRIPTION
## Problem

The `TestSocial_FollowUnfollowAndFeed` test has been failing on CI with:

```
social_test.go:73: expected 400 on self-follow, got 204, body:
```

## Root Cause

The test called `UpsertUser` with `{ID: 1, Login: "testuser"}`, which creates a user with a **random** UUID (via `gen_random_uuid()`). It then tested self-follow via `/api/users/testuser/follow`.

However, the static-token middleware hard-codes the authenticated user's ID as `00000000-0000-0000-0000-000000000001` (the `devdeck-test` user seeded by `truncateAll`). When the `Follow` handler checked `followerID == followingID`, it compared:
- `followerID` → `00000000-0000-0000-0000-000000000001` (from middleware)
- `followingID` → random UUID of `testuser`

These never matched → self-follow guard never fired → returned 204 instead of 400.

## Fix

- Remove the now-incorrect `UpsertUser` for `testuser` (the test user already exists from `truncateAll`)
- Point the self-follow request at `/api/users/devdeck-test/follow`, whose UUID matches the middleware-injected ID