### PR TITLE
feat(auth): implement HttpOnly cookie refresh tokens for web client (ADR 0004)

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -72,6 +72,19 @@ type Config struct {
 	ResendAPIKey     string `env:"RESEND_API_KEY"`
 	FrontendURL      string `env:"FRONTEND_URL" envDefault:"http://localhost:5173"`
 
+	// ─── ADR 0004: HttpOnly cookie refresh tokens (web) ───
+	// AuthCookieMode, when true, makes login/refresh/callback additionally set
+	// the refresh token as an HttpOnly cookie (and refresh reads it cookie-first,
+	// body-fallback). Default false → byte-identical to the legacy body/Bearer
+	// flow. Desktop/extension keep using the JSON body regardless of this flag.
+	AuthCookieMode bool `env:"AUTH_COOKIE_MODE" envDefault:"false"`
+	// AuthCookieSecure controls the Secure attribute on the refresh cookie.
+	// Browsers refuse Secure cookies over plain http://, so local/dev over
+	// http needs this off; production over https keeps it on (the default).
+	// An explicit flag is cleaner than deriving "dev" from CORS origins, since
+	// the config has no dedicated environment/debug indicator.
+	AuthCookieSecure bool `env:"AUTH_COOKIE_SECURE" envDefault:"true"`
+
 	// ─── Wave 5 Fase 18: local AI enrichment ───
 	AIProvider      string `env:"AI_PROVIDER" envDefault:"heuristic"`
 	OpenAIAPIKey    string `env:"OPENAI_API_KEY"`
@@ -138,6 +151,12 @@ func Load() (Config, error) {
 	}
 	if c.AuthMode == "token" && c.APIToken == "" {
 		return c, errors.New("API_TOKEN is required when AUTH_MODE=token")
+	}
+	// CORS runs with AllowCredentials=true (see router.go). A wildcard origin
+	// combined with credentials is invalid per the Fetch spec and leaks
+	// cookies cross-origin, so refuse to boot with "*" in the origin list.
+	if slices.Contains(c.CORSOriginList(), "*") {
+		return c, errors.New(`CORS_ORIGINS must not contain "*" because credentials are allowed; list explicit origins`)
 	}
 	if c.AuthMode != "token" && c.AuthMode != "jwt" {
 		return c, errors.New("AUTH_MODE must be 'token' or 'jwt'")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -231,6 +231,48 @@ func TestLoad(t *testing.T) {
 		}
 	})
 
+	t.Run("Rejects wildcard CORS origin with credentials on", func(t *testing.T) {
+		setenv(t, "DB_URL", "postgres://localhost:5432/db")
+		setenv(t, "AUTH_MODE", "token")
+		setenv(t, "API_TOKEN", "test-token")
+		setenv(t, "CORS_ORIGINS", "http://localhost:5173,*")
+
+		_, err := Load()
+		if err == nil {
+			t.Fatal("expected error for wildcard CORS origin, got nil")
+		}
+	})
+
+	t.Run("Allows explicit CORS origins", func(t *testing.T) {
+		setenv(t, "DB_URL", "postgres://localhost:5432/db")
+		setenv(t, "AUTH_MODE", "token")
+		setenv(t, "API_TOKEN", "test-token")
+		setenv(t, "CORS_ORIGINS", "https://app.devdeck.io,http://localhost:5173")
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("expected no error for explicit origins, got %v", err)
+		}
+	})
+
+	t.Run("AuthCookieMode defaults off and Secure defaults on", func(t *testing.T) {
+		setenv(t, "DB_URL", "postgres://localhost:5432/db")
+		setenv(t, "AUTH_MODE", "token")
+		setenv(t, "API_TOKEN", "test-token")
+		os.Unsetenv("AUTH_COOKIE_MODE")
+		os.Unsetenv("AUTH_COOKIE_SECURE")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if cfg.AuthCookieMode {
+			t.Errorf("AuthCookieMode should default to false")
+		}
+		if !cfg.AuthCookieSecure {
+			t.Errorf("AuthCookieSecure should default to true")
+		}
+	})
+
 	t.Run("LMStudio loads with custom base URL and model", func(t *testing.T) {
 		setenv(t, "DB_URL", "postgres://localhost:5432/db")
 		setenv(t, "AUTH_MODE", "token")

--- a/backend/internal/http/handlers/auth.go
+++ b/backend/internal/http/handlers/auth.go
@@ -35,7 +35,19 @@ type AuthConfig struct {
 	WebOAuthRedirectURL     string
 	DesktopOAuthRedirectURL string
 	RequireInvite           bool
+
+	// ADR 0004: HttpOnly cookie refresh tokens (web).
+	AuthCookieMode   bool     // gates all cookie behavior; false → legacy body/Bearer
+	AuthCookieSecure bool     // Secure attribute on the refresh cookie (off for http dev)
+	AllowedOrigins   []string // CORS origin allowlist, used for the refresh Origin check
 }
+
+// refreshCookieName is the HttpOnly cookie that carries the refresh token in
+// cookie mode. Scoped to /api/auth so it is only sent to the auth endpoints.
+const refreshCookieName = "devdeck_refresh"
+
+// refreshCookiePath scopes the cookie to the auth subtree.
+const refreshCookiePath = "/api/auth"
 
 func NewAuthHandler(s *store.Store, as *authservice.Service, cfg AuthConfig) *AuthHandler {
 	return &AuthHandler{store: s, authService: as, config: cfg}
@@ -169,6 +181,18 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		redirectBase = h.config.DesktopOAuthRedirectURL
 	}
 
+	// ADR 0004: in cookie mode, set the refresh token as an HttpOnly cookie on
+	// this top-level navigation (SameSite=Lax permits it) and keep the refresh
+	// token OUT of the redirect URL so it never lands in browser history. The
+	// desktop redirect (custom scheme) is unaffected — desktop still gets the
+	// full pair in the URL. Cookie mode is requested only by the web client.
+	if h.config.AuthCookieMode && device != "desktop" {
+		h.setRefreshCookie(w, pair.RefreshToken)
+		redirectTo, _ := appendAccessTokenOnly(redirectBase, pair)
+		http.Redirect(w, r, redirectTo, http.StatusTemporaryRedirect)
+		return
+	}
+
 	redirectTo, _ := appendTokenPair(redirectBase, pair)
 	http.Redirect(w, r, redirectTo, http.StatusTemporaryRedirect)
 }
@@ -219,15 +243,39 @@ func (h *AuthHandler) fetchGitHubUser(code string) (*auth.GitHubUser, error) {
 
 // POST /api/auth/refresh
 func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	refreshToken := ""
+
+	if h.config.AuthCookieMode {
+		// ADR 0004: cookie-authenticated refresh is a CSRF target. SameSite=Lax
+		// already blocks cross-site POSTs; additionally verify the Origin/Referer
+		// matches an allowed origin.
+		if !h.originAllowed(r) {
+			writeError(w, http.StatusForbidden, "ORIGIN_NOT_ALLOWED", "request origin is not allowed")
+			return
+		}
+		// Cookie-first: read the refresh token from the HttpOnly cookie.
+		if c, err := r.Cookie(refreshCookieName); err == nil {
+			refreshToken = c.Value
+		}
+	}
+
+	// Body fallback (always for flag-off; for cookie mode only when the cookie
+	// is absent, so desktop/extension keep working). The body is optional in
+	// cookie mode, so an empty/EOF body is not an error there.
 	var body struct {
 		RefreshToken string `json:"refresh_token"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid json body")
-		return
+		if !h.config.AuthCookieMode || !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid json body")
+			return
+		}
+	}
+	if refreshToken == "" {
+		refreshToken = body.RefreshToken
 	}
 
-	tokenHash := h.authService.HashRefreshToken(body.RefreshToken)
+	tokenHash := h.authService.HashRefreshToken(refreshToken)
 	userID, err := h.store.GetRefreshSession(r.Context(), tokenHash)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "INVALID_TOKEN", "expired or invalid session")
@@ -245,6 +293,10 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		writeInternal(w, err)
 		return
 	}
+	// Rotate the cookie with the freshly-minted refresh token.
+	if h.config.AuthCookieMode {
+		h.setRefreshCookie(w, pair.RefreshToken)
+	}
 	writeJSON(w, http.StatusOK, pair)
 }
 
@@ -254,8 +306,25 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 		RefreshToken string `json:"refresh_token"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
-	if body.RefreshToken != "" {
-		tokenHash := h.authService.HashRefreshToken(body.RefreshToken)
+
+	refreshToken := body.RefreshToken
+	// ADR 0004: in cookie mode, resolve the token from the cookie when the body
+	// has none, and clear the cookie regardless.
+	if h.config.AuthCookieMode {
+		if refreshToken == "" {
+			if c, err := r.Cookie(refreshCookieName); err == nil {
+				refreshToken = c.Value
+			}
+		}
+		h.clearRefreshCookie(w)
+	}
+
+	// When a refresh token is provided, the server-side session MUST be
+	// invalidated. GetRefreshSession is delete-on-read by hash, so calling it
+	// consumes the single-use session. (Previously the result was discarded but
+	// the call already deletes the row; we keep that behavior explicit here.)
+	if refreshToken != "" {
+		tokenHash := h.authService.HashRefreshToken(refreshToken)
 		_, _ = h.store.GetRefreshSession(r.Context(), tokenHash)
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -367,6 +436,12 @@ func (h *AuthHandler) LoginLocal(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeInternal(w, err)
 		return
+	}
+	// ADR 0004: in cookie mode also set the refresh token as an HttpOnly cookie.
+	// The body still carries the full pair (additive) so desktop/extension and
+	// the flag-off path are unchanged.
+	if h.config.AuthCookieMode {
+		h.setRefreshCookie(w, pair.RefreshToken)
 	}
 	writeJSON(w, http.StatusOK, pair)
 }
@@ -552,4 +627,77 @@ func appendTokenPair(redirectURI string, pair *auth.TokenPair) (string, error) {
 	q.Set("expires_in", strconv.FormatInt(pair.ExpiresIn, 10))
 	parsed.RawQuery = q.Encode()
 	return parsed.String(), nil
+}
+
+// appendAccessTokenOnly is the cookie-mode variant of appendTokenPair: it adds
+// only the access token + expiry to the redirect URL and OMITS the refresh
+// token (which is delivered via the HttpOnly cookie, never in browser history).
+func appendAccessTokenOnly(redirectURI string, pair *auth.TokenPair) (string, error) {
+	parsed, _ := url.Parse(redirectURI)
+	q := parsed.Query()
+	q.Set("token", pair.AccessToken)
+	q.Set("expires_in", strconv.FormatInt(pair.ExpiresIn, 10))
+	parsed.RawQuery = q.Encode()
+	return parsed.String(), nil
+}
+
+// setRefreshCookie writes the refresh token as an HttpOnly cookie scoped to the
+// auth path. MaxAge mirrors the refresh-token TTL so the cookie and the
+// server-side session expire together.
+func (h *AuthHandler) setRefreshCookie(w http.ResponseWriter, token string) {
+	maxAge := int(time.Until(h.authService.RefreshExpiry()).Seconds())
+	if maxAge < 1 {
+		maxAge = 1
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     refreshCookieName,
+		Value:    token,
+		Path:     refreshCookiePath,
+		MaxAge:   maxAge,
+		HttpOnly: true,
+		Secure:   h.config.AuthCookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearRefreshCookie expires the refresh cookie using the same attributes so
+// the browser drops it.
+func (h *AuthHandler) clearRefreshCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     refreshCookieName,
+		Value:    "",
+		Path:     refreshCookiePath,
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.config.AuthCookieSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// originAllowed checks the request Origin (falling back to Referer) against the
+// configured CORS allowlist. Used as a lightweight CSRF defense on the
+// cookie-authenticated refresh endpoint. An empty allowlist allows all (the
+// caller only invokes this in cookie mode, where an allowlist is expected).
+func (h *AuthHandler) originAllowed(r *http.Request) bool {
+	if len(h.config.AllowedOrigins) == 0 {
+		return true
+	}
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		// Fall back to Referer's origin (scheme://host[:port]).
+		if ref := r.Header.Get("Referer"); ref != "" {
+			if u, err := url.Parse(ref); err == nil && u.Scheme != "" && u.Host != "" {
+				origin = u.Scheme + "://" + u.Host
+			}
+		}
+	}
+	if origin == "" {
+		return false
+	}
+	for _, allowed := range h.config.AllowedOrigins {
+		if strings.EqualFold(strings.TrimSpace(allowed), origin) {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/http/handlers/auth.go
+++ b/backend/internal/http/handlers/auth.go
@@ -649,6 +649,7 @@ func (h *AuthHandler) setRefreshCookie(w http.ResponseWriter, token string) {
 	if maxAge < 1 {
 		maxAge = 1
 	}
+	// #nosec G124 -- Secure attribute is configured dynamically based on environment (disabled in local dev, enabled in prod).
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshCookieName,
 		Value:    token,
@@ -663,6 +664,7 @@ func (h *AuthHandler) setRefreshCookie(w http.ResponseWriter, token string) {
 // clearRefreshCookie expires the refresh cookie using the same attributes so
 // the browser drops it.
 func (h *AuthHandler) clearRefreshCookie(w http.ResponseWriter) {
+	// #nosec G124 -- Secure attribute is configured dynamically based on environment (disabled in local dev, enabled in prod).
 	http.SetCookie(w, &http.Cookie{
 		Name:     refreshCookieName,
 		Value:    "",

--- a/backend/internal/http/handlers/auth_cookie_test.go
+++ b/backend/internal/http/handlers/auth_cookie_test.go
@@ -1,0 +1,427 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"devdeck/internal/ai"
+	"devdeck/internal/authservice"
+	"devdeck/internal/config"
+	"devdeck/internal/domain/auth"
+	"devdeck/internal/email"
+	httpapi "devdeck/internal/http"
+	"devdeck/internal/store"
+	"devdeck/internal/testutil"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	cookieTestPassword = "s3cret-password"
+	cookieTestOrigin   = "http://localhost:5173"
+)
+
+// authTestServer wires a jwt-mode router with a real authservice + Postgres so
+// the cookie-mode auth endpoints (login/refresh/logout/callback) are reachable.
+// AuthCookieMode is configurable per test to prove the flag gate.
+type authTestServer struct {
+	router      http.Handler
+	store       *store.Store
+	authService *authservice.Service
+}
+
+func newAuthTestServer(t *testing.T, cookieMode bool) *authTestServer {
+	t.Helper()
+
+	pool := testutil.SetupPostgres(t)
+	st := store.New(pool)
+
+	// Short-lived access tokens, generous refresh window for the cookie MaxAge.
+	as := authservice.New("test-jwt-secret", 15*time.Minute, 24*time.Hour)
+
+	cfg := config.Config{
+		Port:              "0",
+		AuthMode:          "jwt",
+		JWTSecret:         "test-jwt-secret",
+		LocalAuthEnabled:  true,
+		RateLimitDisabled: true,
+		CORSOrigins:       cookieTestOrigin + ",https://app.devdeck.io",
+		AuthCookieMode:    cookieMode,
+		// Secure off so the test cookie is readable without an https transport;
+		// the attribute itself is asserted separately via a dedicated case.
+		AuthCookieSecure:        false,
+		WebOAuthRedirectURL:     "http://localhost:5173/auth/callback",
+		DesktopOAuthRedirectURL: "devdeck://auth/callback",
+	}
+
+	router := httpapi.NewRouterWithDeps(cfg, httpapi.Deps{
+		Store:       st,
+		AuthService: as,
+		AI:          ai.NewHeuristic(),
+		Embeddings:  ai.NewEmbeddingsService(nil),
+		EmailSender: &email.NoopSender{},
+	})
+
+	return &authTestServer{router: router, store: st, authService: as}
+}
+
+// createLocalUser inserts a user with a bcrypt password so LoginLocal works.
+func (ts *authTestServer) createLocalUser(t *testing.T, login string) *auth.User {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(cookieTestPassword), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	u, err := ts.store.CreateUserLocal(context.Background(), login, string(hash))
+	if err != nil {
+		t.Fatalf("create local user: %v", err)
+	}
+	return u
+}
+
+// post dispatches a JSON POST to the given path with optional headers and
+// returns the recorder. A nil body sends no request body.
+func (ts *authTestServer) post(t *testing.T, path string, body any, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		rdr = bytes.NewReader(raw)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, rdr)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	ts.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// findCookie returns the named Set-Cookie from a recorder, or nil.
+func findCookie(rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func decodePair(t *testing.T, rec *httptest.ResponseRecorder) auth.TokenPair {
+	t.Helper()
+	var p auth.TokenPair
+	if err := json.NewDecoder(rec.Body).Decode(&p); err != nil {
+		t.Fatalf("decode pair: %v\nbody: %s", err, rec.Body.String())
+	}
+	return p
+}
+
+// ─── Flag OFF: behavior must be byte-identical to the legacy flow ───
+
+func TestCookie_LoginLocal_FlagOff_NoCookie_BodyTokens(t *testing.T) {
+	ts := newAuthTestServer(t, false)
+	ts.createLocalUser(t, "off-login@example.com")
+
+	rec := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "off-login@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	if c := findCookie(rec, "devdeck_refresh"); c != nil {
+		t.Errorf("flag off must not set the refresh cookie, got %+v", c)
+	}
+	pair := decodePair(t, rec)
+	if pair.AccessToken == "" || pair.RefreshToken == "" || pair.ExpiresIn == 0 {
+		t.Errorf("flag off must return full token pair in body, got %+v", pair)
+	}
+}
+
+func TestCookie_Refresh_FlagOff_BodyOnly_NoOriginCheck(t *testing.T) {
+	ts := newAuthTestServer(t, false)
+	ts.createLocalUser(t, "off-refresh@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "off-refresh@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	pair := decodePair(t, login)
+
+	// No Origin header, body-supplied token: must still succeed (no origin check
+	// when the flag is off).
+	rec := ts.post(t, "/api/auth/refresh", map[string]string{
+		"refresh_token": pair.RefreshToken,
+	}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	if c := findCookie(rec, "devdeck_refresh"); c != nil {
+		t.Errorf("flag off refresh must not set a cookie, got %+v", c)
+	}
+	got := decodePair(t, rec)
+	if got.RefreshToken == "" {
+		t.Errorf("flag off refresh must return refresh token in body")
+	}
+}
+
+func TestCookie_Logout_FlagOff_NoCookieCleared(t *testing.T) {
+	ts := newAuthTestServer(t, false)
+	ts.createLocalUser(t, "off-logout@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "off-logout@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	pair := decodePair(t, login)
+
+	rec := ts.post(t, "/api/auth/logout", map[string]string{
+		"refresh_token": pair.RefreshToken,
+	}, nil)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+	if c := findCookie(rec, "devdeck_refresh"); c != nil {
+		t.Errorf("flag off logout must not emit a Set-Cookie, got %+v", c)
+	}
+}
+
+// ─── Flag ON ───
+
+func TestCookie_LoginLocal_FlagOn_SetsCookieAndBody(t *testing.T) {
+	ts := newAuthTestServer(t, true)
+	ts.createLocalUser(t, "on-login@example.com")
+
+	rec := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "on-login@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+	}
+
+	c := findCookie(rec, "devdeck_refresh")
+	if c == nil {
+		t.Fatal("flag on login must set devdeck_refresh cookie")
+	}
+	if !c.HttpOnly {
+		t.Errorf("cookie must be HttpOnly")
+	}
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("cookie SameSite must be Lax, got %v", c.SameSite)
+	}
+	if c.Path != "/api/auth" {
+		t.Errorf("cookie Path must be /api/auth, got %q", c.Path)
+	}
+	if c.MaxAge <= 0 {
+		t.Errorf("cookie MaxAge must be positive, got %d", c.MaxAge)
+	}
+
+	// Body still carries the pair (additive — desktop/extension depend on it).
+	pair := decodePair(t, rec)
+	if pair.AccessToken == "" || pair.RefreshToken == "" || pair.ExpiresIn == 0 {
+		t.Errorf("flag on login must still return full token pair in body, got %+v", pair)
+	}
+	if c.Value != pair.RefreshToken {
+		t.Errorf("cookie value must equal body refresh token")
+	}
+}
+
+func TestCookie_LoginLocal_FlagOn_SecureAttribute(t *testing.T) {
+	// Dedicated server with Secure on to assert the attribute is wired.
+	pool := testutil.SetupPostgres(t)
+	st := store.New(pool)
+	as := authservice.New("test-jwt-secret", 15*time.Minute, 24*time.Hour)
+	cfg := config.Config{
+		Port: "0", AuthMode: "jwt", JWTSecret: "test-jwt-secret",
+		LocalAuthEnabled: true, RateLimitDisabled: true,
+		CORSOrigins:      cookieTestOrigin,
+		AuthCookieMode:   true,
+		AuthCookieSecure: true,
+	}
+	router := httpapi.NewRouterWithDeps(cfg, httpapi.Deps{
+		Store: st, AuthService: as, AI: ai.NewHeuristic(),
+		Embeddings: ai.NewEmbeddingsService(nil), EmailSender: &email.NoopSender{},
+	})
+	hash, _ := bcrypt.GenerateFromPassword([]byte(cookieTestPassword), bcrypt.DefaultCost)
+	if _, err := st.CreateUserLocal(context.Background(), "secure@example.com", string(hash)); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"email": "secure@example.com", "password": cookieTestPassword})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	c := findCookie(rec, "devdeck_refresh")
+	if c == nil {
+		t.Fatal("expected cookie")
+	}
+	if !c.Secure {
+		t.Errorf("cookie must be Secure when AuthCookieSecure=true")
+	}
+}
+
+func TestCookie_Refresh_FlagOn_CookieFirst_NoBody(t *testing.T) {
+	ts := newAuthTestServer(t, true)
+	ts.createLocalUser(t, "on-cookie-refresh@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "on-cookie-refresh@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	loginCookie := findCookie(login, "devdeck_refresh")
+	if loginCookie == nil {
+		t.Fatal("login did not set cookie")
+	}
+
+	// Refresh with cookie + valid Origin, NO body.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	req.Header.Set("Origin", cookieTestOrigin)
+	req.AddCookie(&http.Cookie{Name: "devdeck_refresh", Value: loginCookie.Value})
+	rec := httptest.NewRecorder()
+	ts.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	newCookie := findCookie(rec, "devdeck_refresh")
+	if newCookie == nil {
+		t.Fatal("refresh must rotate and set a new cookie")
+	}
+	if newCookie.Value == loginCookie.Value {
+		t.Errorf("refresh must rotate the token (new cookie value)")
+	}
+	pair := decodePair(t, rec)
+	if pair.AccessToken == "" {
+		t.Errorf("refresh must return a new access token in body")
+	}
+}
+
+func TestCookie_Refresh_FlagOn_BodyFallback_NoCookie(t *testing.T) {
+	ts := newAuthTestServer(t, true)
+	ts.createLocalUser(t, "on-body-refresh@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "on-body-refresh@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	pair := decodePair(t, login)
+
+	// No cookie sent; refresh token in body + valid Origin → body fallback works
+	// (desktop/extension path).
+	rec := ts.post(t, "/api/auth/refresh", map[string]string{
+		"refresh_token": pair.RefreshToken,
+	}, map[string]string{"Origin": cookieTestOrigin})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 via body fallback, got %d, body: %s", rec.Code, rec.Body.String())
+	}
+	if findCookie(rec, "devdeck_refresh") == nil {
+		t.Errorf("cookie-mode refresh should still rotate the cookie on body fallback")
+	}
+}
+
+func TestCookie_Refresh_FlagOn_RejectsDisallowedOrigin(t *testing.T) {
+	ts := newAuthTestServer(t, true)
+	ts.createLocalUser(t, "on-bad-origin@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "on-bad-origin@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	loginCookie := findCookie(login, "devdeck_refresh")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.AddCookie(&http.Cookie{Name: "devdeck_refresh", Value: loginCookie.Value})
+	rec := httptest.NewRecorder()
+	ts.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for disallowed origin, got %d, body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCookie_Logout_FlagOn_ClearsCookieAndInvalidates(t *testing.T) {
+	ts := newAuthTestServer(t, true)
+	ts.createLocalUser(t, "on-logout@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "on-logout@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	loginCookie := findCookie(login, "devdeck_refresh")
+	if loginCookie == nil {
+		t.Fatal("login did not set cookie")
+	}
+
+	// Logout sends the cookie, no body.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	req.Header.Set("Origin", cookieTestOrigin)
+	req.AddCookie(&http.Cookie{Name: "devdeck_refresh", Value: loginCookie.Value})
+	rec := httptest.NewRecorder()
+	ts.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+	cleared := findCookie(rec, "devdeck_refresh")
+	if cleared == nil {
+		t.Fatal("logout must emit a clearing Set-Cookie")
+	}
+	if cleared.MaxAge >= 0 || cleared.Value != "" {
+		t.Errorf("clearing cookie must have MaxAge<0 and empty value, got %+v", cleared)
+	}
+
+	// The session must be invalidated: reusing the old refresh token fails.
+	reuse := ts.post(t, "/api/auth/refresh", map[string]string{
+		"refresh_token": loginCookie.Value,
+	}, map[string]string{"Origin": cookieTestOrigin})
+	if reuse.Code != http.StatusUnauthorized {
+		t.Errorf("reusing the logged-out refresh token must fail with 401, got %d", reuse.Code)
+	}
+}
+
+func TestCookie_Refresh_SingleUse_SecondUseFails(t *testing.T) {
+	ts := newAuthTestServer(t, true)
+	ts.createLocalUser(t, "on-rotate@example.com")
+
+	login := ts.post(t, "/api/auth/login", map[string]string{
+		"email":    "on-rotate@example.com",
+		"password": cookieTestPassword,
+	}, nil)
+	loginCookie := findCookie(login, "devdeck_refresh")
+
+	// First refresh consumes the original token.
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+	req.Header.Set("Origin", cookieTestOrigin)
+	req.AddCookie(&http.Cookie{Name: "devdeck_refresh", Value: loginCookie.Value})
+	rec := httptest.NewRecorder()
+	ts.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first refresh: expected 200, got %d", rec.Code)
+	}
+
+	// Reusing the now-consumed original token must fail (single-use rotation).
+	reuse := ts.post(t, "/api/auth/refresh", map[string]string{
+		"refresh_token": loginCookie.Value,
+	}, map[string]string{"Origin": cookieTestOrigin})
+	if reuse.Code != http.StatusUnauthorized {
+		t.Errorf("second use of rotated token must fail with 401, got %d", reuse.Code)
+	}
+}

--- a/backend/internal/http/handlers/auth_cookie_unit_test.go
+++ b/backend/internal/http/handlers/auth_cookie_unit_test.go
@@ -1,0 +1,102 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"devdeck/internal/http/handlers"
+)
+
+// These tests exercise the cookie-mode CSRF (Origin) guard at the handler
+// boundary WITHOUT a database. In cookie mode the Origin check runs before any
+// store/authService access, so a nil-dep handler is sufficient to prove the
+// 403 path and the flag gate. They are CI-verifiable on every platform.
+
+func newOriginGuardHandler(cookieMode bool, origins []string) *handlers.AuthHandler {
+	return handlers.NewAuthHandler(nil, nil, handlers.AuthConfig{
+		AuthCookieMode: cookieMode,
+		AllowedOrigins: origins,
+	})
+}
+
+func TestRefresh_OriginGuard_DBFree(t *testing.T) {
+	allowed := []string{"http://localhost:5173", "https://app.devdeck.io"}
+
+	tests := []struct {
+		name       string
+		cookieMode bool
+		origin     string
+		referer    string
+		wantCode   int // only meaningful for the rejection case
+		wantReject bool
+	}{
+		{
+			name:       "flag on, disallowed origin rejected",
+			cookieMode: true,
+			origin:     "https://evil.example.com",
+			wantCode:   http.StatusForbidden,
+			wantReject: true,
+		},
+		{
+			name:       "flag on, no origin and no referer rejected",
+			cookieMode: true,
+			wantCode:   http.StatusForbidden,
+			wantReject: true,
+		},
+		{
+			name:       "flag on, disallowed referer rejected",
+			cookieMode: true,
+			referer:    "https://evil.example.com/page",
+			wantCode:   http.StatusForbidden,
+			wantReject: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newOriginGuardHandler(tt.cookieMode, allowed)
+			req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.referer != "" {
+				req.Header.Set("Referer", tt.referer)
+			}
+			rec := httptest.NewRecorder()
+			h.Refresh(rec, req)
+
+			if tt.wantReject {
+				if rec.Code != tt.wantCode {
+					t.Fatalf("expected %d, got %d, body: %s", tt.wantCode, rec.Code, rec.Body.String())
+				}
+				if !strings.Contains(rec.Body.String(), "ORIGIN_NOT_ALLOWED") {
+					t.Errorf("expected ORIGIN_NOT_ALLOWED error, got %s", rec.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// TestRefresh_FlagOff_NoOriginGuard proves the flag gate: with the flag OFF,
+// the Origin guard is never consulted. (With nil deps the handler would panic
+// when it reaches the store, so we only assert the guard does not short-circuit
+// to 403 — i.e. it proceeds past the cookie-mode block.)
+func TestRefresh_FlagOff_SkipsOriginGuard(t *testing.T) {
+	h := newOriginGuardHandler(false, []string{"http://localhost:5173"})
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/refresh", strings.NewReader(`{"refresh_token":"x"}`))
+	req.Header.Set("Origin", "https://evil.example.com")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		// Reaching the store with nil deps panics; that is expected and proves
+		// the flag-off path did NOT return 403 from the origin guard.
+		_ = recover()
+		if rec.Code == http.StatusForbidden {
+			t.Errorf("flag off must not run the origin guard (no 403)")
+		}
+	}()
+	h.Refresh(rec, req)
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -78,6 +78,9 @@ func NewRouterWithDeps(cfg config.Config, deps Deps) http.Handler {
 		WebOAuthRedirectURL:     cfg.WebOAuthRedirectURL,
 		DesktopOAuthRedirectURL: cfg.DesktopOAuthRedirectURL,
 		RequireInvite:           cfg.RequireInvite,
+		AuthCookieMode:          cfg.AuthCookieMode,
+		AuthCookieSecure:        cfg.AuthCookieSecure,
+		AllowedOrigins:          cfg.CORSOriginList(),
 	})
 
 	reposH := handlers.NewReposHandler(st, en)


### PR DESCRIPTION
Implements the HttpOnly cookie refresh token flow for the web client as specified in ADR 0004. Wire configurations, set/clear cookie helpers, verify request origin, and add extensive unit & integration tests.